### PR TITLE
Standalone token-authenticated email preferences page

### DIFF
--- a/config/packages/csrf.php
+++ b/config/packages/csrf.php
@@ -30,6 +30,9 @@ return App::config([
                 // Unsubscribe landing page is reached from e-mail links, always
                 // anonymous
                 'newsletter-unsubscribe',
+                // E-mail preferences page is reached from e-mail links, always
+                // anonymous (token-authenticated)
+                'email-preferences',
             ],
         ],
     ],

--- a/docs/features/newsletter/README.md
+++ b/docs/features/newsletter/README.md
@@ -14,7 +14,7 @@ One e-mail = one recipient. When an address belongs to both a player and a guest
 ## Listmonk structure
 
 - **6 private, single opt-in lists**, one per locale: `Newsletter EN/CS/DE/ES/FR/JA` (`ListmonkNewsletterLists`). Looked up by name, auto-created when missing — no ids configured anywhere.
-- Subscriber attribs maintained by the sync: `locale`, `audience` (`player`/`guest`), `unsubscribe_url` (per-recipient signed MySpeedPuzzling URL), `manage_url` (players only).
+- Subscriber attribs maintained by the sync: `locale`, `audience` (`player`/`guest`), `unsubscribe_url` (per-recipient signed MySpeedPuzzling URL), `manage_url` (players only — the standalone e-mail preferences page, see below).
 - The campaign template (versioned at [`listmonk-campaign-template.html`](listmonk-campaign-template.html), uploaded to Listmonk as **"MySpeedPuzzling Newsletter"**) renders a localized footer from those attribs. After editing the file, re-upload via `PUT /api/templates/{id}`.
 
 ## Sync — `myspeedpuzzling:sync-newsletter-subscribers` (cron */15)
@@ -38,8 +38,17 @@ Immediate pushes (async messages, cron is the safety net): profile newsletter to
 Every newsletter footer links `attribs.unsubscribe_url` → `/{locale}/newsletter/unsubscribe/{token}`:
 
 - Stateless HMAC token (`NewsletterTokenSigner`), bound to audience+id+e-mail, **no expiry** (old newsletters must keep working); dies automatically when the e-mail changes.
-- The landing page changes nothing on GET (scanner-safe) and offers exactly two options: **one-click unsubscribe** (POST) and — for players — **manage notification settings** (edit profile).
+- The landing page changes nothing on GET (scanner-safe) and offers exactly two options: **one-click unsubscribe** (POST) and — for players — **manage e-mail preferences** (standalone page, see below).
 - Listmonk additionally sends its own `List-Unsubscribe`/`List-Unsubscribe-Post` headers pointing at itself (Gmail/Yahoo one-click); those unsubscribes reach MySpeedPuzzling via the cron pull within 15 minutes.
+
+## E-mail preferences page (players)
+
+Standalone, token-authenticated page at `/{locale}/email-preferences/{token}` — reachable **only from links in our e-mails** (newsletter footer `manage_url`, digest opt-out, unsubscribe landing page), never from site navigation. Rationale: the edit-profile page is crowded with forms; someone clicking "manage my settings" in an e-mail should land on a focused page that works without signing in.
+
+- Token: `NewsletterTokenSigner` type `preferences` — deterministic, no expiry, dies on e-mail change (same semantics as unsubscribe tokens). URL built by `EmailPreferencesLinkGenerator`.
+- Shows only the e-mail subset of settings: newsletter toggle + notification e-mails toggle + digest frequency. Saving dispatches `EditEmailPreferences` (deliberately narrower than `EditMessagingSettings` — cannot touch `allowDirectMessages`).
+- Anonymous but personal: the GET response is `Cache-Control: no-store`; CSRF id `email-preferences` is stateless (no session cookie).
+- Guests have no preferences page — their single preference (subscribed yes/no) is fully covered by the unsubscribe link and the footer form.
 
 ## Public signup (footer)
 

--- a/src/Controller/EmailPreferencesController.php
+++ b/src/Controller/EmailPreferencesController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Controller;
+
+use SpeedPuzzling\Web\Exceptions\InvalidNewsletterToken;
+use SpeedPuzzling\Web\Exceptions\PlayerNotFound;
+use SpeedPuzzling\Web\Query\GetPlayerProfile;
+use SpeedPuzzling\Web\Services\NewsletterTokenSigner;
+use SpeedPuzzling\Web\Value\EmailNotificationFrequency;
+use SpeedPuzzling\Web\Value\NewsletterAudience;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Standalone e-mail preferences page, reached only from links in our e-mails
+ * (newsletter footer, digest opt-out, unsubscribe page). Token-authenticated,
+ * so it works without signing in - and unlike the crowded edit-profile page it
+ * shows just the e-mail related settings. The token stops working the moment
+ * the player's e-mail address changes.
+ */
+final class EmailPreferencesController extends AbstractController
+{
+    public function __construct(
+        private readonly NewsletterTokenSigner $tokenSigner,
+        private readonly GetPlayerProfile $getPlayerProfile,
+    ) {
+    }
+
+    #[Route(
+        path: [
+            'cs' => '/nastaveni-emailu/{token}',
+            'en' => '/en/email-preferences/{token}',
+            'es' => '/es/preferencias-de-email/{token}',
+            'ja' => '/ja/email-preferences/{token}',
+            'fr' => '/fr/preferences-email/{token}',
+            'de' => '/de/e-mail-einstellungen/{token}',
+        ],
+        name: 'email_preferences',
+        methods: ['GET'],
+    )]
+    public function __invoke(string $token, Request $request): Response
+    {
+        try {
+            $claim = $this->tokenSigner->parsePreferencesToken($token);
+
+            if ($claim->audience !== NewsletterAudience::Player) {
+                throw new InvalidNewsletterToken();
+            }
+
+            $profile = $this->getPlayerProfile->byId($claim->id);
+
+            // The link in an already-sent e-mail must die when the address changes
+            if ($profile->email === null || mb_strtolower(trim($profile->email)) !== $claim->email) {
+                throw new InvalidNewsletterToken();
+            }
+        } catch (InvalidNewsletterToken | PlayerNotFound) {
+            return $this->render('newsletter/invalid-token.html.twig', [
+                'messageKey' => 'newsletter.invalid.invalid_text',
+            ], new Response(status: Response::HTTP_NOT_FOUND));
+        }
+
+        $response = $this->render('newsletter/email-preferences.html.twig', [
+            'token' => $token,
+            'email' => $profile->email,
+            'newsletterEnabled' => $profile->newsletterEnabled,
+            'emailNotificationsEnabled' => $profile->emailNotificationsEnabled,
+            'emailNotificationFrequency' => $profile->emailNotificationFrequency,
+            'frequencies' => EmailNotificationFrequency::cases(),
+            'saved' => $request->query->getBoolean('saved'),
+        ]);
+
+        // Personal settings behind a capability URL: a shared cache must never
+        // store them (and must not serve a stale state right after saving)
+        $response->headers->addCacheControlDirective('no-store');
+
+        return $response;
+    }
+}

--- a/src/Controller/EmailPreferencesSaveController.php
+++ b/src/Controller/EmailPreferencesSaveController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Controller;
+
+use SpeedPuzzling\Web\Exceptions\InvalidNewsletterToken;
+use SpeedPuzzling\Web\Exceptions\PlayerNotFound;
+use SpeedPuzzling\Web\Message\EditEmailPreferences;
+use SpeedPuzzling\Web\Query\GetPlayerProfile;
+use SpeedPuzzling\Web\Services\NewsletterTokenSigner;
+use SpeedPuzzling\Web\Value\EmailNotificationFrequency;
+use SpeedPuzzling\Web\Value\NewsletterAudience;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class EmailPreferencesSaveController extends AbstractController
+{
+    private const string CSRF_TOKEN_ID = 'email-preferences';
+
+    public function __construct(
+        private readonly MessageBusInterface $messageBus,
+        private readonly NewsletterTokenSigner $tokenSigner,
+        private readonly GetPlayerProfile $getPlayerProfile,
+    ) {
+    }
+
+    #[Route(
+        path: [
+            'cs' => '/nastaveni-emailu/{token}/ulozit',
+            'en' => '/en/email-preferences/{token}/save',
+            'es' => '/es/preferencias-de-email/{token}/guardar',
+            'ja' => '/ja/email-preferences/{token}/save',
+            'fr' => '/fr/preferences-email/{token}/enregistrer',
+            'de' => '/de/e-mail-einstellungen/{token}/speichern',
+        ],
+        name: 'email_preferences_save',
+        methods: ['POST'],
+    )]
+    public function __invoke(string $token, Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid(self::CSRF_TOKEN_ID, (string) $request->request->get('_token'))) {
+            return $this->redirectToRoute('email_preferences', ['token' => $token]);
+        }
+
+        try {
+            $claim = $this->tokenSigner->parsePreferencesToken($token);
+
+            if ($claim->audience !== NewsletterAudience::Player) {
+                throw new InvalidNewsletterToken();
+            }
+
+            $profile = $this->getPlayerProfile->byId($claim->id);
+
+            if ($profile->email === null || mb_strtolower(trim($profile->email)) !== $claim->email) {
+                throw new InvalidNewsletterToken();
+            }
+        } catch (InvalidNewsletterToken | PlayerNotFound) {
+            return $this->render('newsletter/invalid-token.html.twig', [
+                'messageKey' => 'newsletter.invalid.invalid_text',
+            ], new Response(status: Response::HTTP_NOT_FOUND));
+        }
+
+        $frequency = EmailNotificationFrequency::tryFrom((string) $request->request->get('email_notification_frequency'))
+            ?? $profile->emailNotificationFrequency;
+
+        $this->messageBus->dispatch(
+            new EditEmailPreferences(
+                playerId: $claim->id,
+                newsletterEnabled: $request->request->getBoolean('newsletter_enabled'),
+                emailNotificationsEnabled: $request->request->getBoolean('email_notifications_enabled'),
+                emailNotificationFrequency: $frequency,
+            ),
+        );
+
+        return $this->redirectToRoute('email_preferences', ['token' => $token, 'saved' => 1]);
+    }
+}

--- a/src/Controller/NewsletterUnsubscribeConfirmController.php
+++ b/src/Controller/NewsletterUnsubscribeConfirmController.php
@@ -6,6 +6,7 @@ namespace SpeedPuzzling\Web\Controller;
 
 use SpeedPuzzling\Web\Exceptions\InvalidNewsletterToken;
 use SpeedPuzzling\Web\Message\UnsubscribeFromNewsletter;
+use SpeedPuzzling\Web\Services\EmailPreferencesLinkGenerator;
 use SpeedPuzzling\Web\Services\NewsletterTokenSigner;
 use SpeedPuzzling\Web\Value\NewsletterAudience;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -22,6 +23,7 @@ final class NewsletterUnsubscribeConfirmController extends AbstractController
     public function __construct(
         private readonly MessageBusInterface $messageBus,
         private readonly NewsletterTokenSigner $tokenSigner,
+        private readonly EmailPreferencesLinkGenerator $emailPreferencesLinkGenerator,
     ) {
     }
 
@@ -56,8 +58,13 @@ final class NewsletterUnsubscribeConfirmController extends AbstractController
             throw $exception;
         }
 
+        $isPlayer = $claim->audience === NewsletterAudience::Player;
+
         return $this->render('newsletter/unsubscribed.html.twig', [
-            'isPlayer' => $claim->audience === NewsletterAudience::Player,
+            'isPlayer' => $isPlayer,
+            'preferencesUrl' => $isPlayer
+                ? $this->emailPreferencesLinkGenerator->forPlayer($claim->id, $claim->email, $request->getLocale())
+                : null,
         ]);
     }
 

--- a/src/Controller/NewsletterUnsubscribeController.php
+++ b/src/Controller/NewsletterUnsubscribeController.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Controller;
 
 use SpeedPuzzling\Web\Exceptions\InvalidNewsletterToken;
+use SpeedPuzzling\Web\Services\EmailPreferencesLinkGenerator;
 use SpeedPuzzling\Web\Services\NewsletterTokenSigner;
 use SpeedPuzzling\Web\Value\NewsletterAudience;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -21,6 +23,7 @@ final class NewsletterUnsubscribeController extends AbstractController
 {
     public function __construct(
         private readonly NewsletterTokenSigner $tokenSigner,
+        private readonly EmailPreferencesLinkGenerator $emailPreferencesLinkGenerator,
     ) {
     }
 
@@ -35,7 +38,7 @@ final class NewsletterUnsubscribeController extends AbstractController
         ],
         name: 'newsletter_unsubscribe',
     )]
-    public function __invoke(string $token): Response
+    public function __invoke(string $token, Request $request): Response
     {
         try {
             $claim = $this->tokenSigner->parseUnsubscribeToken($token);
@@ -45,10 +48,15 @@ final class NewsletterUnsubscribeController extends AbstractController
             ], new Response(status: Response::HTTP_NOT_FOUND));
         }
 
+        $isPlayer = $claim->audience === NewsletterAudience::Player;
+
         return $this->render('newsletter/unsubscribe.html.twig', [
             'token' => $token,
             'email' => $claim->email,
-            'isPlayer' => $claim->audience === NewsletterAudience::Player,
+            'isPlayer' => $isPlayer,
+            'preferencesUrl' => $isPlayer
+                ? $this->emailPreferencesLinkGenerator->forPlayer($claim->id, $claim->email, $request->getLocale())
+                : null,
         ]);
     }
 }

--- a/src/Message/EditEmailPreferences.php
+++ b/src/Message/EditEmailPreferences.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Message;
+
+use SpeedPuzzling\Web\Value\EmailNotificationFrequency;
+
+readonly final class EditEmailPreferences
+{
+    public function __construct(
+        public string $playerId,
+        public bool $newsletterEnabled,
+        public bool $emailNotificationsEnabled,
+        public EmailNotificationFrequency $emailNotificationFrequency,
+    ) {
+    }
+}

--- a/src/MessageHandler/EditEmailPreferencesHandler.php
+++ b/src/MessageHandler/EditEmailPreferencesHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\MessageHandler;
+
+use SpeedPuzzling\Web\Exceptions\PlayerNotFound;
+use SpeedPuzzling\Web\Message\EditEmailPreferences;
+use SpeedPuzzling\Web\Message\PushNewsletterSubscriberToListmonk;
+use SpeedPuzzling\Web\Repository\PlayerRepository;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Saves the e-mail related subset of player settings from the standalone
+ * (token-authenticated) e-mail preferences page. Deliberately narrower than
+ * EditMessagingSettings - the page does not show allowDirectMessages, so the
+ * message cannot touch it.
+ */
+#[AsMessageHandler]
+readonly final class EditEmailPreferencesHandler
+{
+    public function __construct(
+        private PlayerRepository $playerRepository,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @throws PlayerNotFound
+     */
+    public function __invoke(EditEmailPreferences $message): void
+    {
+        $player = $this->playerRepository->get($message->playerId);
+
+        $newsletterChanged = $player->newsletterEnabled !== $message->newsletterEnabled;
+
+        $player->changeEmailNotificationsEnabled($message->emailNotificationsEnabled);
+        $player->changeEmailNotificationFrequency($message->emailNotificationFrequency);
+        $player->changeNewsletterEnabled($message->newsletterEnabled);
+
+        if ($newsletterChanged && $player->email !== null) {
+            $this->messageBus->dispatch(new PushNewsletterSubscriberToListmonk($player->email));
+        }
+    }
+}

--- a/src/MessageHandler/PrepareDigestEmailForPlayerHandler.php
+++ b/src/MessageHandler/PrepareDigestEmailForPlayerHandler.php
@@ -13,6 +13,7 @@ use SpeedPuzzling\Web\Message\PrepareDigestEmailForPlayer;
 use SpeedPuzzling\Web\Query\GetPlayersWithUnreadMessages;
 use SpeedPuzzling\Web\Repository\DigestEmailLogRepository;
 use SpeedPuzzling\Web\Repository\PlayerRepository;
+use SpeedPuzzling\Web\Services\EmailPreferencesLinkGenerator;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -31,6 +32,7 @@ readonly final class PrepareDigestEmailForPlayerHandler
         private ClockInterface $clock,
         private Connection $connection,
         private LoggerInterface $logger,
+        private EmailPreferencesLinkGenerator $emailPreferencesLinkGenerator,
     ) {
     }
 
@@ -81,6 +83,11 @@ readonly final class PrepareDigestEmailForPlayerHandler
                 'summaries' => $summaries,
                 'pendingRequestCount' => $pendingRequestCount,
                 'locale' => $player->locale ?? 'en',
+                'settingsUrl' => $this->emailPreferencesLinkGenerator->forPlayer(
+                    $message->playerId,
+                    $player->email,
+                    $player->locale,
+                ),
             ]);
         $email->getHeaders()->addTextHeader('X-Transport', 'notifications');
 

--- a/src/Services/EmailPreferencesLinkGenerator.php
+++ b/src/Services/EmailPreferencesLinkGenerator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Services;
+
+use SpeedPuzzling\Web\Services\Listmonk\ListmonkNewsletterLists;
+use SpeedPuzzling\Web\Value\NewsletterAudience;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Absolute URL of the standalone e-mail preferences page for a player - the
+ * "manage my notification settings" target used in every e-mail we send
+ * (newsletter footer, digest opt-out, unsubscribe page). Token-authenticated,
+ * so it works without signing in; deterministic, so the Listmonk sync can diff
+ * subscriber attributes without churn.
+ */
+readonly final class EmailPreferencesLinkGenerator
+{
+    public function __construct(
+        private NewsletterTokenSigner $tokenSigner,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function forPlayer(string $playerId, string $email, null|string $locale): string
+    {
+        $token = $this->tokenSigner->generatePreferencesToken(NewsletterAudience::Player, $playerId, $email);
+
+        return $this->urlGenerator->generate(
+            'email_preferences',
+            [
+                '_locale' => ListmonkNewsletterLists::normalizeLocale($locale),
+                'token' => $token,
+            ],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+    }
+}

--- a/src/Services/Listmonk/NewsletterAttributesBuilder.php
+++ b/src/Services/Listmonk/NewsletterAttributesBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Services\Listmonk;
 
 use SpeedPuzzling\Web\Results\NewsletterRecipient;
+use SpeedPuzzling\Web\Services\EmailPreferencesLinkGenerator;
 use SpeedPuzzling\Web\Services\NewsletterTokenSigner;
 use SpeedPuzzling\Web\Value\NewsletterAudience;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -20,6 +21,7 @@ readonly final class NewsletterAttributesBuilder
     public function __construct(
         private NewsletterTokenSigner $tokenSigner,
         private UrlGeneratorInterface $urlGenerator,
+        private EmailPreferencesLinkGenerator $emailPreferencesLinkGenerator,
     ) {
     }
 
@@ -47,10 +49,10 @@ readonly final class NewsletterAttributesBuilder
         ];
 
         if ($recipient->audience === NewsletterAudience::Player) {
-            $attributes['manage_url'] = $this->urlGenerator->generate(
-                'edit_profile',
-                ['_locale' => $locale],
-                UrlGeneratorInterface::ABSOLUTE_URL,
+            $attributes['manage_url'] = $this->emailPreferencesLinkGenerator->forPlayer(
+                $recipient->id,
+                $recipient->email,
+                $locale,
             );
         }
 

--- a/src/Services/NewsletterTokenSigner.php
+++ b/src/Services/NewsletterTokenSigner.php
@@ -10,6 +10,7 @@ use SpeedPuzzling\Web\Exceptions\InvalidNewsletterToken;
 use SpeedPuzzling\Web\Exceptions\NewsletterConfirmTokenExpired;
 use SpeedPuzzling\Web\Value\NewsletterAudience;
 use SpeedPuzzling\Web\Value\NewsletterConfirmClaim;
+use SpeedPuzzling\Web\Value\NewsletterPreferencesClaim;
 use SpeedPuzzling\Web\Value\NewsletterUnsubscribeClaim;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -29,6 +30,7 @@ readonly final class NewsletterTokenSigner
 
     private const string TYPE_UNSUBSCRIBE = 'unsubscribe';
     private const string TYPE_CONFIRM = 'confirm';
+    private const string TYPE_PREFERENCES = 'preferences';
 
     public function __construct(
         #[Autowire(param: 'kernel.secret')]
@@ -58,6 +60,37 @@ readonly final class NewsletterTokenSigner
             'email' => mb_strtolower(trim($email)),
             'expiresAt' => $expiresAt->getTimestamp(),
         ]);
+    }
+
+    /**
+     * Preferences tokens open the standalone e-mail preferences page. Like
+     * unsubscribe tokens they never expire (the link lives in every sent
+     * e-mail) and are deterministic for Listmonk attribute diffing.
+     */
+    public function generatePreferencesToken(NewsletterAudience $audience, string $id, string $email): string
+    {
+        return $this->encode([
+            'type' => self::TYPE_PREFERENCES,
+            'audience' => $audience->value,
+            'id' => $id,
+            'email' => mb_strtolower(trim($email)),
+        ]);
+    }
+
+    /**
+     * @throws InvalidNewsletterToken
+     */
+    public function parsePreferencesToken(#[SensitiveParameter] string $token): NewsletterPreferencesClaim
+    {
+        $claims = $this->decode($token);
+
+        if (($claims['type'] ?? null) !== self::TYPE_PREFERENCES) {
+            throw new InvalidNewsletterToken();
+        }
+
+        [$audience, $id, $email] = $this->readCommonClaims($claims);
+
+        return new NewsletterPreferencesClaim($audience, $id, $email);
     }
 
     /**

--- a/src/Value/NewsletterPreferencesClaim.php
+++ b/src/Value/NewsletterPreferencesClaim.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+readonly final class NewsletterPreferencesClaim
+{
+    public function __construct(
+        public NewsletterAudience $audience,
+        public string $id,
+        public string $email,
+    ) {
+    }
+}

--- a/templates/emails/unread_digest.html.twig
+++ b/templates/emails/unread_digest.html.twig
@@ -58,7 +58,7 @@
                         <spacer size-sm="10"></spacer>
                     {% endif %}
 
-                    <p><small>{{ 'unread_messages.opt_out'|trans({'%settingsUrl%': url('edit_profile')})|raw }}</small></p>
+                    <p><small>{{ 'unread_messages.opt_out'|trans({'%settingsUrl%': settingsUrl})|raw }}</small></p>
                 </columns>
             </row>
 

--- a/templates/newsletter/email-preferences.html.twig
+++ b/templates/newsletter/email-preferences.html.twig
@@ -1,0 +1,75 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ 'email_preferences.headline'|trans }}{% endblock %}
+{% block robots %}<meta name="robots" content="noindex, nofollow">{% endblock %}
+
+{% block content %}
+    <div class="row gy-3 pb-4">
+        <div class="col-lg-6 col-md-8">
+            <h1 class="h2">{{ 'email_preferences.headline'|trans }}</h1>
+
+            <p class="text-muted">{{ 'email_preferences.intro'|trans({'%email%': email})|raw }}</p>
+
+            {% if saved %}
+                <div class="alert alert-success" role="alert">
+                    <i class="ci-check-circle me-2"></i>
+                    {{ 'email_preferences.saved'|trans }}
+                </div>
+            {% endif %}
+
+            <form action="{{ path('email_preferences_save', {'token': token}) }}" method="post" data-turbo="false">
+                <input type="hidden" name="_token" value="{{ csrf_token('email-preferences') }}">
+
+                <div class="card card-body shadow-lg mb-3">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch" id="newsletter-switch"
+                               name="newsletter_enabled" value="1" {{ newsletterEnabled ? 'checked' }}>
+                        <label class="form-check-label" for="newsletter-switch">
+                            <span class="d-block fw-bold">📬 {{ 'email_preferences.newsletter_title'|trans }}</span>
+                        </label>
+                    </div>
+                    <p class="fs-sm text-muted mb-0 mt-1">{{ 'email_preferences.newsletter_description'|trans }}</p>
+                </div>
+
+                <div class="card card-body shadow-lg mb-3" data-controller="conditional-field">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch" id="notifications-switch"
+                               name="email_notifications_enabled" value="1" {{ emailNotificationsEnabled ? 'checked' }}>
+                        <label class="form-check-label" for="notifications-switch">
+                            <span class="d-block fw-bold">💬 {{ 'email_preferences.notifications_title'|trans }}</span>
+                        </label>
+                    </div>
+                    <p class="fs-sm text-muted mb-0 mt-1">{{ 'email_preferences.notifications_description'|trans }}</p>
+
+                    <div data-conditional-field-target="conditionalElement">
+                        <div class="mt-3">
+                            <label class="form-label fs-sm" for="notification-frequency">
+                                {{ 'email_preferences.frequency_label'|trans }}
+                            </label>
+                            <select class="form-select" id="notification-frequency" name="email_notification_frequency">
+                                {% for frequency in frequencies %}
+                                    <option value="{{ frequency.value }}" {{ frequency == emailNotificationFrequency ? 'selected' }}>
+                                        {{ ('edit_profile.frequency_' ~ frequency.value)|trans }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                </div>
+
+                <button type="submit" class="btn btn-primary">
+                    {{ 'email_preferences.save_button'|trans }}
+                </button>
+            </form>
+
+            <p class="fs-sm text-muted mt-4 mb-0">
+                {{ 'email_preferences.more_hint'|trans }}
+                <a class="link-underline" href="{{ path('edit_profile') }}">{{ 'email_preferences.more_link'|trans }}</a>
+            </p>
+        </div>
+
+        <div class="col-lg-5 offset-lg-1 col-md-4 text-center d-none d-md-block">
+            <img class="img-fluid" src="{{ asset('img/puzzlie-1.png') }}" alt="" width="1000" height="949">
+        </div>
+    </div>
+{% endblock %}

--- a/templates/newsletter/unsubscribe.html.twig
+++ b/templates/newsletter/unsubscribe.html.twig
@@ -17,10 +17,10 @@
                 </button>
             </form>
 
-            {% if isPlayer %}
+            {% if isPlayer and preferencesUrl %}
                 <p class="fs-sm text-muted mb-2">{{ 'newsletter.unsubscribe.manage_hint'|trans }}</p>
                 <p>
-                    <a class="btn btn-outline-primary btn-sm" href="{{ path('edit_profile') }}">
+                    <a class="btn btn-outline-primary btn-sm" href="{{ preferencesUrl }}">
                         {{ 'newsletter.unsubscribe.manage_button'|trans }}
                     </a>
                 </p>

--- a/templates/newsletter/unsubscribed.html.twig
+++ b/templates/newsletter/unsubscribed.html.twig
@@ -14,8 +14,8 @@
             </div>
 
             <p class="fs-sm text-muted">
-                {% if isPlayer %}
-                    {{ 'newsletter.unsubscribed.resubscribe_player'|trans({'%settingsUrl%': path('edit_profile')})|raw }}
+                {% if isPlayer and preferencesUrl %}
+                    {{ 'newsletter.unsubscribed.resubscribe_player'|trans({'%settingsUrl%': preferencesUrl})|raw }}
                 {% else %}
                     {{ 'newsletter.unsubscribed.resubscribe_guest'|trans }}
                 {% endif %}

--- a/tests/Controller/EmailPreferencesControllerTest.php
+++ b/tests/Controller/EmailPreferencesControllerTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Controller;
+
+use SpeedPuzzling\Web\Repository\PlayerRepository;
+use SpeedPuzzling\Web\Services\NewsletterTokenSigner;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Value\EmailNotificationFrequency;
+use SpeedPuzzling\Web\Value\NewsletterAudience;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+
+final class EmailPreferencesControllerTest extends WebTestCase
+{
+    public function testPageLoadsWithValidToken(): void
+    {
+        $browser = self::createClient();
+        $token = $this->preferencesToken();
+
+        $browser->request('GET', '/en/email-preferences/' . $token);
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString(
+            PlayerFixture::PLAYER_REGULAR_EMAIL,
+            (string) $browser->getResponse()->getContent(),
+        );
+
+        // Anonymous page reached from e-mail links: no session cookie (#164),
+        // and personal data behind a capability URL must never be shared-cached
+        self::assertSame([], $browser->getResponse()->headers->getCookies());
+        $cacheControl = (string) $browser->getResponse()->headers->get('Cache-Control');
+        self::assertStringContainsString('no-store', $cacheControl);
+        self::assertStringNotContainsString('public', $cacheControl);
+    }
+
+    public function testGarbageTokenShowsInvalidTokenPage(): void
+    {
+        $browser = self::createClient();
+
+        $browser->request('GET', '/en/email-preferences/not-a-token');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnsubscribeTokenIsRejected(): void
+    {
+        $browser = self::createClient();
+        $token = $this->tokenSigner()->generateUnsubscribeToken(
+            NewsletterAudience::Player,
+            PlayerFixture::PLAYER_REGULAR,
+            PlayerFixture::PLAYER_REGULAR_EMAIL,
+        );
+
+        $browser->request('GET', '/en/email-preferences/' . $token);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testGuestAudienceTokenIsRejected(): void
+    {
+        $browser = self::createClient();
+        $token = $this->tokenSigner()->generatePreferencesToken(
+            NewsletterAudience::Guest,
+            PlayerFixture::PLAYER_REGULAR,
+            PlayerFixture::PLAYER_REGULAR_EMAIL,
+        );
+
+        $browser->request('GET', '/en/email-preferences/' . $token);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testTokenDiesWhenEmailNoLongerMatches(): void
+    {
+        $browser = self::createClient();
+
+        // Signed for the address the player had when the e-mail was sent
+        $token = $this->tokenSigner()->generatePreferencesToken(
+            NewsletterAudience::Player,
+            PlayerFixture::PLAYER_REGULAR,
+            'previous-address@example.com',
+        );
+
+        $browser->request('GET', '/en/email-preferences/' . $token);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testSavingUpdatesPreferences(): void
+    {
+        $browser = self::createClient();
+        $token = $this->preferencesToken();
+
+        $crawler = $browser->request('GET', '/en/email-preferences/' . $token);
+
+        $form = $crawler->selectButton('Save my preferences')->form();
+        $newsletterField = $form['newsletter_enabled'];
+        assert($newsletterField instanceof ChoiceFormField);
+        $newsletterField->untick();
+        $frequencyField = $form['email_notification_frequency'];
+        assert($frequencyField instanceof ChoiceFormField);
+        $frequencyField->select('1_week');
+        $browser->submit($form);
+
+        self::assertResponseRedirects('/en/email-preferences/' . $token . '?saved=1');
+
+        $player = self::getContainer()->get(PlayerRepository::class)->get(PlayerFixture::PLAYER_REGULAR);
+        self::assertFalse($player->newsletterEnabled);
+        self::assertTrue($player->emailNotificationsEnabled);
+        self::assertSame(EmailNotificationFrequency::OneWeek, $player->emailNotificationFrequency);
+
+        // Following the redirect shows the success confirmation
+        $browser->followRedirect();
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('alert-success', (string) $browser->getResponse()->getContent());
+    }
+
+    public function testSavingWithInvalidTokenIsRejected(): void
+    {
+        $browser = self::createClient();
+
+        $browser->request('POST', '/en/email-preferences/not-a-token/save', [
+            '_token' => 'csrf-token',
+            'newsletter_enabled' => '1',
+        ], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+        ]);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testSavingWithoutValidCsrfChangesNothing(): void
+    {
+        $browser = self::createClient();
+        $token = $this->preferencesToken();
+
+        // No Origin/Referer header and no double-submit cookie: stateless CSRF fails
+        $browser->request('POST', '/en/email-preferences/' . $token . '/save', [
+            '_token' => 'forged',
+        ]);
+
+        self::assertResponseRedirects('/en/email-preferences/' . $token);
+
+        $player = self::getContainer()->get(PlayerRepository::class)->get(PlayerFixture::PLAYER_REGULAR);
+        self::assertTrue($player->newsletterEnabled);
+    }
+
+    private function preferencesToken(): string
+    {
+        return $this->tokenSigner()->generatePreferencesToken(
+            NewsletterAudience::Player,
+            PlayerFixture::PLAYER_REGULAR,
+            PlayerFixture::PLAYER_REGULAR_EMAIL,
+        );
+    }
+
+    private function tokenSigner(): NewsletterTokenSigner
+    {
+        return self::getContainer()->get(NewsletterTokenSigner::class);
+    }
+}

--- a/tests/MessageHandler/EditEmailPreferencesHandlerTest.php
+++ b/tests/MessageHandler/EditEmailPreferencesHandlerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\MessageHandler;
+
+use SpeedPuzzling\Web\Message\EditEmailPreferences;
+use SpeedPuzzling\Web\Repository\PlayerRepository;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Value\EmailNotificationFrequency;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class EditEmailPreferencesHandlerTest extends KernelTestCase
+{
+    private MessageBusInterface $messageBus;
+    private PlayerRepository $playerRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $this->messageBus = $container->get(MessageBusInterface::class);
+        $this->playerRepository = $container->get(PlayerRepository::class);
+    }
+
+    public function testDisableNewsletterAndNotifications(): void
+    {
+        $this->messageBus->dispatch(
+            new EditEmailPreferences(
+                playerId: PlayerFixture::PLAYER_REGULAR,
+                newsletterEnabled: false,
+                emailNotificationsEnabled: false,
+                emailNotificationFrequency: EmailNotificationFrequency::TwentyFourHours,
+            ),
+        );
+
+        $player = $this->playerRepository->get(PlayerFixture::PLAYER_REGULAR);
+
+        self::assertFalse($player->newsletterEnabled);
+        self::assertFalse($player->emailNotificationsEnabled);
+    }
+
+    public function testChangeFrequency(): void
+    {
+        $this->messageBus->dispatch(
+            new EditEmailPreferences(
+                playerId: PlayerFixture::PLAYER_REGULAR,
+                newsletterEnabled: true,
+                emailNotificationsEnabled: true,
+                emailNotificationFrequency: EmailNotificationFrequency::OneWeek,
+            ),
+        );
+
+        $player = $this->playerRepository->get(PlayerFixture::PLAYER_REGULAR);
+
+        self::assertTrue($player->newsletterEnabled);
+        self::assertTrue($player->emailNotificationsEnabled);
+        self::assertSame(EmailNotificationFrequency::OneWeek, $player->emailNotificationFrequency);
+    }
+
+    public function testDirectMessagesSettingIsUntouched(): void
+    {
+        $before = $this->playerRepository->get(PlayerFixture::PLAYER_REGULAR)->allowDirectMessages;
+
+        $this->messageBus->dispatch(
+            new EditEmailPreferences(
+                playerId: PlayerFixture::PLAYER_REGULAR,
+                newsletterEnabled: false,
+                emailNotificationsEnabled: false,
+                emailNotificationFrequency: EmailNotificationFrequency::SixHours,
+            ),
+        );
+
+        self::assertSame($before, $this->playerRepository->get(PlayerFixture::PLAYER_REGULAR)->allowDirectMessages);
+    }
+}

--- a/tests/Services/NewsletterTokenSignerTest.php
+++ b/tests/Services/NewsletterTokenSignerTest.php
@@ -87,4 +87,39 @@ final class NewsletterTokenSignerTest extends TestCase
         $this->expectException(InvalidNewsletterToken::class);
         $this->signer->parseUnsubscribeToken('not-a-token');
     }
+
+    public function testPreferencesTokenRoundtrip(): void
+    {
+        $token = $this->signer->generatePreferencesToken(NewsletterAudience::Player, 'player-id', 'Someone@Example.com ');
+
+        $claim = $this->signer->parsePreferencesToken($token);
+
+        self::assertSame(NewsletterAudience::Player, $claim->audience);
+        self::assertSame('player-id', $claim->id);
+        self::assertSame('someone@example.com', $claim->email);
+    }
+
+    public function testPreferencesTokenIsDeterministic(): void
+    {
+        $first = $this->signer->generatePreferencesToken(NewsletterAudience::Player, 'id', 'a@b.com');
+        $second = $this->signer->generatePreferencesToken(NewsletterAudience::Player, 'id', 'a@b.com');
+
+        self::assertSame($first, $second);
+    }
+
+    public function testUnsubscribeTokenCannotBeUsedAsPreferencesToken(): void
+    {
+        $token = $this->signer->generateUnsubscribeToken(NewsletterAudience::Player, 'player-id', 'someone@example.com');
+
+        $this->expectException(InvalidNewsletterToken::class);
+        $this->signer->parsePreferencesToken($token);
+    }
+
+    public function testPreferencesTokenCannotBeUsedAsUnsubscribeToken(): void
+    {
+        $token = $this->signer->generatePreferencesToken(NewsletterAudience::Player, 'player-id', 'someone@example.com');
+
+        $this->expectException(InvalidNewsletterToken::class);
+        $this->signer->parseUnsubscribeToken($token);
+    }
 }

--- a/translations/messages.cs.yml
+++ b/translations/messages.cs.yml
@@ -2991,3 +2991,16 @@ newsletter:
         invalid_text: "Odkaz je neplatný nebo už neplatí. Pokud jste se chtěli přihlásit k odběru newsletteru, použijte formulář v patičce stránky."
         expired_text: "Platnost potvrzovacího odkazu vypršela. Nic se neděje — přihlaste se znovu formulářem v patičce stránky a pošleme vám nový."
         cta_homepage: "Zpět na MySpeedPuzzling"
+
+email_preferences:
+    headline: "Nastavení e-mailů"
+    intro: "Co posíláme na <strong>%email%</strong> — máte to plně ve svých rukou."
+    saved: "Uloženo! Vaše nastavení je aktuální."
+    newsletter_title: "Newsletter"
+    newsletter_description: "Co je nového na MySpeedPuzzling — nové funkce a novinky z platformy, jednou měsíčně. Žádný marketing, žádná reklama."
+    notifications_title: "Upozornění e-mailem"
+    notifications_description: "Dáme vám vědět, když vám někdo napíše nebo se s vámi chce spojit — píšeme jen tehdy, když na vás opravdu něco čeká."
+    frequency_label: "Jak často nejvýše?"
+    save_button: "Uložit nastavení"
+    more_hint: "Hledáte víc? Všechna nastavení účtu najdete ve svém profilu."
+    more_link: "Otevřít nastavení profilu"

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -2993,3 +2993,16 @@ newsletter:
         invalid_text: "Der Link ist ungültig oder nicht mehr gültig. Wenn Sie den Newsletter abonnieren wollten, nutzen Sie einfach das Formular in der Fußzeile der Seite."
         expired_text: "Der Bestätigungslink ist abgelaufen. Kein Problem – melden Sie sich einfach erneut über das Formular in der Fußzeile an und wir schicken Ihnen einen neuen."
         cta_homepage: "Zurück zu MySpeedPuzzling"
+
+email_preferences:
+    headline: "Ihre E-Mail-Einstellungen"
+    intro: "Was im Postfach von <strong>%email%</strong> landet – Sie haben die Kontrolle."
+    saved: "Gespeichert! Ihre Einstellungen sind aktuell."
+    newsletter_title: "Newsletter"
+    newsletter_description: "Was gibt es Neues auf MySpeedPuzzling – neue Funktionen und Neuigkeiten zur Plattform, einmal im Monat. Kein Marketing, keine Werbung."
+    notifications_title: "Benachrichtigungs-E-Mails"
+    notifications_description: "Eine kurze Nachricht, wenn Ihnen jemand schreibt oder sich mit Ihnen verbinden möchte – nur dann, wenn wirklich etwas auf Sie wartet."
+    frequency_label: "Wie oft höchstens?"
+    save_button: "Einstellungen speichern"
+    more_hint: "Sie suchen mehr? Alle Kontoeinstellungen finden Sie in Ihrem Profil."
+    more_link: "Profileinstellungen öffnen"

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -3280,3 +3280,16 @@ newsletter:
         invalid_text: "The link is invalid or no longer valid. If you wanted to subscribe to the newsletter, just use the form in the page footer."
         expired_text: "The confirmation link has expired. No worries — subscribe again using the form in the page footer and we'll send you a fresh one."
         cta_homepage: "Back to MySpeedPuzzling"
+
+email_preferences:
+    headline: "Your e-mail preferences"
+    intro: "What lands in the inbox of <strong>%email%</strong> — you're in control."
+    saved: "Saved! Your preferences are up to date."
+    newsletter_title: "Newsletter"
+    newsletter_description: "What's new on MySpeedPuzzling — new features and platform news, once a month. No marketing, no promotions."
+    notifications_title: "Notification e-mails"
+    notifications_description: "A friendly heads-up when someone messages you or wants to connect — sent only when something is actually waiting for you."
+    frequency_label: "How often at most?"
+    save_button: "Save my preferences"
+    more_hint: "Looking for more? All account settings live in your profile."
+    more_link: "Open profile settings"

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -2993,3 +2993,16 @@ newsletter:
         invalid_text: "El enlace no es válido o ya ha caducado. Si querías suscribirte al newsletter, usa el formulario del pie de página."
         expired_text: "El enlace de confirmación ha caducado. No pasa nada: suscríbete de nuevo con el formulario del pie de página y te enviaremos uno nuevo."
         cta_homepage: "Volver a MySpeedPuzzling"
+
+email_preferences:
+    headline: "Tus preferencias de e-mail"
+    intro: "Lo que llega a la bandeja de <strong>%email%</strong> — tú tienes el control."
+    saved: "¡Guardado! Tus preferencias están al día."
+    newsletter_title: "Newsletter"
+    newsletter_description: "Lo nuevo en MySpeedPuzzling: nuevas funciones y novedades de la plataforma, una vez al mes. Sin marketing, sin promociones."
+    notifications_title: "E-mails de notificación"
+    notifications_description: "Un aviso cuando alguien te escribe o quiere conectar contigo — solo cuando de verdad hay algo esperándote."
+    frequency_label: "¿Con qué frecuencia como máximo?"
+    save_button: "Guardar mis preferencias"
+    more_hint: "¿Buscas más? Todos los ajustes de tu cuenta están en tu perfil."
+    more_link: "Abrir ajustes del perfil"

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -2995,3 +2995,16 @@ newsletter:
         invalid_text: "Le lien est invalide ou n'est plus valable. Si vous vouliez vous abonner à la newsletter, utilisez simplement le formulaire en bas de page."
         expired_text: "Le lien de confirmation a expiré. Pas d'inquiétude — réabonnez-vous grâce au formulaire en bas de page et nous vous en enverrons un nouveau."
         cta_homepage: "Retour à MySpeedPuzzling"
+
+email_preferences:
+    headline: "Vos préférences e-mail"
+    intro: "Ce qui arrive dans la boîte de <strong>%email%</strong> — vous gardez le contrôle."
+    saved: "Enregistré ! Vos préférences sont à jour."
+    newsletter_title: "Newsletter"
+    newsletter_description: "Les nouveautés de MySpeedPuzzling — nouvelles fonctionnalités et actualités de la plateforme, une fois par mois. Pas de marketing, pas de promotions."
+    notifications_title: "E-mails de notification"
+    notifications_description: "Un petit mot quand quelqu'un vous écrit ou souhaite entrer en contact — uniquement quand quelque chose vous attend vraiment."
+    frequency_label: "À quelle fréquence au maximum ?"
+    save_button: "Enregistrer mes préférences"
+    more_hint: "Vous cherchez plus ? Tous les réglages de votre compte se trouvent dans votre profil."
+    more_link: "Ouvrir les réglages du profil"

--- a/translations/messages.ja.yml
+++ b/translations/messages.ja.yml
@@ -2982,3 +2982,16 @@ newsletter:
         invalid_text: "このリンクは無効か、有効期限が切れています。ニュースレターの登録をご希望の場合は、ページ下部のフォームをご利用ください。"
         expired_text: "確認リンクの有効期限が切れています。ご心配なく — ページ下部のフォームからもう一度登録していただければ、新しいリンクをお送りします。"
         cta_homepage: "MySpeedPuzzlingに戻る"
+
+email_preferences:
+    headline: "メール設定"
+    intro: "<strong>%email%</strong> に届くメールの設定です。すべてご自身で管理できます。"
+    saved: "保存しました!設定は最新の状態です。"
+    newsletter_title: "ニュースレター"
+    newsletter_description: "MySpeedPuzzlingの最新情報 — 新機能やプラットフォームのニュースを月1回お届けします。マーケティングや宣伝は一切ありません。"
+    notifications_title: "通知メール"
+    notifications_description: "メッセージやつながりのリクエストが届いたときにお知らせします — 本当に何かが待っているときだけお送りします。"
+    frequency_label: "通知の頻度(最大)"
+    save_button: "設定を保存"
+    more_hint: "その他の設定は、プロフィールからご確認いただけます。"
+    more_link: "プロフィール設定を開く"


### PR DESCRIPTION
## What

A dedicated, nicely-focused **e-mail preferences page** reachable only from links in our e-mails — because the edit-profile page already has way too many forms for someone who just clicked "manage my settings" in a newsletter.

`/{locale}/email-preferences/{token}` (all 6 locales) shows exactly three things, as friendly switches:

- 📬 **Newsletter** toggle (once a month, no marketing pitch as description)
- 💬 **Notification e-mails** toggle
- Digest **frequency** select (shown only while notifications are on, via the existing `conditional-field` controller)

Works without signing in — authenticated by a signed token in the URL, same mechanism as the unsubscribe links.

## How

- **Token**: new `preferences` type in `NewsletterTokenSigner` — deterministic, no expiry (the link lives in every sent e-mail), dies the moment the player's e-mail changes. GET additionally verifies the claim e-mail still matches the player.
- **Write path**: new `EditEmailPreferences` message + handler — deliberately narrower than `EditMessagingSettings` (cannot touch `allowDirectMessages`), pushes to Listmonk when the newsletter toggle flips.
- **Anonymous but personal**: stateless CSRF id `email-preferences` (no session cookie → shared caching stays intact), response is `Cache-Control: no-store`, `noindex`.
- **All e-mail links updated** via new `EmailPreferencesLinkGenerator`: Listmonk `manage_url` attrib (sync updates ~9.9k subscribers' attribs on next cron run), unsubscribe landing + "you're unsubscribed" pages, digest opt-out link. Guests keep the unsubscribe link — subscribed yes/no is their only preference.

## Verified

- PHPStan max, PHPCS, `doctrine:schema:validate`, full test suite (1425 tests) green
- Manual E2E in dev: GET renders with `no-store`, POST saves (DB checked), PRG redirect shows success alert, invalid/foreign tokens → branded 404 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tQcc2qZpKUzznUUokfr1Q