### PR TITLE
Exclude private players from rankings

### DIFF
--- a/src/Query/GetFastestGroups.php
+++ b/src/Query/GetFastestGroups.php
@@ -86,6 +86,7 @@ player_data AS (
     LEFT JOIN player p ON p.id = (player_elem.player ->> 'player_id')::UUID
     LEFT JOIN player_skill ps_member ON ps_member.player_id = p.id
     GROUP BY puzzle.id, player.id, manufacturer.id, pst.id, competition.id, ps_main.skill_tier
+    HAVING bool_or(p.is_private = false)
 )
 SELECT *
 FROM player_data

--- a/src/Query/GetFastestPairs.php
+++ b/src/Query/GetFastestPairs.php
@@ -86,6 +86,7 @@ player_data AS (
     LEFT JOIN player p ON p.id = (player_elem.player ->> 'player_id')::UUID
     LEFT JOIN player_skill ps_member ON ps_member.player_id = p.id
     GROUP BY puzzle.id, player.id, manufacturer.id, pst.id, competition.id, ps_main.skill_tier
+    HAVING bool_or(p.is_private = false)
 )
 SELECT *
 FROM player_data

--- a/src/Query/GetPlayerRatingRanking.php
+++ b/src/Query/GetPlayerRatingRanking.php
@@ -84,7 +84,7 @@ SELECT rank FROM (
     FROM player_elo pe
     INNER JOIN player p ON p.id = pe.player_id
     WHERE pe.pieces_count = :piecesCount
-        AND p.is_private = false
+        AND (p.is_private = false OR p.id = :playerId)
         AND p.ranking_opted_out = false
 ) ranked
 WHERE ranked.player_id = :playerId
@@ -170,8 +170,8 @@ SQL;
 SELECT
     pe.pieces_count,
     pe.elo_rating,
-    (SELECT COUNT(*) FROM player_elo pe2 INNER JOIN player p2 ON p2.id = pe2.player_id WHERE pe2.pieces_count = pe.pieces_count AND p2.is_private = false AND pe2.elo_rating >= pe.elo_rating) AS rank,
-    (SELECT COUNT(*) FROM player_elo pe3 INNER JOIN player p3 ON p3.id = pe3.player_id WHERE pe3.pieces_count = pe.pieces_count AND p3.is_private = false) AS total
+    (SELECT COUNT(*) FROM player_elo pe2 INNER JOIN player p2 ON p2.id = pe2.player_id WHERE pe2.pieces_count = pe.pieces_count AND (p2.is_private = false OR p2.id = :playerId) AND pe2.elo_rating >= pe.elo_rating) AS rank,
+    (SELECT COUNT(*) FROM player_elo pe3 INNER JOIN player p3 ON p3.id = pe3.player_id WHERE pe3.pieces_count = pe.pieces_count AND (p3.is_private = false OR p3.id = :playerId)) AS total
 FROM player_elo pe
 WHERE pe.player_id = :playerId
 ORDER BY pe.pieces_count ASC

--- a/src/Query/GetRanking.php
+++ b/src/Query/GetRanking.php
@@ -58,9 +58,11 @@ BestTimes AS (
     FROM
         puzzle_solving_time pst
         INNER JOIN PlayerPuzzles pp ON pst.puzzle_id = pp.puzzle_id
+        INNER JOIN player pl ON pl.id = pst.player_id
     WHERE
         pst.puzzling_type = 'solo'
         AND pst.seconds_to_solve IS NOT NULL
+        AND (pl.is_private = false OR pl.id = :playerId)
     GROUP BY
         pst.puzzle_id, pst.player_id
 ),
@@ -152,16 +154,18 @@ SQL;
         $query = <<<SQL
 WITH BestTimes AS (
     SELECT
-        puzzle_id,
-        player_id,
-        MIN(seconds_to_solve) as best_time
+        pst.puzzle_id,
+        pst.player_id,
+        MIN(pst.seconds_to_solve) as best_time
     FROM
-        puzzle_solving_time
-    WHERE puzzling_type = 'solo'
-        AND puzzle_id = :puzzleId
-        AND seconds_to_solve IS NOT NULL
+        puzzle_solving_time pst
+        INNER JOIN player pl ON pl.id = pst.player_id
+    WHERE pst.puzzling_type = 'solo'
+        AND pst.puzzle_id = :puzzleId
+        AND pst.seconds_to_solve IS NOT NULL
+        AND (pl.is_private = false OR pl.id = :playerId)
     GROUP BY
-        puzzle_id, player_id
+        pst.puzzle_id, pst.player_id
 ),
 RankedTimes AS (
     SELECT

--- a/tests/Query/GetFastestPairsTest.php
+++ b/tests/Query/GetFastestPairsTest.php
@@ -5,17 +5,24 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Tests\Query;
 
 use SpeedPuzzling\Web\Query\GetFastestPairs;
+use SpeedPuzzling\Web\Repository\PlayerRepository;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class GetFastestPairsTest extends KernelTestCase
 {
     private GetFastestPairs $query;
+    private PlayerRepository $playerRepository;
 
     protected function setUp(): void
     {
         self::bootKernel();
         $container = self::getContainer();
         $this->query = $container->get(GetFastestPairs::class);
+
+        /** @var PlayerRepository $playerRepository */
+        $playerRepository = $container->get(PlayerRepository::class);
+        $this->playerRepository = $playerRepository;
     }
 
     public function testPerPiecesCountReturnsDuoTimes(): void
@@ -42,5 +49,28 @@ final class GetFastestPairsTest extends KernelTestCase
         $results = $this->query->perPiecesCount(1000, 1, null);
 
         self::assertLessThanOrEqual(1, count($results));
+    }
+
+    public function testMixedTeamWithOnePublicMemberIsShown(): void
+    {
+        // Both fixture pairs are PLAYER_REGULAR (public) + PLAYER_PRIVATE (private):
+        // bool_or(p.is_private = false) is true, so the team must appear.
+        $results = $this->query->perPiecesCount(1000, 10, null);
+
+        self::assertNotEmpty($results);
+    }
+
+    public function testFullyPrivateTeamIsHidden(): void
+    {
+        // Both fixture pair teams are [PLAYER_REGULAR, PLAYER_PRIVATE]. Marking
+        // PLAYER_REGULAR as private leaves no public member, so the bool_or HAVING
+        // clause must drop both pair entries.
+        $regular = $this->playerRepository->get(PlayerFixture::PLAYER_REGULAR);
+        $regular->changeProfileVisibility(isPrivate: true);
+        self::getContainer()->get('doctrine.orm.entity_manager')->flush();
+
+        $results = $this->query->perPiecesCount(1000, 10, null);
+
+        self::assertEmpty($results);
     }
 }

--- a/tests/Query/GetPlayerRatingRankingPrivacyTest.php
+++ b/tests/Query/GetPlayerRatingRankingPrivacyTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Query;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use SpeedPuzzling\Web\Entity\PlayerElo;
+use SpeedPuzzling\Web\Query\GetPlayerRatingRanking;
+use SpeedPuzzling\Web\Repository\PlayerRepository;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class GetPlayerRatingRankingPrivacyTest extends KernelTestCase
+{
+    private const int PIECES_COUNT = 500;
+
+    private GetPlayerRatingRanking $query;
+    private PlayerRepository $playerRepository;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        /** @var GetPlayerRatingRanking $query */
+        $query = $container->get(GetPlayerRatingRanking::class);
+        $this->query = $query;
+
+        /** @var PlayerRepository $playerRepository */
+        $playerRepository = $container->get(PlayerRepository::class);
+        $this->playerRepository = $playerRepository;
+
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine.orm.entity_manager');
+        $this->em = $em;
+
+        // Test fixtures don't have enough solves to trigger MspRatingCalculator
+        // thresholds. Seed PlayerElo rows directly so the privacy filter can be
+        // exercised end-to-end.
+        $this->seedRatings([
+            PlayerFixture::PLAYER_ADMIN => 1500.0,
+            PlayerFixture::PLAYER_REGULAR => 1400.0,
+            PlayerFixture::PLAYER_WITH_FAVORITES => 1300.0,
+            PlayerFixture::PLAYER_WITH_STRIPE => 1200.0,
+        ]);
+    }
+
+    public function testPrivatePlayerHiddenFromGlobalRanking(): void
+    {
+        // Make a ranked public player private — they must vanish from ranking() and totalCount().
+        $totalBefore = $this->query->totalCount(self::PIECES_COUNT);
+        self::assertSame(4, $totalBefore);
+
+        $player = $this->playerRepository->get(PlayerFixture::PLAYER_REGULAR);
+        $player->changeProfileVisibility(isPrivate: true);
+        $this->em->flush();
+
+        $totalAfter = $this->query->totalCount(self::PIECES_COUNT);
+        self::assertSame(3, $totalAfter);
+
+        $playerIds = array_map(
+            static fn ($entry) => $entry->playerId,
+            $this->query->ranking(self::PIECES_COUNT),
+        );
+        self::assertNotContains(PlayerFixture::PLAYER_REGULAR, $playerIds);
+    }
+
+    public function testPlayerPositionVisibleToPrivateSubject(): void
+    {
+        $player = $this->playerRepository->get(PlayerFixture::PLAYER_REGULAR);
+        $player->changeProfileVisibility(isPrivate: true);
+        $this->em->flush();
+
+        // Subject exception: a private player querying their own position must
+        // still get a rank (against the pool of public players + themselves).
+        $position = $this->query->playerPosition(PlayerFixture::PLAYER_REGULAR, self::PIECES_COUNT);
+
+        // Pool with subject = PLAYER_ADMIN (1500), PLAYER_REGULAR (1400),
+        // PLAYER_WITH_FAVORITES (1300), PLAYER_WITH_STRIPE (1200) → rank 2.
+        self::assertSame(2, $position);
+    }
+
+    public function testPlayerPositionHiddenFromOthersForPrivatePlayer(): void
+    {
+        $player = $this->playerRepository->get(PlayerFixture::PLAYER_REGULAR);
+        $player->changeProfileVisibility(isPrivate: true);
+        $this->em->flush();
+
+        // A different player querying the private player's position must not see them.
+        // (playerPosition only takes the subject's id, so the subject IS who is
+        // queried — but for sanity, the private player's neighbors should keep
+        // contiguous ranks because the private one is excluded from their pool.)
+        $adminPosition = $this->query->playerPosition(PlayerFixture::PLAYER_ADMIN, self::PIECES_COUNT);
+        $favoritesPosition = $this->query->playerPosition(PlayerFixture::PLAYER_WITH_FAVORITES, self::PIECES_COUNT);
+
+        self::assertSame(1, $adminPosition);
+        // Without the private filter PLAYER_WITH_FAVORITES would be rank 3 (admin,
+        // private, favorites). With the filter PLAYER_REGULAR is dropped from
+        // PLAYER_WITH_FAVORITES's pool → rank 2.
+        self::assertSame(2, $favoritesPosition);
+    }
+
+    public function testAllForPlayerIncludesPrivateSubjectInOwnRank(): void
+    {
+        $player = $this->playerRepository->get(PlayerFixture::PLAYER_REGULAR);
+        $player->changeProfileVisibility(isPrivate: true);
+        $this->em->flush();
+
+        $data = $this->query->allForPlayer(PlayerFixture::PLAYER_REGULAR);
+
+        self::assertArrayHasKey(self::PIECES_COUNT, $data);
+        // Subject's pool: 3 public + self (4 total). One public player faster (admin).
+        self::assertSame(2, $data[self::PIECES_COUNT]['rank']);
+        self::assertSame(4, $data[self::PIECES_COUNT]['total']);
+    }
+
+    public function testAllForPlayerExcludesOtherPrivatePeers(): void
+    {
+        // Mark a peer (not the subject) private — they must not count in the
+        // subject's rank/total.
+        $peer = $this->playerRepository->get(PlayerFixture::PLAYER_ADMIN);
+        $peer->changeProfileVisibility(isPrivate: true);
+        $this->em->flush();
+
+        $data = $this->query->allForPlayer(PlayerFixture::PLAYER_REGULAR);
+
+        self::assertArrayHasKey(self::PIECES_COUNT, $data);
+        // Pool now: PLAYER_REGULAR (1400, subject), PLAYER_WITH_FAVORITES (1300),
+        // PLAYER_WITH_STRIPE (1200). Admin excluded. Subject is fastest → rank 1 of 3.
+        self::assertSame(1, $data[self::PIECES_COUNT]['rank']);
+        self::assertSame(3, $data[self::PIECES_COUNT]['total']);
+    }
+
+    /**
+     * @param array<string, float> $ratings player id => rating
+     */
+    private function seedRatings(array $ratings): void
+    {
+        foreach ($ratings as $playerId => $rating) {
+            $player = $this->playerRepository->get($playerId);
+            $this->em->persist(new PlayerElo(
+                id: Uuid::uuid7(),
+                player: $player,
+                piecesCount: self::PIECES_COUNT,
+                eloRating: $rating,
+            ));
+        }
+
+        $this->em->flush();
+    }
+}

--- a/tests/Query/GetRankingTest.php
+++ b/tests/Query/GetRankingTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Query;
+
+use Ramsey\Uuid\Uuid;
+use SpeedPuzzling\Web\Query\GetRanking;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class GetRankingTest extends KernelTestCase
+{
+    private GetRanking $query;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        /** @var GetRanking $query */
+        $query = $container->get(GetRanking::class);
+        $this->query = $query;
+    }
+
+    public function testOfPuzzleForPlayerExcludesPrivatePeersForPublicSubject(): void
+    {
+        // PUZZLE_500_01 best solo times per player (no verified/suspicious filter):
+        //   PLAYER_ADMIN            1200 (public)
+        //   PLAYER_PRIVATE          1400 (private — must be excluded)
+        //   PLAYER_REGULAR          1750 (public, subject)
+        //   PLAYER_WITH_STRIPE      2100 (public)
+        //   PLAYER_WITH_FAVORITES   3000 (public)
+        // Without privacy filter PLAYER_REGULAR would be rank 3 of 5.
+        $ranking = $this->query->ofPuzzleForPlayer(
+            PuzzleFixture::PUZZLE_500_01,
+            PlayerFixture::PLAYER_REGULAR,
+        );
+
+        self::assertNotNull($ranking);
+        self::assertSame(2, $ranking->rank);
+        self::assertSame(4, $ranking->totalPlayers);
+    }
+
+    public function testOfPuzzleForPlayerIncludesPrivateSubjectInOwnPool(): void
+    {
+        // PLAYER_PRIVATE viewing themselves on PUZZLE_500_01 must include self.
+        // Pool: all public + self → 5 players, PLAYER_PRIVATE at rank 2 (1400 vs PLAYER_ADMIN 1200).
+        $ranking = $this->query->ofPuzzleForPlayer(
+            PuzzleFixture::PUZZLE_500_01,
+            PlayerFixture::PLAYER_PRIVATE,
+        );
+
+        self::assertNotNull($ranking);
+        self::assertSame(2, $ranking->rank);
+        self::assertSame(5, $ranking->totalPlayers);
+    }
+
+    public function testOfPuzzleForPlayerReturnsNullForPlayerWhoDidNotSolve(): void
+    {
+        // Random uuid7 — guaranteed not in fixtures.
+        $randomPlayerId = Uuid::uuid7()->toString();
+
+        $ranking = $this->query->ofPuzzleForPlayer(
+            PuzzleFixture::PUZZLE_500_01,
+            $randomPlayerId,
+        );
+
+        self::assertNull($ranking);
+    }
+
+    public function testAllForPlayerExcludesPrivatePeers(): void
+    {
+        // PUZZLE_500_01 only — verify the PLAYER_REGULAR row matches the per-puzzle method.
+        $rankings = $this->query->allForPlayer(PlayerFixture::PLAYER_REGULAR);
+
+        self::assertArrayHasKey(PuzzleFixture::PUZZLE_500_01, $rankings);
+        $entry = $rankings[PuzzleFixture::PUZZLE_500_01];
+        self::assertSame(2, $entry->rank);
+        self::assertSame(4, $entry->totalPlayers);
+    }
+
+    public function testAllForPlayerIncludesPrivateSubject(): void
+    {
+        $rankings = $this->query->allForPlayer(PlayerFixture::PLAYER_PRIVATE);
+
+        // The private subject must see their own puzzles' rankings.
+        self::assertArrayHasKey(PuzzleFixture::PUZZLE_500_01, $rankings);
+        $entry = $rankings[PuzzleFixture::PUZZLE_500_01];
+        self::assertSame(2, $entry->rank);
+        self::assertSame(5, $entry->totalPlayers);
+    }
+}


### PR DESCRIPTION
## Summary

The result image (cached PNG, shared on social media), the post-submit recap page, the player profile, the compare-players page, and the global pairs/groups ladders all counted private puzzlers in their rank totals and positions. This PR makes the ranking SQL ignore private players, with one exception: **the subject of the ranking is always included** so a private user still sees their own rank on their own pages.

- \`GetRanking\` (used by recap, result image, player profile, comparison, \`PlayerSolvedPuzzles\` / \`MostSolvedPuzzles\` / \`RecentActivity\`): JOIN \`player\` in the \`BestTimes\` CTE and require \`(is_private = false OR id = :playerId)\`. The subject (\`:playerId\`) is exactly the player whose rank is shown — no new parameter needed.
- \`GetFastestPairs\` / \`GetFastestGroups\` (global \`LadderTable\`): \`HAVING bool_or(p.is_private = false)\` on the puzzlers aggregate, so a team is shown only if at least one member is public — matching \`PuzzlesSorter::filterOutPrivateProfiles\` for an anonymous viewer and the existing solo \`GetFastestPlayers\` behavior.
- \`GetPlayerRatingRanking\`: same subject exception in \`playerPosition\` and \`allForPlayer\` so a private player can see their own MSP-Rating; \`ranking()\`/\`totalCount()\`/\`distinctCountries()\` (global views) are unchanged and still hide private players entirely.

\`PuzzleTimes\` already filters per-viewer via \`PuzzlesSorter::filterOutPrivateProfiles(\$grouped, \$loggedPlayerId)\` (with the logged-user exception), so its query stays untouched.

## Test plan

New / extended PHPUnit tests cover:

- [x] \`GetRankingTest\`: public subject excludes a private peer from rank/total; private subject sees self in own rank; non-solver returns null.
- [x] \`GetFastestPairsTest\`: a mixed (one public + one private) team is still shown; flipping the public puzzler to private hides both fixture pair entries.
- [x] \`GetPlayerRatingRankingPrivacyTest\`: seeded \`PlayerElo\` rows; \`ranking()\`/\`totalCount()\` drop a now-private player; \`playerPosition()\` for that private subject still returns their rank; \`allForPlayer()\` for the private subject includes self in rank/total; other public peers' positions renumber correctly when a peer is hidden.

Manual smoke (post-merge):

- [ ] As a public solver on a puzzle that has a faster private peer, open \`/cas-pridan/{timeId}\` — "Rank X of Y" should drop by one (or more) vs. before. The matching \`/result-image/{timeId}\` PNG agrees on next regeneration (existing cached PNGs persist for up to 1 month at \`players/{playerId}/results/{timeId}.png\`).
- [ ] Log in as a private user, submit a time, open the recap — own rank visible with self counted.
- [ ] \`/ladder\` pairs/groups tabs no longer show fully-private teams.
- [ ] \`/msp-rating\` as a private logged-in user shows the personal position chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)