### PR TITLE
Marketplace: add "New" as a puzzle condition option

### DIFF
--- a/src/FormType/AddToSellSwapListFormType.php
+++ b/src/FormType/AddToSellSwapListFormType.php
@@ -54,6 +54,7 @@ final class AddToSellSwapListFormType extends AbstractType
             'required' => true,
             'placeholder' => 'sell_swap_list.form.condition_placeholder',
             'choices' => [
+                'sell_swap_list.condition.new' => PuzzleCondition::New,
                 'sell_swap_list.condition.like_new' => PuzzleCondition::LikeNew,
                 'sell_swap_list.condition.normal' => PuzzleCondition::Normal,
                 'sell_swap_list.condition.not_so_good' => PuzzleCondition::NotSoGood,

--- a/src/Value/PuzzleCondition.php
+++ b/src/Value/PuzzleCondition.php
@@ -6,6 +6,7 @@ namespace SpeedPuzzling\Web\Value;
 
 enum PuzzleCondition: string
 {
+    case New = 'new';
     case LikeNew = 'like_new';
     case Normal = 'normal';
     case NotSoGood = 'not_so_good';

--- a/templates/_puzzle_library_item.html.twig
+++ b/templates/_puzzle_library_item.html.twig
@@ -145,7 +145,9 @@
                                 {% endif %}
 
                                 <span class="badge bg-secondary">
-                                    {% if item.condition.value == 'like_new' %}
+                                    {% if item.condition.value == 'new' %}
+                                        {{ 'sell_swap_list.condition.new'|trans }}
+                                    {% elseif item.condition.value == 'like_new' %}
                                         {{ 'sell_swap_list.condition.like_new'|trans }}
                                     {% elseif item.condition.value == 'normal' %}
                                         {{ 'sell_swap_list.condition.normal'|trans }}

--- a/templates/components/MarketplaceListing.html.twig
+++ b/templates/components/MarketplaceListing.html.twig
@@ -102,6 +102,7 @@
                         <label class="form-label form-label-sm mb-0"><small>{{ 'marketplace.filter.condition'|trans }}</small></label>
                         <select data-model="condition" class="form-select form-select-sm">
                             <option value="">{{ 'marketplace.all'|trans }}</option>
+                            <option value="new" {{ this.condition == 'new' ? 'selected' }}>{{ 'marketplace.condition.new'|trans }}</option>
                             <option value="like_new" {{ this.condition == 'like_new' ? 'selected' }}>{{ 'marketplace.condition.like_new'|trans }}</option>
                             <option value="normal" {{ this.condition == 'normal' ? 'selected' }}>{{ 'marketplace.condition.normal'|trans }}</option>
                             <option value="not_so_good" {{ this.condition == 'not_so_good' ? 'selected' }}>{{ 'marketplace.condition.not_so_good'|trans }}</option>

--- a/templates/marketplace/_listing_card.html.twig
+++ b/templates/marketplace/_listing_card.html.twig
@@ -110,7 +110,9 @@
                             <span class="badge bg-danger" style="font-size: 0.75rem;">{{ 'marketplace.listing_type.free'|trans }}</span>
                         {% endif %}
 
-                        {% if item.condition == 'like_new' %}
+                        {% if item.condition == 'new' %}
+                            <span class="badge bg-secondary" style="font-size: 0.75rem;">{{ 'marketplace.condition.new'|trans }}</span>
+                        {% elseif item.condition == 'like_new' %}
                             <span class="badge bg-secondary" style="font-size: 0.75rem;">{{ 'marketplace.condition.like_new'|trans }}</span>
                         {% elseif item.condition == 'normal' %}
                             <span class="badge bg-secondary" style="font-size: 0.75rem;">{{ 'marketplace.condition.normal'|trans }}</span>

--- a/templates/sell-swap/_item_card.html.twig
+++ b/templates/sell-swap/_item_card.html.twig
@@ -113,7 +113,9 @@
                             <span class="badge bg-primary" style="font-size: 0.75rem;">{{ 'sell_swap_list.listing_type.both'|trans }}</span>
                         {% endif %}
 
-                        {% if item.condition.value == 'like_new' %}
+                        {% if item.condition.value == 'new' %}
+                            <span class="badge bg-secondary" style="font-size: 0.75rem;">{{ 'sell_swap_list.condition.new'|trans }}</span>
+                        {% elseif item.condition.value == 'like_new' %}
                             <span class="badge bg-secondary" style="font-size: 0.75rem;">{{ 'sell_swap_list.condition.like_new'|trans }}</span>
                         {% elseif item.condition.value == 'normal' %}
                             <span class="badge bg-secondary" style="font-size: 0.75rem;">{{ 'sell_swap_list.condition.normal'|trans }}</span>

--- a/tests/DataFixtures/SellSwapListItemFixture.php
+++ b/tests/DataFixtures/SellSwapListItemFixture.php
@@ -30,6 +30,7 @@ final class SellSwapListItemFixture extends Fixture implements DependentFixtureI
     public const string SELLSWAP_10 = '018d000b-0000-0000-0000-000000000010';
     public const string SELLSWAP_11 = '018d000b-0000-0000-0000-000000000011';
     public const string SELLSWAP_12 = '018d000b-0000-0000-0000-000000000012';
+    public const string SELLSWAP_13 = '018d000b-0000-0000-0000-000000000013';
 
     public function __construct(
         private readonly ClockInterface $clock,
@@ -241,6 +242,20 @@ final class SellSwapListItemFixture extends Fixture implements DependentFixtureI
         $item12->markAsReserved();
         $manager->persist($item12);
         $this->addReference(self::SELLSWAP_12, $item12);
+
+        // SELLSWAP_13: sealed/never-opened puzzle, the new "New" condition
+        $item13 = $this->createSellSwapListItem(
+            id: self::SELLSWAP_13,
+            player: $player3,
+            puzzle: $puzzle1500_01,
+            listingType: ListingType::Sell,
+            price: 30.00,
+            condition: PuzzleCondition::New,
+            comment: 'Sealed in original shrink wrap',
+            daysAgo: 1,
+        );
+        $manager->persist($item13);
+        $this->addReference(self::SELLSWAP_13, $item13);
 
         $manager->flush();
     }

--- a/tests/Query/GetMarketplaceListingsTest.php
+++ b/tests/Query/GetMarketplaceListingsTest.php
@@ -103,6 +103,17 @@ final class GetMarketplaceListingsTest extends KernelTestCase
         }
     }
 
+    public function testFilterByConditionNew(): void
+    {
+        $items = $this->query->search(condition: PuzzleCondition::New);
+
+        self::assertNotEmpty($items);
+
+        foreach ($items as $item) {
+            self::assertSame('new', $item->condition);
+        }
+    }
+
     public function testSortByNewest(): void
     {
         $items = $this->query->search(sort: 'newest');

--- a/translations/messages.cs.yml
+++ b/translations/messages.cs.yml
@@ -1290,6 +1290,7 @@
     "both": "Prodej i výměna"
     "free": "Zdarma k odběru"
   "condition":
+    "new": "Nové"
     "like_new": "Jako nové"
     "normal": "Normální"
     "not_so_good": "Není v nejlepším stavu"
@@ -1641,6 +1642,7 @@
   "all_countries": "Jakákoliv země"
   "all_types": "Všechny typy"
   "condition":
+    "new": "Nové"
     "like_new": "Jako nové"
     "missing_pieces": "Chybějící díly"
     "normal": "Normální"

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -1222,6 +1222,7 @@
     "both": "Verkauf oder Tausch"
     "free": "Kostenlos abzugeben"
   "condition":
+    "new": "Neu"
     "like_new": "Wie neu"
     "normal": "Normal"
     "not_so_good": "Nicht so gut"
@@ -1643,6 +1644,7 @@
   "all_countries": "Beliebiges Land"
   "all_types": "Alle Typen"
   "condition":
+    "new": "Neu"
     "like_new": "Wie neu"
     "missing_pieces": "Fehlende Teile"
     "normal": "Normal"

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1565,6 +1565,7 @@ sell_swap_list:
         both: "Either Sell or Swap"
         free: "Give Away for Free"
     condition:
+        new: "New"
         like_new: "Like New"
         normal: "Normal"
         not_so_good: "Not So Good"
@@ -1988,6 +1989,7 @@ marketplace:
         both: "Sell / Swap"
         free: "Free"
     condition:
+        new: "New"
         like_new: "Like New"
         normal: "Normal"
         not_so_good: "Not So Good"

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -1223,6 +1223,7 @@
     "both": "Venta o Intercambio"
     "free": "Gratis"
   "condition":
+    "new": "Nuevo"
     "like_new": "Como Nuevo"
     "normal": "Normal"
     "not_so_good": "No Tan Bueno"
@@ -1643,6 +1644,7 @@
   "all_countries": "Cualquier país"
   "all_types": "Todos los tipos"
   "condition":
+    "new": "Nuevo"
     "like_new": "Como nuevo"
     "missing_pieces": "Piezas faltantes"
     "normal": "Normal"

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -1224,6 +1224,7 @@
     "both": "Vente ou échange"
     "free": "Gratuit"
   "condition":
+    "new": "Neuf"
     "like_new": "Comme neuf"
     "normal": "Normal"
     "not_so_good": "État moyen"
@@ -1644,6 +1645,7 @@
   "all_countries": "N'importe quel pays"
   "all_types": "Tous les types"
   "condition":
+    "new": "Neuf"
     "like_new": "Comme neuf"
     "missing_pieces": "Pièces manquantes"
     "normal": "Normal"

--- a/translations/messages.ja.yml
+++ b/translations/messages.ja.yml
@@ -1148,6 +1148,7 @@
   "already_in_list": "このパズルは既に売買・交換リストにあります。"
   "back_to_list": "売買・交換リストに戻る"
   "condition":
+    "new": "新品"
     "like_new": "新品同様"
     "missing_pieces": "ピース欠け"
     "normal": "普通"
@@ -1632,6 +1633,7 @@
   "all_countries": "すべての国"
   "all_types": "すべてのタイプ"
   "condition":
+    "new": "新品"
     "like_new": "新品同様"
     "missing_pieces": "ピース欠品あり"
     "normal": "普通"


### PR DESCRIPTION
## Summary
- Added `PuzzleCondition::New = 'new'` as the first case in the enum; surfaced first in the sell-swap FormType choices, the marketplace `<select>` filter, and the three listing-card templates (marketplace, sell-swap, puzzle library).
- Added 12 translation keys (`sell_swap_list.condition.new` and `marketplace.condition.new`) across en / cs / de / es / fr / ja.
- Added one `SellSwapListItem` fixture using the new condition and a matching `testFilterByConditionNew` query test. No migration required — column is a plain string with Doctrine `enumType` mapping.

Closes #116

Linked feature request: https://myspeedpuzzling.com/en/feature-requests/019d222c-adb5-72ac-9eac-c327e95ad1ba

## Test plan
- [ ] Open `/en/sell-swap/{puzzleId}/add?context=detail` as a Turbo-frame modal and as a standalone page — confirm "New" is the first option in the condition dropdown.
- [ ] On `/en/marketplace`, confirm the condition filter dropdown shows "New" first and filtering by it returns the seeded fixture item.
- [ ] Spot-check a non-English locale (e.g. `/cs/marketplace`) — confirm the CS translation "Nové" renders in both the filter and the listing-card badge.
- [ ] Verify the new listing-card badge appears on marketplace list, sell-swap user list, and puzzle library for the fixture item.