### PR TITLE
Add email:read OAuth2 scope gating user email in /api/v1/me

### DIFF
--- a/config/packages/api_platform.php
+++ b/config/packages/api_platform.php
@@ -44,6 +44,7 @@ return static function (ContainerConfigurator $configurator): void {
             'authorizationUrl' => '/oauth2/authorize',
             'scopes' => [
                 'profile:read' => 'Read user profile',
+                'email:read' => 'Read user email address',
                 'results:read' => 'Read player results',
                 'statistics:read' => 'Read player statistics',
                 'collections:read' => 'Read player collections',

--- a/config/packages/league_oauth2_server.php
+++ b/config/packages/league_oauth2_server.php
@@ -26,6 +26,7 @@ return App::config([
         'scopes' => [
             'available' => [
                 'profile:read',
+                'email:read',
                 'results:read',
                 'statistics:read',
                 'collections:read',

--- a/docs/features/api/README.md
+++ b/docs/features/api/README.md
@@ -37,6 +37,7 @@ Built on `league/oauth2-server-bundle`. Supports two flows:
 | Scope | Description | Auth Code | Client Credentials |
 |-------|-------------|-----------|-------------------|
 | `profile:read` (default) | View profile info | Yes | Yes |
+| `email:read` | View user email address | Yes | Yes |
 | `results:read` | View puzzle solving results | Yes | Yes |
 | `statistics:read` | View solving statistics | Yes | Yes |
 | `collections:read` | View puzzle collections | Yes | Yes |
@@ -55,7 +56,7 @@ Built on `league/oauth2-server-bundle`. Supports two flows:
 
 | Method | Endpoint | Required |
 |--------|----------|----------|
-| GET | `/api/v1/me` | PAT or `profile:read` |
+| GET | `/api/v1/me` | PAT or `profile:read` (the `email` field is populated only for PAT or tokens granted `email:read`, otherwise `null`) |
 | GET | `/api/v1/me/results?type=solo\|duo\|team` | PAT or `results:read` |
 | GET | `/api/v1/me/statistics` | PAT or `statistics:read` |
 | POST | `/api/v1/me/solving-times` | PAT or `solving-times:write` |

--- a/src/Api/V1/CurrentUserResponse.php
+++ b/src/Api/V1/CurrentUserResponse.php
@@ -24,6 +24,7 @@ final class CurrentUserResponse
     public function __construct(
         public string $id,
         public null|string $name,
+        public null|string $email,
         public string $code,
         public null|string $avatar,
         public null|string $country,

--- a/src/Api/V1/CurrentUserResponseProvider.php
+++ b/src/Api/V1/CurrentUserResponseProvider.php
@@ -28,9 +28,16 @@ final readonly class CurrentUserResponseProvider implements ProviderInterface
 
         $profile = $this->getPlayerProfile->byId($user->getPlayer()->id->toString());
 
+        // Email is private. Personal Access Tokens grant full access to the owner's own
+        // data, while third-party OAuth2 clients must be explicitly granted the
+        // "email:read" scope (role ROLE_OAUTH2_EMAIL:READ) — otherwise email stays null.
+        $canReadEmail = $this->security->isGranted('ROLE_PAT')
+            || $this->security->isGranted('ROLE_OAUTH2_EMAIL:READ');
+
         return new CurrentUserResponse(
             id: $profile->playerId,
             name: $profile->playerName,
+            email: $canReadEmail ? $profile->email : null,
             code: $profile->code,
             avatar: $profile->avatar,
             country: $profile->country,

--- a/src/FormType/RequestApiAccessFormType.php
+++ b/src/FormType/RequestApiAccessFormType.php
@@ -62,6 +62,7 @@ final class RequestApiAccessFormType extends AbstractType
             'expanded' => true,
             'choices' => [
                 'request_api_access.scope_profile' => 'profile:read',
+                'request_api_access.scope_email' => 'email:read',
                 'request_api_access.scope_results' => 'results:read',
                 'request_api_access.scope_statistics' => 'statistics:read',
                 'request_api_access.scope_collections_read' => 'collections:read',

--- a/templates/for-developers.html.twig
+++ b/templates/for-developers.html.twig
@@ -195,6 +195,14 @@
         <div class="col-md-6 col-lg-4">
             <div class="card border-0 shadow-sm h-100">
                 <div class="card-body py-3">
+                    <code class="text-primary fw-bold">email:read</code>
+                    <p class="text-muted mb-0 mt-1 fs-sm">{{ 'request_api_access.scope_email'|trans }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6 col-lg-4">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body py-3">
                     <code class="text-primary fw-bold">results:read</code>
                     <p class="text-muted mb-0 mt-1 fs-sm">{{ 'request_api_access.scope_results'|trans }}</p>
                 </div>

--- a/templates/oauth2/consent.html.twig
+++ b/templates/oauth2/consent.html.twig
@@ -31,6 +31,7 @@
 
                             {% set scope_labels = {
                                 'profile:read': {'icon': 'ci-user', 'label': 'View your profile information (name, avatar, country)'},
+                                'email:read': {'icon': 'ci-mail', 'label': 'View your email address'},
                                 'results:read': {'icon': 'ci-time', 'label': 'View your puzzle solving results'},
                                 'statistics:read': {'icon': 'ci-increase', 'label': 'View your statistics'},
                                 'collections:read': {'icon': 'ci-view-grid', 'label': 'View your puzzle collections'},

--- a/tests/Controller/Api/PersonalAccessTokenAuthTest.php
+++ b/tests/Controller/Api/PersonalAccessTokenAuthTest.php
@@ -25,10 +25,13 @@ final class PersonalAccessTokenAuthTest extends WebTestCase
         $responseContent = $browser->getResponse()->getContent();
         $this->assertIsString($responseContent);
 
-        /** @var array{id: string} $response */
+        /** @var array{id: string, email: null|string} $response */
         $response = json_decode($responseContent, true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertSame(PlayerFixture::PLAYER_REGULAR, $response['id']);
+        // A Personal Access Token grants full access to the owner's own data,
+        // so the email is always present (no scope concept for PATs).
+        $this->assertSame(PlayerFixture::PLAYER_REGULAR_EMAIL, $response['email']);
     }
 
     public function testInvalidPatReturnsUnauthorized(): void

--- a/tests/Controller/Api/V1/CurrentUserEndpointTest.php
+++ b/tests/Controller/Api/V1/CurrentUserEndpointTest.php
@@ -60,6 +60,74 @@ final class CurrentUserEndpointTest extends WebTestCase
         $this->assertArrayHasKey('country', $response);
     }
 
+    public function testEmailIsNullWithoutEmailReadScope(): void
+    {
+        $browser = self::createClient();
+
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            PlayerFixture::PLAYER_REGULAR,
+            ['profile:read'],
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+
+        $responseContent = $browser->getResponse()->getContent();
+        $this->assertIsString($responseContent);
+
+        /** @var array<string, mixed> $response */
+        $response = json_decode($responseContent, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('email', $response);
+        $this->assertNull($response['email']);
+    }
+
+    public function testEmailIsReturnedWithEmailReadScope(): void
+    {
+        $browser = self::createClient();
+
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            PlayerFixture::PLAYER_REGULAR,
+            ['profile:read', 'email:read'],
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+
+        $responseContent = $browser->getResponse()->getContent();
+        $this->assertIsString($responseContent);
+
+        /** @var array{email: null|string} $response */
+        $response = json_decode($responseContent, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(PlayerFixture::PLAYER_REGULAR_EMAIL, $response['email']);
+    }
+
+    public function testEmailReadScopeAloneCannotAccessEndpoint(): void
+    {
+        $browser = self::createClient();
+
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            PlayerFixture::PLAYER_REGULAR,
+            ['email:read'], // Missing profile:read which gates the endpoint
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
     public function testWithoutRequiredScopeReturnsForbidden(): void
     {
         $browser = self::createClient();

--- a/tests/DataFixtures/OAuth2ClientFixture.php
+++ b/tests/DataFixtures/OAuth2ClientFixture.php
@@ -60,6 +60,7 @@ final class OAuth2ClientFixture extends Fixture
         );
         $confidentialClient->setScopes(
             new Scope('profile:read'),
+            new Scope('email:read'),
             new Scope('results:read'),
             new Scope('statistics:read'),
         );

--- a/translations/messages.cs.yml
+++ b/translations/messages.cs.yml
@@ -2203,6 +2203,7 @@ qr_code:
     "type_public": "SPA / mobilní aplikace (public) — používá PKCE, bez secret"
     "scopes_heading": "Požadovaná oprávnění"
     "scope_profile": "Číst profil uživatele"
+    "scope_email": "Číst e-mailovou adresu uživatele"
     "scope_results": "Číst výsledky hráče"
     "scope_statistics": "Číst statistiky hráče"
     "scope_collections_read": "Číst kolekce hráče"

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -2205,6 +2205,7 @@ qr_code:
     "type_public": "SPA / Mobile App (öffentlich) — verwendet PKCE, kein Secret"
     "scopes_heading": "Angeforderte Berechtigungen"
     "scope_profile": "Benutzerprofil lesen"
+    "scope_email": "E-Mail-Adresse des Benutzers lesen"
     "scope_results": "Spielerergebnisse lesen"
     "scope_statistics": "Spielerstatistiken lesen"
     "scope_collections_read": "Spielersammlungen lesen"

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -625,6 +625,7 @@ request_api_access:
     type_public: "SPA / Mobile App (public) — uses PKCE, no secret"
     scopes_heading: "Requested Permissions"
     scope_profile: "Read user profile"
+    scope_email: "Read user email address"
     scope_results: "Read player results"
     scope_statistics: "Read player statistics"
     scope_collections_read: "Read player collections"

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -2205,6 +2205,7 @@ request_api_access:
     type_public: "SPA / App Móvil (pública) — usa PKCE, sin secreto"
     scopes_heading: "Permisos Solicitados"
     scope_profile: "Leer perfil de usuario"
+    scope_email: "Leer la dirección de correo electrónico del usuario"
     scope_results: "Leer resultados del jugador"
     scope_statistics: "Leer estadísticas del jugador"
     scope_collections_read: "Leer colecciones del jugador"

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -2206,6 +2206,7 @@ qr_code:
     "type_public": "SPA / Application mobile (publique) — utilise PKCE, sans secret"
     "scopes_heading": "Autorisations demandées"
     "scope_profile": "Lire le profil utilisateur"
+    "scope_email": "Lire l'adresse e-mail de l'utilisateur"
     "scope_results": "Lire les résultats des joueurs"
     "scope_statistics": "Lire les statistiques des joueurs"
     "scope_collections_read": "Lire les collections des joueurs"

--- a/translations/messages.ja.yml
+++ b/translations/messages.ja.yml
@@ -2194,6 +2194,7 @@ qr_code:
     "type_public": "SPA / モバイルアプリ（公開）— PKCEを使用、シークレットなし"
     "scopes_heading": "要求する権限"
     "scope_profile": "ユーザープロフィールの読み取り"
+    "scope_email": "ユーザーのメールアドレスの読み取り"
     "scope_results": "プレイヤーの結果の読み取り"
     "scope_statistics": "プレイヤーの統計の読み取り"
     "scope_collections_read": "プレイヤーのコレクションの読み取り"


### PR DESCRIPTION
## Summary

Adds a new OAuth2 scope **`email:read`** that gates the user's email address on the `GET /api/v1/me` endpoint.

- **OAuth2 clients** receive the `email` field **only** when granted the `email:read` scope (role `ROLE_OAUTH2_EMAIL:READ`). Without it, `email` is `null`.
- **Personal Access Tokens** (own-data-only access) always receive the email — consistent with PAT already returning the full owner profile. PATs have no scope concept.
- Because API Platform is configured with `skip_null_values: false`, the `email` key is always present in the response (null when not authorized).

The scope→role mapping is automatic in `league/oauth2-server-bundle` (`email:read` → `ROLE_OAUTH2_EMAIL:READ`), so no mapping code or DB migration is needed — the scope strings are stored as JSON/TEXT.

Note: `email:read` is an *additional* field-level scope. The `/api/v1/me` endpoint itself stays gated by `profile:read` (or PAT), so `email:read` alone cannot reach the endpoint.

## Changes

**Scope registration**
- `config/packages/league_oauth2_server.php` — add `email:read` to `scopes.available`
- `config/packages/api_platform.php` — Swagger scope description

**Gating logic**
- `src/Api/V1/CurrentUserResponse.php` — new `null|string $email` field
- `src/Api/V1/CurrentUserResponseProvider.php` — populate email only for PAT or `ROLE_OAUTH2_EMAIL:READ`

**UI / docs**
- `src/FormType/RequestApiAccessFormType.php` — request-access checkbox choice
- `templates/oauth2/consent.html.twig` — consent screen label (`ci-mail` icon)
- `templates/for-developers.html.twig` — scope reference card
- `docs/features/api/README.md` — scopes table row + `/api/v1/me` note

**i18n**
- `request_api_access.scope_email` added to all 6 locales (en, cs, de, es, fr, ja)

**Tests**
- `tests/Controller/Api/V1/CurrentUserEndpointTest.php` — email is `null` without the scope; present with `profile:read + email:read`; `email:read` alone → 403
- `tests/Controller/Api/PersonalAccessTokenAuthTest.php` — PAT receives email
- `tests/DataFixtures/OAuth2ClientFixture.php` — grant `email:read` to the confidential test client

## Verification

All green in the `web` container:
- `composer run cs-fix` — no violations
- `composer run phpstan` — no errors
- `vendor/bin/phpunit --exclude-group panther tests/Controller/Api` — 35 tests pass
- `php bin/console doctrine:schema:validate` — in sync
- `php bin/console cache:warmup` — ok

The change was additionally reviewed by a 3-dimension adversarial agent pass (completeness / correctness+security / tests+i18n+docs); the only confirmed finding — a missing row in the canonical API README — is fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)