### PR TITLE
Add optional round_id to solving-time create API

### DIFF
--- a/docs/features/api/README.md
+++ b/docs/features/api/README.md
@@ -113,12 +113,14 @@ Puzzle difficulty and player skill tiers are included in responses only if the t
     "finished_at": "2025-12-01T14:30:00+00:00",
     "first_attempt": true,
     "unboxed": false,
+    "round_id": "uuid",
     "group_players": ["#PLAYER_CODE", "Guest Name"]
 }
 ```
 
 - `time` format: `HH:MM:SS` or `MM:SS`
 - `group_players`: player codes prefixed with `#`, or plain names for unregistered players
+- `round_id`: optional, nullable. When set, the time is linked to that competition round and automatically to its competition. An invalid or unknown `round_id` returns 404.
 - Photo uploads not supported via API (use the website)
 
 ### Privacy

--- a/src/Api/V1/CreateSolvingTimeInput.php
+++ b/src/Api/V1/CreateSolvingTimeInput.php
@@ -38,6 +38,8 @@ final class CreateSolvingTimeInput
 
     public bool $unboxed = false;
 
+    public null|string $round_id = null;
+
     /** @var array<string> */
     public array $group_players = [];
 }

--- a/src/Api/V1/CreateSolvingTimeProcessor.php
+++ b/src/Api/V1/CreateSolvingTimeProcessor.php
@@ -9,6 +9,7 @@ use ApiPlatform\State\ProcessorInterface;
 use DateTimeImmutable;
 use Ramsey\Uuid\Uuid;
 use SpeedPuzzling\Web\Message\AddPuzzleSolvingTime;
+use SpeedPuzzling\Web\Repository\CompetitionRoundRepository;
 use SpeedPuzzling\Web\Security\ApiUser;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -21,6 +22,7 @@ final readonly class CreateSolvingTimeProcessor implements ProcessorInterface
     public function __construct(
         private Security $security,
         private MessageBusInterface $messageBus,
+        private CompetitionRoundRepository $competitionRoundRepository,
     ) {
     }
 
@@ -34,6 +36,13 @@ final readonly class CreateSolvingTimeProcessor implements ProcessorInterface
 
         $playerId = $user->getPlayer()->id->toString();
         $timeId = Uuid::uuid7();
+
+        // Validate the optional round here so an invalid/unknown id surfaces as 404
+        // (CompetitionRoundNotFound is a NotFoundHttpException). The handler re-resolves
+        // the round to wire it onto the entity.
+        if ($data->round_id !== null) {
+            $this->competitionRoundRepository->get($data->round_id);
+        }
 
         $finishedAt = $data->finished_at !== null ? new DateTimeImmutable($data->finished_at) : null;
 
@@ -50,6 +59,7 @@ final readonly class CreateSolvingTimeProcessor implements ProcessorInterface
                 finishedAt: $finishedAt,
                 firstAttempt: $data->first_attempt,
                 unboxed: $data->unboxed,
+                roundId: $data->round_id,
             ),
         );
 
@@ -61,6 +71,7 @@ final readonly class CreateSolvingTimeProcessor implements ProcessorInterface
             first_attempt: $data->first_attempt,
             unboxed: $data->unboxed,
             comment: $data->comment,
+            round_id: $data->round_id,
         );
     }
 }

--- a/src/Api/V1/SolvingTimeResponse.php
+++ b/src/Api/V1/SolvingTimeResponse.php
@@ -14,6 +14,7 @@ final class SolvingTimeResponse
         public bool $first_attempt,
         public bool $unboxed,
         public null|string $comment,
+        public null|string $round_id = null,
     ) {
     }
 }

--- a/src/Message/AddPuzzleSolvingTime.php
+++ b/src/Message/AddPuzzleSolvingTime.php
@@ -24,6 +24,7 @@ readonly final class AddPuzzleSolvingTime
         public null|DateTimeImmutable $finishedAt,
         public bool $firstAttempt,
         public bool $unboxed,
+        public null|string $roundId = null,
     ) {
     }
 

--- a/src/MessageHandler/AddPuzzleSolvingTimeHandler.php
+++ b/src/MessageHandler/AddPuzzleSolvingTimeHandler.php
@@ -14,6 +14,7 @@ use SpeedPuzzling\Web\Exceptions\CouldNotGenerateUniqueCode;
 use SpeedPuzzling\Web\Exceptions\SuspiciousPpm;
 use SpeedPuzzling\Web\Message\AddPuzzleSolvingTime;
 use SpeedPuzzling\Web\Repository\CompetitionRepository;
+use SpeedPuzzling\Web\Repository\CompetitionRoundRepository;
 use SpeedPuzzling\Web\Repository\PlayerRepository;
 use SpeedPuzzling\Web\Repository\PuzzleRepository;
 use SpeedPuzzling\Web\Services\ImageOptimizer;
@@ -33,6 +34,7 @@ readonly final class AddPuzzleSolvingTimeHandler
         private PuzzlersGrouping $puzzlersGrouping,
         private ClockInterface $clock,
         private CompetitionRepository $competitionRepository,
+        private CompetitionRoundRepository $competitionRoundRepository,
         private ImageOptimizer $imageOptimizer,
         private MistypedYearNormalizer $mistypedYearNormalizer,
     ) {
@@ -54,9 +56,14 @@ readonly final class AddPuzzleSolvingTimeHandler
         $finishedAt = $this->mistypedYearNormalizer->normalizeFinishedAt($message->finishedAt);
         $solvingTime = SolvingTime::fromUserInput($message->time);
         $puzzlersCount = 1;
+        $competitionRound = null;
         $competition = null;
 
-        if ($message->competitionId !== null) {
+        if ($message->roundId !== null) {
+            // The round's competition is derived; both are written together so they cannot disagree.
+            $competitionRound = $this->competitionRoundRepository->get($message->roundId);
+            $competition = $competitionRound->competition;
+        } elseif ($message->competitionId !== null) {
             try {
                 $competition = $this->competitionRepository->get($message->competitionId);
             } catch (CompetitionNotFound) {
@@ -103,6 +110,7 @@ readonly final class AddPuzzleSolvingTimeHandler
             $finishedPuzzlePhotoPath,
             $message->firstAttempt,
             $message->unboxed,
+            competitionRound: $competitionRound,
             competition: $competition,
         );
 

--- a/tests/Controller/Api/V1/CreateSolvingTimeEndpointTest.php
+++ b/tests/Controller/Api/V1/CreateSolvingTimeEndpointTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
+
+use Doctrine\DBAL\Connection;
+use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionRoundFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Tests\PatTestHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CreateSolvingTimeEndpointTest extends WebTestCase
+{
+    public function testWithoutTokenReturnsUnauthorized(): void
+    {
+        $browser = self::createClient();
+
+        $browser->request(
+            'POST',
+            '/api/v1/me/solving-times',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode([
+                'puzzle_id' => PuzzleFixture::PUZZLE_500_01,
+                'time' => '10:00',
+            ]),
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testCreateWithoutRoundId(): void
+    {
+        $browser = self::createClient();
+
+        $token = PatTestHelper::createToken($browser, PlayerFixture::PLAYER_REGULAR);
+        PatTestHelper::addBearerToken($browser, $token);
+
+        $browser->request(
+            'POST',
+            '/api/v1/me/solving-times',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode([
+                'puzzle_id' => PuzzleFixture::PUZZLE_500_01,
+                'time' => '10:00',
+            ]),
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $timeId = $this->extractTimeId($browser->getResponse()->getContent());
+
+        /** @var null|string|false $competitionRoundId */
+        $competitionRoundId = $this->database()->fetchOne(
+            'SELECT competition_round_id FROM puzzle_solving_time WHERE id = :id',
+            ['id' => $timeId],
+        );
+
+        self::assertNull($competitionRoundId);
+    }
+
+    public function testCreateWithValidRoundIdLinksRoundAndCompetition(): void
+    {
+        $browser = self::createClient();
+
+        $token = PatTestHelper::createToken($browser, PlayerFixture::PLAYER_REGULAR);
+        PatTestHelper::addBearerToken($browser, $token);
+
+        $browser->request(
+            'POST',
+            '/api/v1/me/solving-times',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode([
+                'puzzle_id' => PuzzleFixture::PUZZLE_500_01,
+                'time' => '10:00',
+                'round_id' => CompetitionRoundFixture::ROUND_WJPC_QUALIFICATION,
+            ]),
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $timeId = $this->extractTimeId($browser->getResponse()->getContent());
+
+        /** @var array{competition_round_id: null|string, competition_id: null|string}|false $row */
+        $row = $this->database()->fetchAssociative(
+            'SELECT competition_round_id, competition_id FROM puzzle_solving_time WHERE id = :id',
+            ['id' => $timeId],
+        );
+
+        self::assertNotFalse($row);
+        self::assertSame(CompetitionRoundFixture::ROUND_WJPC_QUALIFICATION, $row['competition_round_id']);
+        self::assertSame(CompetitionFixture::COMPETITION_WJPC_2024, $row['competition_id']);
+    }
+
+    public function testInvalidRoundIdReturnsNotFound(): void
+    {
+        $browser = self::createClient();
+
+        $token = PatTestHelper::createToken($browser, PlayerFixture::PLAYER_REGULAR);
+        PatTestHelper::addBearerToken($browser, $token);
+
+        $browser->request(
+            'POST',
+            '/api/v1/me/solving-times',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode([
+                'puzzle_id' => PuzzleFixture::PUZZLE_500_01,
+                'time' => '10:00',
+                'round_id' => '00000000-0000-0000-0000-000000000000',
+            ]),
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    private function database(): Connection
+    {
+        return self::getContainer()->get(Connection::class);
+    }
+
+    private function extractTimeId(string|false $responseContent): string
+    {
+        self::assertIsString($responseContent);
+
+        /** @var array{time_id: string} $response */
+        $response = json_decode($responseContent, true, 512, JSON_THROW_ON_ERROR);
+
+        return $response['time_id'];
+    }
+}

--- a/tests/MessageHandler/AddPuzzleSolvingTimeHandlerTest.php
+++ b/tests/MessageHandler/AddPuzzleSolvingTimeHandlerTest.php
@@ -6,8 +6,11 @@ namespace SpeedPuzzling\Web\Tests\MessageHandler;
 
 use Doctrine\DBAL\Connection;
 use Ramsey\Uuid\Uuid;
+use SpeedPuzzling\Web\Exceptions\CompetitionRoundNotFound;
 use SpeedPuzzling\Web\Exceptions\SuspiciousPpm;
 use SpeedPuzzling\Web\Message\AddPuzzleSolvingTime;
+use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionRoundFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -140,5 +143,63 @@ final class AddPuzzleSolvingTimeHandlerTest extends KernelTestCase
         );
 
         self::assertNull($competitionId);
+    }
+
+    public function testTimeIsAttachedToCompetitionRound(): void
+    {
+        // When a round is supplied, the time links to that round and (derived) to its competition.
+        $timeId = Uuid::uuid7();
+
+        $this->messageBus->dispatch(new AddPuzzleSolvingTime(
+            timeId: $timeId,
+            userId: PlayerFixture::PLAYER_REGULAR_USER_ID,
+            puzzleId: PuzzleFixture::PUZZLE_500_01,
+            competitionId: null,
+            time: '00:45:00',
+            comment: null,
+            finishedPuzzlesPhoto: null,
+            groupPlayers: [],
+            finishedAt: null,
+            firstAttempt: false,
+            unboxed: false,
+            roundId: CompetitionRoundFixture::ROUND_WJPC_QUALIFICATION,
+        ));
+
+        /** @var array{competition_round_id: null|string, competition_id: null|string}|false $row */
+        $row = $this->database->fetchAssociative(
+            'SELECT competition_round_id, competition_id FROM puzzle_solving_time WHERE id = :id',
+            ['id' => $timeId->toString()],
+        );
+
+        self::assertNotFalse($row);
+        self::assertSame(CompetitionRoundFixture::ROUND_WJPC_QUALIFICATION, $row['competition_round_id']);
+        self::assertSame(CompetitionFixture::COMPETITION_WJPC_2024, $row['competition_id']);
+    }
+
+    public function testUnknownRoundIdThrows(): void
+    {
+        // The API processor guards this before it reaches the handler; here we document
+        // the handler-level behavior: an unknown round id bubbles up as CompetitionRoundNotFound.
+        $this->expectException(HandlerFailedException::class);
+
+        try {
+            $this->messageBus->dispatch(new AddPuzzleSolvingTime(
+                timeId: Uuid::uuid7(),
+                userId: PlayerFixture::PLAYER_REGULAR_USER_ID,
+                puzzleId: PuzzleFixture::PUZZLE_500_01,
+                competitionId: null,
+                time: '00:45:00',
+                comment: null,
+                finishedPuzzlesPhoto: null,
+                groupPlayers: [],
+                finishedAt: null,
+                firstAttempt: false,
+                unboxed: false,
+                roundId: '00000000-0000-0000-0000-000000000000',
+            ));
+        } catch (HandlerFailedException $exception) {
+            self::assertInstanceOf(CompetitionRoundNotFound::class, $exception->getPrevious());
+            throw $exception;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds an optional, nullable `round_id` to the solving-time **create** endpoint `POST /api/v1/me/solving-times`. When supplied, the solving time is linked to that `CompetitionRound` and, derived, to its `Competition`.

The relation was previously inert: `PuzzleSolvingTime.competitionRound` and the `competition_round_id` DB column already existed but were never written. This change populates them from the API. No reader is built yet (out of scope).

### Thread of the id
`CreateSolvingTimeInput.round_id` → validated in `CreateSolvingTimeProcessor` (resolved via `CompetitionRoundRepository::get()`) → forwarded as `roundId` on the `AddPuzzleSolvingTime` message → `AddPuzzleSolvingTimeHandler` resolves the round, sets `competitionRound = round` and `competition = round.competition`, and passes both to `new PuzzleSolvingTime(...)`. The id is echoed back in `SolvingTimeResponse`.

## Design decisions

- **D1 — Create only.** Scope is `POST /api/v1/me/solving-times`. The `PUT` update endpoint is **out of scope** — it carries a separate competition-null-overwrite semantic in `EditPuzzleSolvingTime`/`modify()` that needs its own decision.
- **D2 — Competition derived from round.** When `round_id` is set, BOTH `competitionRound = round` AND `competition = round.competition` are written together, so the two can never disagree.
- **D3 — Invalid/unknown `round_id` → 404.** Validated in the **processor** via `CompetitionRoundRepository::get()`, whose `CompetitionRoundNotFound` is a `NotFoundHttpException` and propagates cleanly as 404 (the command bus does not unwrap handler exceptions, so handler-thrown errors would otherwise surface as 500). Not silently swallowed — it is explicit client input.
- **D4 — Permissive on domain invariants.** v1 does NOT enforce "puzzle must belong to the round" or "player must be a participant". Documented as optional future hardening.
- **D5 — No migration, no entity change.** The `competition_round_id` column/FK/index already exist (`Version20240216124858`); the `PuzzleSolvingTime` constructor already accepts `competitionRound`. `modify()` is untouched since update is out of scope.
- **D6 — Echo `round_id`** back in `SolvingTimeResponse` (trailing constructor param defaulted to `null`, so `UpdateSolvingTimeProcessor` — which builds the same DTO with named args — is unaffected).

## Files changed

- `src/Api/V1/CreateSolvingTimeInput.php` — nullable `round_id` field
- `src/Api/V1/CreateSolvingTimeProcessor.php` — inject `CompetitionRoundRepository`, validate round, forward `roundId`, echo `round_id`
- `src/Api/V1/SolvingTimeResponse.php` — trailing nullable `round_id`
- `src/Message/AddPuzzleSolvingTime.php` — trailing nullable `roundId`
- `src/MessageHandler/AddPuzzleSolvingTimeHandler.php` — inject `CompetitionRoundRepository`, resolve round + derived competition, wire onto entity
- `docs/features/api/README.md` — document the new field
- `tests/MessageHandler/AddPuzzleSolvingTimeHandlerTest.php` — `testTimeIsAttachedToCompetitionRound`, `testUnknownRoundIdThrows`
- `tests/Controller/Api/V1/CreateSolvingTimeEndpointTest.php` — NEW: without-token (401), without-round, valid-round links round+competition, invalid-round (404)

## Gate results

- `composer run cs-fix`: No violations were found
- `composer run phpstan`: No errors
- `phpunit --filter "AddPuzzleSolvingTimeHandler|CreateSolvingTimeEndpoint"`: OK (10 tests, 28 assertions)
- `phpunit --exclude-group panther`: Tests: 1131, Assertions: 3181, 0 failures (1 pre-existing `league/oauth2-server` BearerTokenValidator warning, harmless)
- `doctrine:schema:validate`: mapping correct, schema in sync
- `cache:warmup --env=prod`: success

🤖 Generated with [Claude Code](https://claude.com/claude-code)