### PR TITLE
Link feature request title in status change emails

### DIFF
--- a/src/MessageHandler/NotifyWhenFeatureRequestStatusChanged.php
+++ b/src/MessageHandler/NotifyWhenFeatureRequestStatusChanged.php
@@ -35,6 +35,7 @@ readonly final class NotifyWhenFeatureRequestStatusChanged
                 locale: $author->locale ?? 'en',
                 template: 'emails/feature_request_status_changed.html.twig',
                 subjectKey: 'feature_request_status_changed.subject',
+                featureRequestId: $event->featureRequestId->toString(),
                 featureRequestTitle: $featureRequest->title,
                 oldStatus: $event->oldStatus,
                 newStatus: $event->newStatus,
@@ -53,6 +54,7 @@ readonly final class NotifyWhenFeatureRequestStatusChanged
                 locale: $voter->locale ?? 'en',
                 template: 'emails/feature_request_status_changed_upvoter.html.twig',
                 subjectKey: 'feature_request_status_changed.upvoter.subject',
+                featureRequestId: $event->featureRequestId->toString(),
                 featureRequestTitle: $featureRequest->title,
                 oldStatus: $event->oldStatus,
                 newStatus: $event->newStatus,
@@ -66,6 +68,7 @@ readonly final class NotifyWhenFeatureRequestStatusChanged
         string $locale,
         string $template,
         string $subjectKey,
+        string $featureRequestId,
         string $featureRequestTitle,
         FeatureRequestStatus $oldStatus,
         FeatureRequestStatus $newStatus,
@@ -96,6 +99,7 @@ readonly final class NotifyWhenFeatureRequestStatusChanged
             ->subject($subject)
             ->htmlTemplate($template)
             ->context([
+                'featureRequestId' => $featureRequestId,
                 'featureRequestTitle' => $featureRequestTitle,
                 'oldStatus' => $oldStatusLabel,
                 'newStatus' => $newStatusLabel,

--- a/templates/emails/feature_request_status_changed.html.twig
+++ b/templates/emails/feature_request_status_changed.html.twig
@@ -16,6 +16,7 @@
                 <columns>
                     {{ 'feature_request_status_changed.content'|trans({
                         '%featureRequestTitle%': featureRequestTitle,
+                        '%featureRequestUrl%': url('feature_request_detail', {featureRequestId: featureRequestId}),
                         '%oldStatus%': oldStatus,
                         '%newStatus%': newStatus,
                     })|raw }}

--- a/templates/emails/feature_request_status_changed_upvoter.html.twig
+++ b/templates/emails/feature_request_status_changed_upvoter.html.twig
@@ -16,6 +16,7 @@
                 <columns>
                     {{ 'feature_request_status_changed.upvoter.content'|trans({
                         '%featureRequestTitle%': featureRequestTitle,
+                        '%featureRequestUrl%': url('feature_request_detail', {featureRequestId: featureRequestId}),
                         '%oldStatus%': oldStatus,
                         '%newStatus%': newStatus,
                     })|raw }}

--- a/translations/emails.cs.yml
+++ b/translations/emails.cs.yml
@@ -115,7 +115,7 @@ feature_request_status_changed:
     subject: "Váš návrh funkce byl aktualizován: %title%"
     title: "Aktualizace stavu návrhu funkce"
     content: |
-        <p>Váš návrh funkce <strong>%featureRequestTitle%</strong> byl aktualizován.</p>
+        <p>Váš návrh funkce <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> byl aktualizován.</p>
         <p>Stav se změnil z <strong>%oldStatus%</strong> na <strong>%newStatus%</strong>.</p>
     admin_comment: |
         <p><strong>Komentář od týmu:</strong> %adminComment%</p>
@@ -123,7 +123,7 @@ feature_request_status_changed:
         subject: "Návrh funkce, pro který jste hlasovali, byl aktualizován: %title%"
         title: "Aktualizace stavu návrhu funkce"
         content: |
-            <p>Návrh funkce, pro který jste hlasovali — <strong>%featureRequestTitle%</strong> — byl aktualizován.</p>
+            <p>Návrh funkce, pro který jste hlasovali — <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> — byl aktualizován.</p>
             <p>Stav se změnil z <strong>%oldStatus%</strong> na <strong>%newStatus%</strong>.</p>
             <p>Děkujeme, že jste tento nápad podpořili!</p>
         admin_comment: |

--- a/translations/emails.de.yml
+++ b/translations/emails.de.yml
@@ -115,7 +115,7 @@ feature_request_status_changed:
     subject: "Dein Feature-Wunsch wurde aktualisiert: %title%"
     title: "Statusänderung deines Feature-Wunsches"
     content: |
-        <p>Dein Feature-Wunsch <strong>%featureRequestTitle%</strong> wurde aktualisiert.</p>
+        <p>Dein Feature-Wunsch <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> wurde aktualisiert.</p>
         <p>Der Status hat sich von <strong>%oldStatus%</strong> zu <strong>%newStatus%</strong> geändert.</p>
     admin_comment: |
         <p><strong>Kommentar vom Team:</strong> %adminComment%</p>
@@ -123,7 +123,7 @@ feature_request_status_changed:
         subject: "Ein Feature-Wunsch, für den du gestimmt hast, wurde aktualisiert: %title%"
         title: "Statusänderung eines Feature-Wunsches"
         content: |
-            <p>Ein Feature-Wunsch, für den du gestimmt hast — <strong>%featureRequestTitle%</strong> — wurde aktualisiert.</p>
+            <p>Ein Feature-Wunsch, für den du gestimmt hast — <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> — wurde aktualisiert.</p>
             <p>Der Status hat sich von <strong>%oldStatus%</strong> zu <strong>%newStatus%</strong> geändert.</p>
             <p>Danke, dass du diese Idee unterstützt!</p>
         admin_comment: |

--- a/translations/emails.en.yml
+++ b/translations/emails.en.yml
@@ -115,7 +115,7 @@ feature_request_status_changed:
     subject: "Your feature request has been updated: %title%"
     title: "Feature Request Status Update"
     content: |
-        <p>Your feature request <strong>%featureRequestTitle%</strong> has been updated.</p>
+        <p>Your feature request <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> has been updated.</p>
         <p>Status changed from <strong>%oldStatus%</strong> to <strong>%newStatus%</strong>.</p>
     admin_comment: |
         <p><strong>Comment from the team:</strong> %adminComment%</p>
@@ -123,7 +123,7 @@ feature_request_status_changed:
         subject: "A feature request you upvoted has been updated: %title%"
         title: "Feature Request Status Update"
         content: |
-            <p>A feature request you upvoted — <strong>%featureRequestTitle%</strong> — has been updated.</p>
+            <p>A feature request you upvoted — <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> — has been updated.</p>
             <p>Status changed from <strong>%oldStatus%</strong> to <strong>%newStatus%</strong>.</p>
             <p>Thank you for supporting this idea!</p>
         admin_comment: |

--- a/translations/emails.es.yml
+++ b/translations/emails.es.yml
@@ -115,7 +115,7 @@ feature_request_status_changed:
     subject: "Tu solicitud de función ha sido actualizada: %title%"
     title: "Actualización del estado de la solicitud"
     content: |
-        <p>Tu solicitud de función <strong>%featureRequestTitle%</strong> ha sido actualizada.</p>
+        <p>Tu solicitud de función <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> ha sido actualizada.</p>
         <p>El estado ha cambiado de <strong>%oldStatus%</strong> a <strong>%newStatus%</strong>.</p>
     admin_comment: |
         <p><strong>Comentario del equipo:</strong> %adminComment%</p>
@@ -123,7 +123,7 @@ feature_request_status_changed:
         subject: "Una solicitud de función que apoyaste ha sido actualizada: %title%"
         title: "Actualización del estado de la solicitud"
         content: |
-            <p>Una solicitud de función que apoyaste — <strong>%featureRequestTitle%</strong> — ha sido actualizada.</p>
+            <p>Una solicitud de función que apoyaste — <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> — ha sido actualizada.</p>
             <p>El estado ha cambiado de <strong>%oldStatus%</strong> a <strong>%newStatus%</strong>.</p>
             <p>¡Gracias por apoyar esta idea!</p>
         admin_comment: |

--- a/translations/emails.fr.yml
+++ b/translations/emails.fr.yml
@@ -115,7 +115,7 @@ feature_request_status_changed:
     subject: "Votre demande de fonctionnalité a été mise à jour : %title%"
     title: "Mise à jour du statut de la demande"
     content: |
-        <p>Votre demande de fonctionnalité <strong>%featureRequestTitle%</strong> a été mise à jour.</p>
+        <p>Votre demande de fonctionnalité <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> a été mise à jour.</p>
         <p>Le statut est passé de <strong>%oldStatus%</strong> à <strong>%newStatus%</strong>.</p>
     admin_comment: |
         <p><strong>Commentaire de l'équipe :</strong> %adminComment%</p>
@@ -123,7 +123,7 @@ feature_request_status_changed:
         subject: "Une demande de fonctionnalité que vous avez soutenue a été mise à jour : %title%"
         title: "Mise à jour du statut de la demande"
         content: |
-            <p>Une demande de fonctionnalité que vous avez soutenue — <strong>%featureRequestTitle%</strong> — a été mise à jour.</p>
+            <p>Une demande de fonctionnalité que vous avez soutenue — <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> — a été mise à jour.</p>
             <p>Le statut est passé de <strong>%oldStatus%</strong> à <strong>%newStatus%</strong>.</p>
             <p>Merci de soutenir cette idée !</p>
         admin_comment: |

--- a/translations/emails.ja.yml
+++ b/translations/emails.ja.yml
@@ -115,7 +115,7 @@ feature_request_status_changed:
     subject: "機能リクエストが更新されました: %title%"
     title: "機能リクエストのステータス更新"
     content: |
-        <p>あなたの機能リクエスト <strong>%featureRequestTitle%</strong> が更新されました。</p>
+        <p>あなたの機能リクエスト <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> が更新されました。</p>
         <p>ステータスが <strong>%oldStatus%</strong> から <strong>%newStatus%</strong> に変更されました。</p>
     admin_comment: |
         <p><strong>チームからのコメント:</strong> %adminComment%</p>
@@ -123,7 +123,7 @@ feature_request_status_changed:
         subject: "あなたが支持した機能リクエストが更新されました: %title%"
         title: "機能リクエストのステータス更新"
         content: |
-            <p>あなたが支持した機能リクエスト — <strong>%featureRequestTitle%</strong> — が更新されました。</p>
+            <p>あなたが支持した機能リクエスト — <a href="%featureRequestUrl%"><strong>%featureRequestTitle%</strong></a> — が更新されました。</p>
             <p>ステータスが <strong>%oldStatus%</strong> から <strong>%newStatus%</strong> に変更されました。</p>
             <p>このアイデアへのご支援、ありがとうございます！</p>
         admin_comment: |


### PR DESCRIPTION
Wraps the feature request title in an anchor linking to its detail page in both author and upvoter status-change notifications, so recipients can jump straight to the request. URL is generated via the feature_request_detail route and injected into translations across all six locales.