### PR TITLE
Auth0 fork: skip the authenticator for requests without a session cookie

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -466,12 +466,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JanMikes/auth0-symfony.git",
-                "reference": "9bc1eb0401d72fe916d2fe9aee10691ee26676cb"
+                "reference": "592dc623be9771fdb860a760e4965ffed971809c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JanMikes/auth0-symfony/zipball/9bc1eb0401d72fe916d2fe9aee10691ee26676cb",
-                "reference": "9bc1eb0401d72fe916d2fe9aee10691ee26676cb",
+                "url": "https://api.github.com/repos/JanMikes/auth0-symfony/zipball/592dc623be9771fdb860a760e4965ffed971809c",
+                "reference": "592dc623be9771fdb860a760e4965ffed971809c",
                 "shasum": ""
             },
             "require": {
@@ -601,7 +601,7 @@
             "support": {
                 "source": "https://github.com/JanMikes/auth0-symfony/tree/main"
             },
-            "time": "2026-07-23T17:45:14+00:00"
+            "time": "2026-08-01T18:10:08+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
Picks up [JanMikes/auth0-symfony@592dc62](https://github.com/JanMikes/auth0-symfony/commit/592dc62). Lock-only change here.

## The change

The forked `Authenticator` answered `supports() === true` on **every** request and let `authenticate()` throw when there were no stored credentials. But `authenticate()` already refused such requests on exactly the same condition (`!$request->hasPreviousSession()`), so declining in `supports()` **changes no authentication outcome** — it only stops the pointless attempt.

What goes away are the side effects of attempting-and-failing on every anonymous request:

- **No `LoginFailureEvent` per request.** Every listener subscribed to it was firing on plain anonymous browsing. Symfony's `RememberMeListener` clears the remember-me cookie unconditionally on it — that is precisely what forced the listener swap in #176 — and firewall-level `login_throttling` could not be used at all, because it would burn its per-IP budget through ordinary browsing.
- **No `onAuthenticationFailure()`**, which wrote `auth0:callback_redirect` into the session for protected pages. Its `hasSession()` check starts a session lazily.

Requests that **do** carry a session cookie are unaffected — they still run, and still fail the same way when the session holds no Auth0 credentials.

## Measured

On dev, before/after, anonymous hit on a protected URL:

| | session contents |
|---|---|
| before | `_security.main.target_path` **and** `auth0:callback_redirect` |
| after | `_security.main.target_path` only |

Production's `sessions` table is **3,434,070 rows / 1.8 GB**, and a sample found **68,450 of 68,524 rows anonymous** — written by exactly this pattern (crawlers hitting protected URLs; there are 332 `IsGranted`/`denyAccessUnlessGranted` sites).

**This does not stop session creation on its own** — `ExceptionListener::setTargetPath()` writes `target_path` independently, and that half goes away with the return-URL work (`docs/features/return-url.md`, PR 2 of that series). This PR removes one of the two writers and all the event side effects.

## Side benefit

On `^/admin` the Auth0 failure handler used to return its `/login` redirect before `RememberMeAuthenticator` ran, so admin deep links were not restored from a remember-me cookie (the known limitation documented in #176). With `supports()` declining, they are.

## Verification

Full suite green (**1509 tests**), including the window-A dual-wiring tests. Notably `testEntryPointFunnelReturnsToOriginallyRequestedPage` still passes: the deep link now comes back via `target_path` instead of `auth0:callback_redirect`, so the funnel behaviour is unchanged from the user's point of view. Legacy Auth0 sessions still authenticate (`testAuth0SessionStillAuthenticatesThroughTheChainProvider`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019T14AZLJKaSrdioZ5vSGGQ