### PR TITLE
Consider latest puzzle times when sorting by oldest

### DIFF
--- a/src/Services/PuzzlesSorter.php
+++ b/src/Services/PuzzlesSorter.php
@@ -386,7 +386,7 @@ readonly final class PuzzlesSorter
     {
         // 1) Sort times within groups as they are supposed to be
         foreach ($groupedSolvedPuzzles as $index => $solvedPuzzle) {
-            $groupedSolvedPuzzles[$index] = $this->sortByOldest($solvedPuzzle);
+            $groupedSolvedPuzzles[$index] = $this->sortByNewest($solvedPuzzle);
 
             if ($onlyFirstTries === true) {
                 $groupedSolvedPuzzles[$index] = $this->makeFirstAttemptFirst($groupedSolvedPuzzles[$index]);


### PR DESCRIPTION
When sorting by oldest puzzles, I expect to see the oldest results from the most recent time of each puzzle. That way I can check from the puzzles I have done, which one I haven't done in a long time.

Current behaviour shows the puzzles sorted by oldest but each group is also sorted by oldest.

![Captura de ecrã 2025-05-23 193508](https://github.com/user-attachments/assets/3cd0ad8c-6ebe-4566-9d56-09c03814d683)
