### PR TITLE
Make S3 bucket configurable, stop sending public-read ACL on uploads

### DIFF
--- a/.env
+++ b/.env
@@ -40,6 +40,7 @@ S3_REGION=global
 S3_ENDPOINT=http://minio:9000
 S3_ACCESS_KEY=speedpuzzling
 S3_SECRET_KEY=speedpuzzling
+S3_BUCKET=puzzle
 
 REDIS_CACHE_DSN=redis://redis:6379/1
 

--- a/config/packages/oneup_flysystem.php
+++ b/config/packages/oneup_flysystem.php
@@ -13,7 +13,7 @@ return App::config([
             'minio' => [
                 'async_aws_s3' => [
                     'client' => S3Client::class,
-                    'bucket' => 'puzzle',
+                    'bucket' => '%env(S3_BUCKET)%',
                 ],
             ],
         ],
@@ -21,8 +21,9 @@ return App::config([
             'minio' => [
                 'adapter' => 'minio',
                 'alias' => Filesystem::class,
-                'visibility' => 'public',
-                'directory_visibility' => 'public',
+                // No 'visibility' => 'public' here: it would send a public-read ACL
+                // per object, which Hetzner Object Storage honors — punching public
+                // holes in the private bucket. Reads go through credentialed imgproxy.
             ],
         ],
     ],


### PR DESCRIPTION
Preparation for the storage migration to Hetzner Object Storage (private bucket `myspeedpuzzling`) — see migration plan in lily.srv repo (`docs/speedpuzzling-migration-plan.md`, P4).

- Bucket name now comes from `S3_BUCKET` env (default `puzzle` — matches current prod, so this deploys as a no-op on spare).
- Dropped `visibility: public` / `directory_visibility: public` from the flysystem config: it makes the adapter send a `public-read` ACL on every upload, and the P2 verification spike proved Hetzner **honors** per-object ACLs — every app upload would become anonymously readable at the raw storage endpoint, defeating the private-bucket design. On MinIO the ACL is meaningless (the bucket policy governs), so no change on current prod.
- All reads go through credentialed imgproxy (thumbnails + `raw:1` originals), so nothing needs public objects.

Verified: PHPStan clean, PHPCS clean, `cache:warmup` compiles (`%env(S3_BUCKET)%` resolves), PHPUnit 1303 tests green apart from the 49 Panther tests that can't run without a browser locally (environmental — CI covers them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)