### PR TITLE
[cutover-only] Deploy via lily webhook instead of SSH to spare

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,16 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v7
 
-            -   uses: appleboy/ssh-action@v1
-                with:
-                    host: myspeedpuzzling.com
-                    username: ${{ secrets.DEPLOY_USERNAME }}
-                    key: ${{ secrets.DEPLOY_PRIVATE_KEY }}
-                    script: cd /deployment/speedpuzzling && ./deploy.sh
+            -   name: Trigger lily deploy (HMAC webhook)
+                env:
+                    SECRET: ${{ secrets.DEPLOY_WEBHOOK_SECRET }}
+                run: |
+                    BODY='{"app":"myspeedpuzzling","tag":"main"}'
+                    SIG="$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.* //')"
+                    curl -fsS -X POST https://deploy.lily.srv.thedevs.cz/hooks/myspeedpuzzling \
+                      -H 'Content-Type: application/json' \
+                      -H "X-Hub-Signature-256: sha256=$SIG" \
+                      --data-raw "$BODY"
 
             -   name: Create Sentry release
                 uses: getsentry/action-release@v3


### PR DESCRIPTION
## ⚠️ DRAFT — merge ONLY at the spare→lily cutover moment

Part of the MySpeedPuzzling migration to `lily.srv`. This is the **single app-repo change** needed for cutover: it flips where a successful `main` build deploys.

### What changes
The `deploy` job's SSH-to-spare step →

```
appleboy/ssh-action → cd /deployment/speedpuzzling && ./deploy.sh   (spare)
```

becomes an HMAC-signed POST to lily's deploy-trigger receiver:

```
POST https://deploy.lily.srv.thedevs.cz/hooks/myspeedpuzzling
body:   {"app":"myspeedpuzzling","tag":"main"}      # app pinned by the hook; only `tag` is consumed
header: X-Hub-Signature-256: sha256=<hmac-sha256(raw body, key=DEPLOY_WEBHOOK_SECRET)>
```

Matches lily's documented webhook contract (`infra/webhook/README.md`). The webhook receiver verifies the HMAC, enqueues a job, and the root host executor runs `/srv/myspeedpuzzling/deploy.sh main` (blue-green rollout).

### Unchanged
- The `docker` build job still builds + pushes `ghcr.io/myspeedpuzzling/website:main` **and** `:sha-<sha>` (lily compose uses `${IMAGE_TAG:-main}`; sha tags give manual rollback-by-redeploy).
- The Sentry release step.

### Prereqs (already in place)
- `DEPLOY_WEBHOOK_SECRET` GH secret set (mirrors the box `/srv/webhook/secrets.env`).
- `myspeedpuzzling` hook registered on lily; `/srv/myspeedpuzzling/deploy.sh` present.

### After merge
- One deploy flows through lily end-to-end (verify).
- Disable the `spare.srv` speedpuzzling infra workflow so a stray push can't resurrect spare.
- `DEPLOY_USERNAME` / `DEPLOY_PRIVATE_KEY` secrets become unused (can be deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)