### PR TITLE
Stop check-translations flagging English-only guides

### DIFF
--- a/src/Controller/GuidesController.php
+++ b/src/Controller/GuidesController.php
@@ -13,6 +13,26 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * Guides hub index. Guides are English-only by design: a single /en/ URL,
  * no localized route variants (head handling is overridden in the guides
  * base template accordingly).
+ *
+ * Why English-only, not an oversight: search authority is scarce for a growing
+ * site, so each guide concentrates every backlink and ranking signal on one
+ * strong URL aimed at the high-volume English term "speed puzzling", rather
+ * than splitting it across six weaker localized URLs. The guide body copy is
+ * likewise hardcoded English prose in templates/guides/*.twig, and the
+ * `guides.*` translation keys exist only in messages.en.yml.
+ *
+ * Consequences to respect:
+ *  - Do NOT fill `guides.*` keys in other locale files — the routes pin
+ *    `_locale => 'en'` and the controllers pin `trans(locale: 'en')`, so a
+ *    translated value can never render. tools/check-translations.php therefore
+ *    ignores `messages.guides.*` (see its $ignoredKeyPrefixes) so it stops
+ *    reporting a false gap.
+ *  - The "(in English)" disclaimers next to guide links in other locales
+ *    (de/es/fr/ja) are accurate — leave them until the guides are localized.
+ *
+ * Translating the guides is a deliberate future project (extract the prose,
+ * drop the locale pins, add hreflang, translate the winners once they rank),
+ * not a gap to be filled piecemeal.
  */
 final class GuidesController extends AbstractController
 {

--- a/tools/check-translations.php
+++ b/tools/check-translations.php
@@ -12,6 +12,31 @@ $outputFile = __DIR__ . '/../translations-missing.json';
 $locales = ['cs', 'en', 'de', 'es', 'fr', 'ja'];
 
 /**
+ * Fully-qualified key prefixes ("domain.nested.path") that are intentionally
+ * English-only and must NOT be reported as missing in other locales.
+ *
+ * `messages.guides.*` — the SEO guide pages (/en/guides/*) are English-only by
+ * design. Every guide route pins `defaults: ['_locale' => 'en']` and the
+ * controllers pin `trans(locale: 'en')`, so a translated value would never
+ * render; on top of that, ~2,600 words of guide body copy live as hardcoded
+ * English prose in templates/guides/*.twig, not in translation files at all.
+ *
+ * Why English-only: search authority is scarce for a growing site, so the
+ * guides concentrate every backlink and ranking signal on one strong URL per
+ * guide (aimed at the high-volume English term "speed puzzling") instead of
+ * splitting it across six weaker localized URLs. Translating them is a
+ * deliberate future project — extract the prose, drop the locale pins, add
+ * hreflang, translate the winners once they rank — not a gap to be filled by
+ * this checker. Until that decision is made, filling `guides.*` in other
+ * locales produces dead keys. See src/Controller/GuidesController.php.
+ *
+ * @var list<string>
+ */
+$ignoredKeyPrefixes = [
+    'messages.guides.',
+];
+
+/**
  * Flatten nested array keys into dot notation
  * @param array<string, mixed> $array
  * @param string $prefix
@@ -88,9 +113,26 @@ foreach ($files as $file) {
 // Find missing keys
 // Structure: $missing["domain.key"] = ["filled" => [...], "missing" => [...]]
 $missing = [];
+$ignoredCount = 0;
 
 foreach ($allKeysByDomain as $domain => $keys) {
     foreach (array_keys($keys) as $key) {
+        $fullKey = $domain . '.' . $key;
+
+        // Intentionally English-only keys are never reported as missing.
+        $isIgnored = false;
+        foreach ($ignoredKeyPrefixes as $ignoredPrefix) {
+            if (str_starts_with($fullKey, $ignoredPrefix)) {
+                $isIgnored = true;
+                break;
+            }
+        }
+
+        if ($isIgnored) {
+            $ignoredCount++;
+            continue;
+        }
+
         $missingIn = [];
         $filledIn = [];
 
@@ -104,7 +146,6 @@ foreach ($allKeysByDomain as $domain => $keys) {
         }
 
         if ($missingIn !== []) {
-            $fullKey = $domain . '.' . $key;
             $missing[$fullKey] = [
                 'filled' => $filledIn,
                 'missing' => $missingIn,
@@ -130,6 +171,11 @@ file_put_contents($outputFile, $json . "\n");
 $totalMissing = count($missing);
 echo "Translation check complete!\n";
 echo "Found $totalMissing keys with missing translations.\n";
+
+if ($ignoredCount > 0) {
+    echo "Ignored $ignoredCount key(s) that are intentionally English-only (see \$ignoredKeyPrefixes).\n";
+}
+
 echo "Output written to: translations-missing.json\n";
 
 // Print per-locale summary


### PR DESCRIPTION
## What

`tools/check-translations.php` reported all 25 `guides.*` keys as "missing" in cs/de/es/fr/ja — a **false gap**. The guides are English-only by design:

- Every guide route pins `defaults: ['_locale' => 'en']`
- The controllers pin `trans(locale: 'en')`
- The guide body copy is ~2,600 words of hardcoded English prose in `templates/guides/*.twig`, not in translation files at all

So a translated `guides.*` value can never render — filling those keys produces dead entries (which is exactly what we did briefly before catching it).

## The fix

Adds an `$ignoredKeyPrefixes` list (`messages.guides.`) so those keys are skipped instead of reported. Two deliberate choices:

- **Not a silent skip.** The summary now prints `Ignored 25 key(s) that are intentionally English-only` — coverage that's bounded is stated, not hidden.
- **The reasoning is written down**, so this decision doesn't get re-litigated. The constant and the `GuidesController` docblock both explain *why* English-only: search authority is scarce for a growing site, so each guide concentrates every backlink and ranking signal on one strong URL aimed at the high-volume English term "speed puzzling", rather than splitting it across six weaker localized ones. Translating them is a deliberate future project (extract the prose, drop the locale pins, add hreflang, translate the winners once they rank), not a gap to fill piecemeal.

The `GuidesController` docblock also records the two consequences to respect: don't fill `guides.*` in other locales, and leave the accurate "(in English)" disclaimers on guide links until the guides are actually localized.

## Safety

The prefix is anchored with a trailing dot, so `nav.guides`, a hypothetical `guides_extra.*`, and other domains (`emails.*`) are unaffected — verified with a small match table.

Checker now reports **0 missing, 25 ignored**. phpstan clean; the pre-existing phpcs "side effects" warning on this one-off script is unchanged (present on main, not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)