### PR TITLE
Notify all upvoters on feature request status change

### DIFF
--- a/src/MessageHandler/NotifyWhenFeatureRequestStatusChanged.php
+++ b/src/MessageHandler/NotifyWhenFeatureRequestStatusChanged.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\MessageHandler;
 
 use SpeedPuzzling\Web\Events\FeatureRequestStatusChanged;
+use SpeedPuzzling\Web\Query\GetFeatureRequestVoters;
 use SpeedPuzzling\Web\Repository\FeatureRequestRepository;
+use SpeedPuzzling\Web\Value\FeatureRequestStatus;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -16,6 +18,7 @@ readonly final class NotifyWhenFeatureRequestStatusChanged
 {
     public function __construct(
         private FeatureRequestRepository $featureRequestRepository,
+        private GetFeatureRequestVoters $getFeatureRequestVoters,
         private MailerInterface $mailer,
         private TranslatorInterface $translator,
     ) {
@@ -24,43 +27,79 @@ readonly final class NotifyWhenFeatureRequestStatusChanged
     public function __invoke(FeatureRequestStatusChanged $event): void
     {
         $featureRequest = $this->featureRequestRepository->get($event->featureRequestId->toString());
-        $player = $featureRequest->author;
+        $author = $featureRequest->author;
 
-        if ($player->email === null) {
-            return;
+        if ($author->email !== null) {
+            $this->sendEmail(
+                toEmail: $author->email,
+                locale: $author->locale ?? 'en',
+                template: 'emails/feature_request_status_changed.html.twig',
+                subjectKey: 'feature_request_status_changed.subject',
+                featureRequestTitle: $featureRequest->title,
+                oldStatus: $event->oldStatus,
+                newStatus: $event->newStatus,
+                adminComment: $featureRequest->adminComment,
+            );
         }
 
-        $playerLocale = $player->locale ?? 'en';
+        $voters = ($this->getFeatureRequestVoters)->excludingPlayer(
+            featureRequestId: $event->featureRequestId->toString(),
+            excludedPlayerId: $author->id->toString(),
+        );
 
+        foreach ($voters as $voter) {
+            $this->sendEmail(
+                toEmail: $voter->email,
+                locale: $voter->locale ?? 'en',
+                template: 'emails/feature_request_status_changed_upvoter.html.twig',
+                subjectKey: 'feature_request_status_changed.upvoter.subject',
+                featureRequestTitle: $featureRequest->title,
+                oldStatus: $event->oldStatus,
+                newStatus: $event->newStatus,
+                adminComment: $featureRequest->adminComment,
+            );
+        }
+    }
+
+    private function sendEmail(
+        string $toEmail,
+        string $locale,
+        string $template,
+        string $subjectKey,
+        string $featureRequestTitle,
+        FeatureRequestStatus $oldStatus,
+        FeatureRequestStatus $newStatus,
+        null|string $adminComment,
+    ): void {
         $oldStatusLabel = $this->translator->trans(
-            'feature_request_status_changed.status.' . $event->oldStatus->value,
+            'feature_request_status_changed.status.' . $oldStatus->value,
             domain: 'emails',
-            locale: $playerLocale,
+            locale: $locale,
         );
 
         $newStatusLabel = $this->translator->trans(
-            'feature_request_status_changed.status.' . $event->newStatus->value,
+            'feature_request_status_changed.status.' . $newStatus->value,
             domain: 'emails',
-            locale: $playerLocale,
+            locale: $locale,
         );
 
         $subject = $this->translator->trans(
-            'feature_request_status_changed.subject',
-            ['%title%' => $featureRequest->title],
+            $subjectKey,
+            ['%title%' => $featureRequestTitle],
             domain: 'emails',
-            locale: $playerLocale,
+            locale: $locale,
         );
 
         $email = (new TemplatedEmail())
-            ->to($player->email)
-            ->locale($playerLocale)
+            ->to($toEmail)
+            ->locale($locale)
             ->subject($subject)
-            ->htmlTemplate('emails/feature_request_status_changed.html.twig')
+            ->htmlTemplate($template)
             ->context([
-                'featureRequestTitle' => $featureRequest->title,
+                'featureRequestTitle' => $featureRequestTitle,
                 'oldStatus' => $oldStatusLabel,
                 'newStatus' => $newStatusLabel,
-                'adminComment' => $featureRequest->adminComment,
+                'adminComment' => $adminComment,
             ]);
         $email->getHeaders()->addTextHeader('X-Transport', 'transactional');
 

--- a/src/MessageHandler/NotifyWhenFeatureRequestStatusChanged.php
+++ b/src/MessageHandler/NotifyWhenFeatureRequestStatusChanged.php
@@ -42,7 +42,7 @@ readonly final class NotifyWhenFeatureRequestStatusChanged
             );
         }
 
-        $voters = ($this->getFeatureRequestVoters)->excludingPlayer(
+        $voters = $this->getFeatureRequestVoters->excludingPlayer(
             featureRequestId: $event->featureRequestId->toString(),
             excludedPlayerId: $author->id->toString(),
         );

--- a/src/Query/GetFeatureRequestVoters.php
+++ b/src/Query/GetFeatureRequestVoters.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Query;
+
+use Doctrine\DBAL\Connection;
+use SpeedPuzzling\Web\Results\FeatureRequestVoter;
+
+readonly final class GetFeatureRequestVoters
+{
+    public function __construct(
+        private Connection $database,
+    ) {
+    }
+
+    /**
+     * @return list<FeatureRequestVoter>
+     */
+    public function excludingPlayer(string $featureRequestId, string $excludedPlayerId): array
+    {
+        $query = <<<SQL
+SELECT DISTINCT ON (fv.voter_id)
+    fv.voter_id AS player_id,
+    p.email AS email,
+    p.locale AS locale
+FROM feature_request_vote fv
+JOIN player p ON fv.voter_id = p.id
+WHERE fv.feature_request_id = :featureRequestId
+    AND fv.voter_id != :excludedPlayerId
+    AND p.email IS NOT NULL
+ORDER BY fv.voter_id, fv.voted_at DESC
+SQL;
+
+        /** @var list<array{player_id: string, email: string, locale: null|string}> $rows */
+        $rows = $this->database->fetchAllAssociative($query, [
+            'featureRequestId' => $featureRequestId,
+            'excludedPlayerId' => $excludedPlayerId,
+        ]);
+
+        return array_map(
+            static fn(array $row): FeatureRequestVoter => new FeatureRequestVoter(
+                playerId: $row['player_id'],
+                email: $row['email'],
+                locale: $row['locale'],
+            ),
+            $rows,
+        );
+    }
+}

--- a/src/Results/FeatureRequestVoter.php
+++ b/src/Results/FeatureRequestVoter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Results;
+
+readonly final class FeatureRequestVoter
+{
+    public function __construct(
+        public string $playerId,
+        public string $email,
+        public null|string $locale,
+    ) {
+    }
+}

--- a/templates/emails/feature_request_status_changed_upvoter.html.twig
+++ b/templates/emails/feature_request_status_changed_upvoter.html.twig
@@ -1,0 +1,38 @@
+{% trans_default_domain 'emails' %}
+{% apply inky_to_html|inline_css(source('@styles/foundation-emails.css')) %}
+    <wrapper>
+        <container>
+            {{ include('emails/_header.html.twig') }}
+
+            <row>
+                <columns>
+                    <spacer size-sm="24"></spacer>
+                    <h3>{{ 'feature_request_status_changed.upvoter.title'|trans }}</h3>
+                    <spacer size-sm="8"></spacer>
+                </columns>
+            </row>
+
+            <row>
+                <columns>
+                    {{ 'feature_request_status_changed.upvoter.content'|trans({
+                        '%featureRequestTitle%': featureRequestTitle,
+                        '%oldStatus%': oldStatus,
+                        '%newStatus%': newStatus,
+                    })|raw }}
+                </columns>
+            </row>
+
+            {% if adminComment is not null %}
+                <row>
+                    <columns>
+                        {{ 'feature_request_status_changed.upvoter.admin_comment'|trans({
+                            '%adminComment%': adminComment,
+                        })|raw }}
+                    </columns>
+                </row>
+            {% endif %}
+
+            {{ include('emails/_footer.html.twig') }}
+        </container>
+    </wrapper>
+{% endapply %}

--- a/tests/MessageHandler/NotifyWhenFeatureRequestStatusChangedTest.php
+++ b/tests/MessageHandler/NotifyWhenFeatureRequestStatusChangedTest.php
@@ -9,13 +9,24 @@ use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 use SpeedPuzzling\Web\Events\FeatureRequestStatusChanged;
 use SpeedPuzzling\Web\MessageHandler\NotifyWhenFeatureRequestStatusChanged;
+use SpeedPuzzling\Web\Query\GetFeatureRequestVoters;
+use SpeedPuzzling\Web\Repository\FeatureRequestRepository;
 use SpeedPuzzling\Web\Tests\DataFixtures\FeatureRequestFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Value\FeatureRequestStatus;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class NotifyWhenFeatureRequestStatusChangedTest extends KernelTestCase
 {
+    private const string AUTHOR_TEMPLATE = 'emails/feature_request_status_changed.html.twig';
+    private const string UPVOTER_TEMPLATE = 'emails/feature_request_status_changed_upvoter.html.twig';
+
     private NotifyWhenFeatureRequestStatusChanged $handler;
+    private TestMailerSpy $mailer;
     private Connection $connection;
     private EntityManagerInterface $entityManager;
 
@@ -23,53 +34,228 @@ final class NotifyWhenFeatureRequestStatusChangedTest extends KernelTestCase
     {
         self::bootKernel();
         $container = self::getContainer();
-        $this->handler = $container->get(NotifyWhenFeatureRequestStatusChanged::class);
+
+        $this->mailer = new TestMailerSpy();
         $this->connection = $container->get(Connection::class);
         $this->entityManager = $container->get(EntityManagerInterface::class);
+
+        $this->handler = new NotifyWhenFeatureRequestStatusChanged(
+            featureRequestRepository: $container->get(FeatureRequestRepository::class),
+            getFeatureRequestVoters: $container->get(GetFeatureRequestVoters::class),
+            mailer: $this->mailer,
+            translator: $container->get(TranslatorInterface::class),
+        );
     }
 
-    public function testSendsEmailWhenStatusChanges(): void
+    public function testAuthorOnlyWhenNoUpvoters(): void
     {
-        $this->expectNotToPerformAssertions();
-
+        // FEATURE_REQUEST_NEW: author=PLAYER_ADMIN, no votes
         ($this->handler)(new FeatureRequestStatusChanged(
             featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_NEW),
             oldStatus: FeatureRequestStatus::Open,
             newStatus: FeatureRequestStatus::InProgress,
         ));
+
+        self::assertCount(1, $this->mailer->sent);
+        $email = $this->assertTemplatedEmail($this->mailer->sent[0]);
+        self::assertSame(['admin@speedpuzzling.cz'], $this->toAddresses($email));
+        self::assertSame(self::AUTHOR_TEMPLATE, $email->getHtmlTemplate());
     }
 
-    public function testHandlesAllStatusTransitions(): void
+    public function testAuthorPlusAllUpvoters(): void
     {
-        $this->expectNotToPerformAssertions();
-
+        // FEATURE_REQUEST_POPULAR: author=PLAYER_WITH_STRIPE, voters=[ADMIN, REGULAR]
         ($this->handler)(new FeatureRequestStatusChanged(
-            featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_NEW),
+            featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_POPULAR),
             oldStatus: FeatureRequestStatus::Open,
             newStatus: FeatureRequestStatus::Completed,
         ));
+
+        self::assertCount(3, $this->mailer->sent);
+
+        $summary = $this->summarize($this->mailer->sent);
+
+        self::assertSame(self::AUTHOR_TEMPLATE, $summary[PlayerFixture::PLAYER_WITH_STRIPE_EMAIL]);
+        self::assertSame(self::UPVOTER_TEMPLATE, $summary['admin@speedpuzzling.cz']);
+        self::assertSame(self::UPVOTER_TEMPLATE, $summary[PlayerFixture::PLAYER_REGULAR_EMAIL]);
+    }
+
+    public function testSkipsWhenAuthorHasNoEmailButStillNotifiesUpvoters(): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE player SET email = NULL WHERE id = :id',
+            ['id' => PlayerFixture::PLAYER_WITH_STRIPE],
+        );
+        $this->entityManager->clear();
 
         ($this->handler)(new FeatureRequestStatusChanged(
             featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_POPULAR),
             oldStatus: FeatureRequestStatus::Open,
             newStatus: FeatureRequestStatus::Declined,
         ));
+
+        self::assertCount(2, $this->mailer->sent);
+        foreach ($this->mailer->sent as $message) {
+            $email = $this->assertTemplatedEmail($message);
+            self::assertSame(self::UPVOTER_TEMPLATE, $email->getHtmlTemplate());
+        }
     }
 
-    public function testSkipsWhenPlayerHasNoEmail(): void
+    public function testSkipsUpvoterWithoutEmail(): void
     {
-        $this->expectNotToPerformAssertions();
-
         $this->connection->executeStatement(
-            'UPDATE player SET email = NULL WHERE id = (SELECT author_id FROM feature_request WHERE id = :id)',
-            ['id' => FeatureRequestFixture::FEATURE_REQUEST_NEW],
+            'UPDATE player SET email = NULL WHERE id = :id',
+            ['id' => PlayerFixture::PLAYER_REGULAR],
         );
         $this->entityManager->clear();
 
         ($this->handler)(new FeatureRequestStatusChanged(
-            featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_NEW),
+            featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_POPULAR),
+            oldStatus: FeatureRequestStatus::Open,
+            newStatus: FeatureRequestStatus::Completed,
+        ));
+
+        // Expected: author (PLAYER_WITH_STRIPE) + 1 upvoter (ADMIN). REGULAR skipped.
+        self::assertCount(2, $this->mailer->sent);
+
+        $summary = $this->summarize($this->mailer->sent);
+
+        self::assertArrayNotHasKey(PlayerFixture::PLAYER_REGULAR_EMAIL, $summary);
+        self::assertSame(self::AUTHOR_TEMPLATE, $summary[PlayerFixture::PLAYER_WITH_STRIPE_EMAIL]);
+        self::assertSame(self::UPVOTER_TEMPLATE, $summary['admin@speedpuzzling.cz']);
+    }
+
+    public function testAuthorNeverReceivesUpvoterEmailEvenIfTheyAlsoVoted(): void
+    {
+        // Defensive: bypass the business rule and insert a vote row by the author.
+        $this->connection->executeStatement(
+            'INSERT INTO feature_request_vote (id, feature_request_id, voter_id, voted_at) '
+            . 'VALUES (:id, :featureRequestId, :voterId, NOW())',
+            [
+                'id' => Uuid::uuid7()->toString(),
+                'featureRequestId' => FeatureRequestFixture::FEATURE_REQUEST_POPULAR,
+                'voterId' => PlayerFixture::PLAYER_WITH_STRIPE,
+            ],
+        );
+
+        ($this->handler)(new FeatureRequestStatusChanged(
+            featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_POPULAR),
+            oldStatus: FeatureRequestStatus::Open,
+            newStatus: FeatureRequestStatus::Completed,
+        ));
+
+        // Total: author + 2 other upvoters (ADMIN, REGULAR) = 3 — author row is excluded
+        self::assertCount(3, $this->mailer->sent);
+
+        $summary = $this->summarize($this->mailer->sent);
+        self::assertSame(self::AUTHOR_TEMPLATE, $summary[PlayerFixture::PLAYER_WITH_STRIPE_EMAIL]);
+
+        $authorEmails = array_filter(
+            $this->mailer->sent,
+            fn(RawMessage $m): bool => $this->toAddresses($this->assertTemplatedEmail($m))[0] === PlayerFixture::PLAYER_WITH_STRIPE_EMAIL,
+        );
+        self::assertCount(1, $authorEmails, 'Author must receive exactly one email');
+    }
+
+    public function testUsesRecipientLocale(): void
+    {
+        // Author: Czech. Upvoter ADMIN: German. Upvoter REGULAR: unset → en fallback.
+        $this->connection->executeStatement(
+            'UPDATE player SET locale = :locale WHERE id = :id',
+            ['locale' => 'cs', 'id' => PlayerFixture::PLAYER_WITH_STRIPE],
+        );
+        $this->connection->executeStatement(
+            'UPDATE player SET locale = :locale WHERE id = :id',
+            ['locale' => 'de', 'id' => PlayerFixture::PLAYER_ADMIN],
+        );
+        $this->entityManager->clear();
+
+        ($this->handler)(new FeatureRequestStatusChanged(
+            featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_POPULAR),
+            oldStatus: FeatureRequestStatus::Open,
+            newStatus: FeatureRequestStatus::Completed,
+        ));
+
+        $localesByRecipient = [];
+        foreach ($this->mailer->sent as $message) {
+            $email = $this->assertTemplatedEmail($message);
+            $localesByRecipient[$this->toAddresses($email)[0]] = $email->getLocale();
+        }
+
+        self::assertSame('cs', $localesByRecipient[PlayerFixture::PLAYER_WITH_STRIPE_EMAIL]);
+        self::assertSame('de', $localesByRecipient['admin@speedpuzzling.cz']);
+        self::assertSame('en', $localesByRecipient[PlayerFixture::PLAYER_REGULAR_EMAIL]);
+    }
+
+    public function testAdminCommentPresentInContextForBothTemplates(): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE feature_request SET admin_comment = :comment WHERE id = :id',
+            [
+                'comment' => 'Building this next sprint.',
+                'id' => FeatureRequestFixture::FEATURE_REQUEST_POPULAR,
+            ],
+        );
+        $this->entityManager->clear();
+
+        ($this->handler)(new FeatureRequestStatusChanged(
+            featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_POPULAR),
             oldStatus: FeatureRequestStatus::Open,
             newStatus: FeatureRequestStatus::InProgress,
         ));
+
+        self::assertCount(3, $this->mailer->sent);
+        foreach ($this->mailer->sent as $message) {
+            $email = $this->assertTemplatedEmail($message);
+            self::assertSame('Building this next sprint.', $email->getContext()['adminComment']);
+        }
+    }
+
+    public function testAdminCommentNullPassedToContext(): void
+    {
+        ($this->handler)(new FeatureRequestStatusChanged(
+            featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_POPULAR),
+            oldStatus: FeatureRequestStatus::Open,
+            newStatus: FeatureRequestStatus::InProgress,
+        ));
+
+        self::assertCount(3, $this->mailer->sent);
+        foreach ($this->mailer->sent as $message) {
+            $email = $this->assertTemplatedEmail($message);
+            self::assertNull($email->getContext()['adminComment']);
+        }
+    }
+
+    /**
+     * @param list<RawMessage> $messages
+     * @return array<string, null|string> recipient email => html template
+     */
+    private function summarize(array $messages): array
+    {
+        $summary = [];
+        foreach ($messages as $message) {
+            $email = $this->assertTemplatedEmail($message);
+            $summary[$this->toAddresses($email)[0]] = $email->getHtmlTemplate();
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function toAddresses(TemplatedEmail $email): array
+    {
+        return array_values(array_map(
+            fn(Address $address): string => $address->getAddress(),
+            $email->getTo(),
+        ));
+    }
+
+    private function assertTemplatedEmail(RawMessage $message): TemplatedEmail
+    {
+        self::assertInstanceOf(TemplatedEmail::class, $message);
+
+        return $message;
     }
 }

--- a/tests/MessageHandler/NotifyWhenFeatureRequestStatusChangedTest.php
+++ b/tests/MessageHandler/NotifyWhenFeatureRequestStatusChangedTest.php
@@ -157,6 +157,37 @@ final class NotifyWhenFeatureRequestStatusChangedTest extends KernelTestCase
         self::assertCount(1, $authorEmails, 'Author must receive exactly one email');
     }
 
+    public function testUpvoterWithMultipleVotesReceivesOnlyOneEmail(): void
+    {
+        // The unique constraint on (feature_request_id, voter_id) was dropped in
+        // Version20260324082438, so the same upvoter can have multiple vote rows
+        // for the same feature request. They must still receive exactly one email.
+        $this->connection->executeStatement(
+            'INSERT INTO feature_request_vote (id, feature_request_id, voter_id, voted_at) '
+            . 'VALUES (:id, :featureRequestId, :voterId, NOW())',
+            [
+                'id' => Uuid::uuid7()->toString(),
+                'featureRequestId' => FeatureRequestFixture::FEATURE_REQUEST_POPULAR,
+                'voterId' => PlayerFixture::PLAYER_ADMIN,
+            ],
+        );
+
+        ($this->handler)(new FeatureRequestStatusChanged(
+            featureRequestId: Uuid::fromString(FeatureRequestFixture::FEATURE_REQUEST_POPULAR),
+            oldStatus: FeatureRequestStatus::Open,
+            newStatus: FeatureRequestStatus::Completed,
+        ));
+
+        // Author + 2 distinct upvoters (ADMIN deduped, REGULAR) = 3
+        self::assertCount(3, $this->mailer->sent);
+
+        $adminEmails = array_filter(
+            $this->mailer->sent,
+            fn(RawMessage $m): bool => $this->toAddresses($this->assertTemplatedEmail($m))[0] === 'admin@speedpuzzling.cz',
+        );
+        self::assertCount(1, $adminEmails, 'Upvoter with duplicate votes must receive exactly one email');
+    }
+
     public function testUsesRecipientLocale(): void
     {
         // Author: Czech. Upvoter ADMIN: German. Upvoter REGULAR: unset → en fallback.

--- a/tests/MessageHandler/TestMailerSpy.php
+++ b/tests/MessageHandler/TestMailerSpy.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\MessageHandler;
+
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\RawMessage;
+
+final class TestMailerSpy implements MailerInterface
+{
+    /** @var list<RawMessage> */
+    public array $sent = [];
+
+    public function send(RawMessage $message, null|Envelope $envelope = null): void
+    {
+        $this->sent[] = $message;
+    }
+}

--- a/tests/Query/GetFeatureRequestVotersTest.php
+++ b/tests/Query/GetFeatureRequestVotersTest.php
@@ -117,17 +117,17 @@ final class GetFeatureRequestVotersTest extends KernelTestCase
         self::assertSame('de', $admin->locale);
     }
 
-    public function testDistinctVoterIdDefensiveAgainstDuplicateRows(): void
+    public function testDistinctVoterIdCollapsesRepeatedVotesOnSameRequest(): void
     {
-        // UNIQUE (feature_request_id, voter_id) normally prevents duplicates.
-        // Even so, the query uses DISTINCT ON (voter_id) — verify by simulating via a second
-        // vote row for a DIFFERENT feature request (same voter) then querying POPULAR.
+        // Migration Version20260324082438 dropped UNIQUE (feature_request_id, voter_id),
+        // so a player can legitimately have multiple vote rows for the same request.
+        // The query must collapse them so that recipient lists never contain duplicates.
         $this->connection->executeStatement(
             'INSERT INTO feature_request_vote (id, feature_request_id, voter_id, voted_at) '
             . 'VALUES (:id, :featureRequestId, :voterId, NOW())',
             [
                 'id' => Uuid::uuid7()->toString(),
-                'featureRequestId' => FeatureRequestFixture::FEATURE_REQUEST_NEW,
+                'featureRequestId' => FeatureRequestFixture::FEATURE_REQUEST_POPULAR,
                 'voterId' => PlayerFixture::PLAYER_ADMIN,
             ],
         );
@@ -141,6 +141,6 @@ final class GetFeatureRequestVotersTest extends KernelTestCase
             $voters,
             fn($v) => $v->playerId === PlayerFixture::PLAYER_ADMIN,
         ));
-        self::assertSame(1, $adminCount);
+        self::assertSame(1, $adminCount, 'Admin must appear exactly once even with repeated vote rows');
     }
 }

--- a/tests/Query/GetFeatureRequestVotersTest.php
+++ b/tests/Query/GetFeatureRequestVotersTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Query;
+
+use Doctrine\DBAL\Connection;
+use Ramsey\Uuid\Uuid;
+use SpeedPuzzling\Web\Query\GetFeatureRequestVoters;
+use SpeedPuzzling\Web\Tests\DataFixtures\FeatureRequestFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class GetFeatureRequestVotersTest extends KernelTestCase
+{
+    private GetFeatureRequestVoters $query;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $this->query = $container->get(GetFeatureRequestVoters::class);
+        $this->connection = $container->get(Connection::class);
+    }
+
+    public function testReturnsAllVotersExcludingTheSpecifiedPlayer(): void
+    {
+        // FEATURE_REQUEST_POPULAR: voters are ADMIN + REGULAR. Author = PLAYER_WITH_STRIPE.
+        $voters = $this->query->excludingPlayer(
+            featureRequestId: FeatureRequestFixture::FEATURE_REQUEST_POPULAR,
+            excludedPlayerId: PlayerFixture::PLAYER_WITH_STRIPE,
+        );
+
+        $playerIds = array_map(fn($v) => $v->playerId, $voters);
+        self::assertContains(PlayerFixture::PLAYER_ADMIN, $playerIds);
+        self::assertContains(PlayerFixture::PLAYER_REGULAR, $playerIds);
+        self::assertNotContains(PlayerFixture::PLAYER_WITH_STRIPE, $playerIds);
+        self::assertCount(2, $voters);
+    }
+
+    public function testExcludesVoterMatchingExcludedPlayer(): void
+    {
+        $voters = $this->query->excludingPlayer(
+            featureRequestId: FeatureRequestFixture::FEATURE_REQUEST_POPULAR,
+            excludedPlayerId: PlayerFixture::PLAYER_ADMIN,
+        );
+
+        $playerIds = array_map(fn($v) => $v->playerId, $voters);
+        self::assertNotContains(PlayerFixture::PLAYER_ADMIN, $playerIds);
+        self::assertContains(PlayerFixture::PLAYER_REGULAR, $playerIds);
+        self::assertCount(1, $voters);
+    }
+
+    public function testSkipsVotersWithNullEmail(): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE player SET email = NULL WHERE id = :id',
+            ['id' => PlayerFixture::PLAYER_REGULAR],
+        );
+
+        $voters = $this->query->excludingPlayer(
+            featureRequestId: FeatureRequestFixture::FEATURE_REQUEST_POPULAR,
+            excludedPlayerId: PlayerFixture::PLAYER_WITH_STRIPE,
+        );
+
+        $playerIds = array_map(fn($v) => $v->playerId, $voters);
+        self::assertNotContains(PlayerFixture::PLAYER_REGULAR, $playerIds);
+        self::assertContains(PlayerFixture::PLAYER_ADMIN, $playerIds);
+        self::assertCount(1, $voters);
+    }
+
+    public function testReturnsEmptyArrayWhenNoVoters(): void
+    {
+        // FEATURE_REQUEST_NEW has no votes.
+        $voters = $this->query->excludingPlayer(
+            featureRequestId: FeatureRequestFixture::FEATURE_REQUEST_NEW,
+            excludedPlayerId: PlayerFixture::PLAYER_ADMIN,
+        );
+
+        self::assertSame([], $voters);
+    }
+
+    public function testDoesNotLeakVotersFromOtherFeatureRequests(): void
+    {
+        // Query a feature request different from POPULAR; must only return its voters (none here).
+        $voters = $this->query->excludingPlayer(
+            featureRequestId: FeatureRequestFixture::FEATURE_REQUEST_NEW,
+            excludedPlayerId: PlayerFixture::PLAYER_ADMIN,
+        );
+
+        self::assertCount(0, $voters);
+    }
+
+    public function testIncludesEmailAndLocaleInResult(): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE player SET locale = :locale WHERE id = :id',
+            ['locale' => 'de', 'id' => PlayerFixture::PLAYER_ADMIN],
+        );
+
+        $voters = $this->query->excludingPlayer(
+            featureRequestId: FeatureRequestFixture::FEATURE_REQUEST_POPULAR,
+            excludedPlayerId: PlayerFixture::PLAYER_WITH_STRIPE,
+        );
+
+        $admin = null;
+        foreach ($voters as $voter) {
+            if ($voter->playerId === PlayerFixture::PLAYER_ADMIN) {
+                $admin = $voter;
+                break;
+            }
+        }
+
+        self::assertNotNull($admin);
+        self::assertSame('admin@speedpuzzling.cz', $admin->email);
+        self::assertSame('de', $admin->locale);
+    }
+
+    public function testDistinctVoterIdDefensiveAgainstDuplicateRows(): void
+    {
+        // UNIQUE (feature_request_id, voter_id) normally prevents duplicates.
+        // Even so, the query uses DISTINCT ON (voter_id) — verify by simulating via a second
+        // vote row for a DIFFERENT feature request (same voter) then querying POPULAR.
+        $this->connection->executeStatement(
+            'INSERT INTO feature_request_vote (id, feature_request_id, voter_id, voted_at) '
+            . 'VALUES (:id, :featureRequestId, :voterId, NOW())',
+            [
+                'id' => Uuid::uuid7()->toString(),
+                'featureRequestId' => FeatureRequestFixture::FEATURE_REQUEST_NEW,
+                'voterId' => PlayerFixture::PLAYER_ADMIN,
+            ],
+        );
+
+        $voters = $this->query->excludingPlayer(
+            featureRequestId: FeatureRequestFixture::FEATURE_REQUEST_POPULAR,
+            excludedPlayerId: PlayerFixture::PLAYER_WITH_STRIPE,
+        );
+
+        $adminCount = count(array_filter(
+            $voters,
+            fn($v) => $v->playerId === PlayerFixture::PLAYER_ADMIN,
+        ));
+        self::assertSame(1, $adminCount);
+    }
+}

--- a/translations/emails.cs.yml
+++ b/translations/emails.cs.yml
@@ -110,3 +110,26 @@ oauth2_client_rejected:
         <p>Bohužel vaše žádost o OAuth2 aplikaci <strong>%clientName%</strong> nebyla schválena.</p>
         <p><strong>Důvod:</strong> %reason%</p>
         <p>Máte-li dotazy nebo byste chtěli toto dále prodiskutovat, kontaktujte nás prosím na <a href="mailto:jan@myspeedpuzzling.com">jan@myspeedpuzzling.com</a>.</p>
+
+feature_request_status_changed:
+    subject: "Váš návrh funkce byl aktualizován: %title%"
+    title: "Aktualizace stavu návrhu funkce"
+    content: |
+        <p>Váš návrh funkce <strong>%featureRequestTitle%</strong> byl aktualizován.</p>
+        <p>Stav se změnil z <strong>%oldStatus%</strong> na <strong>%newStatus%</strong>.</p>
+    admin_comment: |
+        <p><strong>Komentář od týmu:</strong> %adminComment%</p>
+    upvoter:
+        subject: "Návrh funkce, pro který jste hlasovali, byl aktualizován: %title%"
+        title: "Aktualizace stavu návrhu funkce"
+        content: |
+            <p>Návrh funkce, pro který jste hlasovali — <strong>%featureRequestTitle%</strong> — byl aktualizován.</p>
+            <p>Stav se změnil z <strong>%oldStatus%</strong> na <strong>%newStatus%</strong>.</p>
+            <p>Děkujeme, že jste tento nápad podpořili!</p>
+        admin_comment: |
+            <p><strong>Komentář od týmu:</strong> %adminComment%</p>
+    status:
+        open: "Otevřený"
+        in_progress: "Pracuje se"
+        completed: "Hotovo"
+        declined: "Zamítnuto"

--- a/translations/emails.de.yml
+++ b/translations/emails.de.yml
@@ -110,3 +110,26 @@ competition_rejected:
         <p>Leider wurde Ihre Veranstaltung <strong>%competitionName%</strong> nicht genehmigt.</p>
         <p><strong>Grund:</strong> %reason%</p>
         <p>Bei Fragen oder wenn Sie dies besprechen möchten, kontaktieren Sie uns unter <a href="mailto:jan@myspeedpuzzling.com">jan@myspeedpuzzling.com</a>.</p>
+
+feature_request_status_changed:
+    subject: "Dein Feature-Wunsch wurde aktualisiert: %title%"
+    title: "Statusänderung deines Feature-Wunsches"
+    content: |
+        <p>Dein Feature-Wunsch <strong>%featureRequestTitle%</strong> wurde aktualisiert.</p>
+        <p>Der Status hat sich von <strong>%oldStatus%</strong> zu <strong>%newStatus%</strong> geändert.</p>
+    admin_comment: |
+        <p><strong>Kommentar vom Team:</strong> %adminComment%</p>
+    upvoter:
+        subject: "Ein Feature-Wunsch, für den du gestimmt hast, wurde aktualisiert: %title%"
+        title: "Statusänderung eines Feature-Wunsches"
+        content: |
+            <p>Ein Feature-Wunsch, für den du gestimmt hast — <strong>%featureRequestTitle%</strong> — wurde aktualisiert.</p>
+            <p>Der Status hat sich von <strong>%oldStatus%</strong> zu <strong>%newStatus%</strong> geändert.</p>
+            <p>Danke, dass du diese Idee unterstützt!</p>
+        admin_comment: |
+            <p><strong>Kommentar vom Team:</strong> %adminComment%</p>
+    status:
+        open: "Offen"
+        in_progress: "In Arbeit"
+        completed: "Erledigt"
+        declined: "Abgelehnt"

--- a/translations/emails.en.yml
+++ b/translations/emails.en.yml
@@ -119,6 +119,15 @@ feature_request_status_changed:
         <p>Status changed from <strong>%oldStatus%</strong> to <strong>%newStatus%</strong>.</p>
     admin_comment: |
         <p><strong>Comment from the team:</strong> %adminComment%</p>
+    upvoter:
+        subject: "A feature request you upvoted has been updated: %title%"
+        title: "Feature Request Status Update"
+        content: |
+            <p>A feature request you upvoted — <strong>%featureRequestTitle%</strong> — has been updated.</p>
+            <p>Status changed from <strong>%oldStatus%</strong> to <strong>%newStatus%</strong>.</p>
+            <p>Thank you for supporting this idea!</p>
+        admin_comment: |
+            <p><strong>Comment from the team:</strong> %adminComment%</p>
     status:
         open: "Open"
         in_progress: "In Progress"

--- a/translations/emails.es.yml
+++ b/translations/emails.es.yml
@@ -110,3 +110,26 @@ competition_rejected:
         <p>Lamentablemente, tu evento <strong>%competitionName%</strong> no fue aprobado.</p>
         <p><strong>Razón:</strong> %reason%</p>
         <p>Si tienes preguntas o deseas discutir esto, contáctanos en <a href="mailto:jan@myspeedpuzzling.com">jan@myspeedpuzzling.com</a>.</p>
+
+feature_request_status_changed:
+    subject: "Tu solicitud de función ha sido actualizada: %title%"
+    title: "Actualización del estado de la solicitud"
+    content: |
+        <p>Tu solicitud de función <strong>%featureRequestTitle%</strong> ha sido actualizada.</p>
+        <p>El estado ha cambiado de <strong>%oldStatus%</strong> a <strong>%newStatus%</strong>.</p>
+    admin_comment: |
+        <p><strong>Comentario del equipo:</strong> %adminComment%</p>
+    upvoter:
+        subject: "Una solicitud de función que apoyaste ha sido actualizada: %title%"
+        title: "Actualización del estado de la solicitud"
+        content: |
+            <p>Una solicitud de función que apoyaste — <strong>%featureRequestTitle%</strong> — ha sido actualizada.</p>
+            <p>El estado ha cambiado de <strong>%oldStatus%</strong> a <strong>%newStatus%</strong>.</p>
+            <p>¡Gracias por apoyar esta idea!</p>
+        admin_comment: |
+            <p><strong>Comentario del equipo:</strong> %adminComment%</p>
+    status:
+        open: "Abierta"
+        in_progress: "En progreso"
+        completed: "Completada"
+        declined: "Rechazada"

--- a/translations/emails.fr.yml
+++ b/translations/emails.fr.yml
@@ -110,3 +110,26 @@ competition_rejected:
         <p>Malheureusement, votre événement <strong>%competitionName%</strong> n'a pas été approuvé.</p>
         <p><strong>Raison :</strong> %reason%</p>
         <p>Si vous avez des questions ou souhaitez en discuter, contactez-nous à <a href="mailto:jan@myspeedpuzzling.com">jan@myspeedpuzzling.com</a>.</p>
+
+feature_request_status_changed:
+    subject: "Votre demande de fonctionnalité a été mise à jour : %title%"
+    title: "Mise à jour du statut de la demande"
+    content: |
+        <p>Votre demande de fonctionnalité <strong>%featureRequestTitle%</strong> a été mise à jour.</p>
+        <p>Le statut est passé de <strong>%oldStatus%</strong> à <strong>%newStatus%</strong>.</p>
+    admin_comment: |
+        <p><strong>Commentaire de l'équipe :</strong> %adminComment%</p>
+    upvoter:
+        subject: "Une demande de fonctionnalité que vous avez soutenue a été mise à jour : %title%"
+        title: "Mise à jour du statut de la demande"
+        content: |
+            <p>Une demande de fonctionnalité que vous avez soutenue — <strong>%featureRequestTitle%</strong> — a été mise à jour.</p>
+            <p>Le statut est passé de <strong>%oldStatus%</strong> à <strong>%newStatus%</strong>.</p>
+            <p>Merci de soutenir cette idée !</p>
+        admin_comment: |
+            <p><strong>Commentaire de l'équipe :</strong> %adminComment%</p>
+    status:
+        open: "Ouverte"
+        in_progress: "En cours"
+        completed: "Terminée"
+        declined: "Refusée"

--- a/translations/emails.ja.yml
+++ b/translations/emails.ja.yml
@@ -110,3 +110,26 @@ competition_rejected:
         <p>残念ながら、イベント <strong>%competitionName%</strong> は承認されませんでした。</p>
         <p><strong>理由:</strong> %reason%</p>
         <p>ご質問がある場合やさらに話し合いたい場合は、<a href="mailto:jan@myspeedpuzzling.com">jan@myspeedpuzzling.com</a> までご連絡ください。</p>
+
+feature_request_status_changed:
+    subject: "機能リクエストが更新されました: %title%"
+    title: "機能リクエストのステータス更新"
+    content: |
+        <p>あなたの機能リクエスト <strong>%featureRequestTitle%</strong> が更新されました。</p>
+        <p>ステータスが <strong>%oldStatus%</strong> から <strong>%newStatus%</strong> に変更されました。</p>
+    admin_comment: |
+        <p><strong>チームからのコメント:</strong> %adminComment%</p>
+    upvoter:
+        subject: "あなたが支持した機能リクエストが更新されました: %title%"
+        title: "機能リクエストのステータス更新"
+        content: |
+            <p>あなたが支持した機能リクエスト — <strong>%featureRequestTitle%</strong> — が更新されました。</p>
+            <p>ステータスが <strong>%oldStatus%</strong> から <strong>%newStatus%</strong> に変更されました。</p>
+            <p>このアイデアへのご支援、ありがとうございます！</p>
+        admin_comment: |
+            <p><strong>チームからのコメント:</strong> %adminComment%</p>
+    status:
+        open: "オープン"
+        in_progress: "進行中"
+        completed: "完了"
+        declined: "却下"


### PR DESCRIPTION
## Summary

- Extends `NotifyWhenFeatureRequestStatusChanged` so every upvoter receives a status-change email, not only the author.
- Author and upvoters get **different** email templates so the wording matches their relationship to the request.
- Deduplicates strictly by `player_id` — even a stray vote row owned by the author (bypassing the business rule that prevents self-voting) cannot cause the author to receive both emails. The author always gets exactly one email, the author template.
- Backfills the `feature_request_status_changed` translations into `cs`, `de`, `es`, `fr`, `ja` (previously English-only) and adds the new `upvoter.*` keys to all six locales.

## Implementation

- New `GetFeatureRequestVoters` query: `DISTINCT ON (voter_id)`, excludes a given player id, skips voters with `email IS NULL`.
- New `FeatureRequestVoter` DTO.
- New `templates/emails/feature_request_status_changed_upvoter.html.twig`.
- Handler renders each email in the recipient's own locale.

## Test plan

- [x] `tests/MessageHandler/NotifyWhenFeatureRequestStatusChangedTest.php` — 8 scenarios:
  - Author only when no upvoters
  - Author + all upvoters get correct templates
  - Author missing email → upvoters still get theirs
  - Upvoter missing email → that upvoter is skipped, others unaffected
  - **Critical dedup:** author with a vote row receives only the author email, never the upvoter one
  - Recipient-specific locale used per email
  - Admin comment present → in context for both templates
  - Admin comment null → null in context
- [x] `tests/Query/GetFeatureRequestVotersTest.php` — 7 scenarios for the query
- [x] `composer run phpstan` (max level) — clean
- [x] `composer run cs` — clean
- [x] `vendor/bin/phpunit --exclude-group panther` — 1012 tests, 0 failures
- [x] `php bin/console doctrine:schema:validate` — schema in sync (no DB changes)
- [x] `php bin/console cache:warmup` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)