### PR TITLE
Return granted scope on token exchange, fix solving-times:write role check

### DIFF
--- a/config/packages/league_oauth2_server.php
+++ b/config/packages/league_oauth2_server.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use SpeedPuzzling\Web\Security\OAuth2\ScopeAwareBearerTokenResponse;
+
 return App::config([
     'league_oauth2_server' => [
         'authorization_server' => [
@@ -19,6 +21,7 @@ return App::config([
             'enable_auth_code_grant' => true,
             'enable_implicit_grant' => false,
             'require_code_challenge_for_public_clients' => true,
+            'response_type_class' => ScopeAwareBearerTokenResponse::class,
         ],
         'resource_server' => [
             'public_key' => '%env(OAUTH2_PUBLIC_KEY)%',

--- a/src/Api/V1/CreateSolvingTimeInput.php
+++ b/src/Api/V1/CreateSolvingTimeInput.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Post(
             uriTemplate: '/v1/me/solving-times',
             openapi: new OpenApiOperation(tags: ['My Results & Solving Times']),
-            security: "is_granted('ROLE_PAT') or is_granted('ROLE_OAUTH2_SOLVING_TIMES:WRITE')",
+            security: "is_granted('ROLE_PAT') or is_granted('ROLE_OAUTH2_SOLVING-TIMES:WRITE')",
             output: SolvingTimeResponse::class,
             processor: CreateSolvingTimeProcessor::class,
         ),

--- a/src/Api/V1/UpdateSolvingTimeInput.php
+++ b/src/Api/V1/UpdateSolvingTimeInput.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Put(
             uriTemplate: '/v1/me/solving-times/{timeId}',
             openapi: new OpenApiOperation(tags: ['My Results & Solving Times']),
-            security: "is_granted('ROLE_PAT') or is_granted('ROLE_OAUTH2_SOLVING_TIMES:WRITE')",
+            security: "is_granted('ROLE_PAT') or is_granted('ROLE_OAUTH2_SOLVING-TIMES:WRITE')",
             output: SolvingTimeResponse::class,
             // No state provider exists for this DTO resource - without read: false,
             // ReadProvider resolves null state and 404s before the processor runs.

--- a/src/Security/OAuth2/ScopeAwareBearerTokenResponse.php
+++ b/src/Security/OAuth2/ScopeAwareBearerTokenResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Security\OAuth2;
+
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
+
+final class ScopeAwareBearerTokenResponse extends BearerTokenResponse
+{
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken): array
+    {
+        $scopes = array_map(
+            static fn ($scope): string => $scope->getIdentifier(),
+            $accessToken->getScopes(),
+        );
+
+        return ['scope' => implode(' ', $scopes)];
+    }
+}


### PR DESCRIPTION
## Summary

Two independent, small fixes bundled together since they touch the same file group:

**1. Token response never includes granted scope**

`league/oauth2-server`'s default response never includes which scopes were actually granted (`BearerTokenResponse::getExtraParams` returns `[]`). Nothing wrong with that as shipped, but a consuming app that wants to detect a stale, pre-scope-expansion authorization (e.g. re-checking for a write scope before attempting a write, rather than attempting a call that will 403) has nothing to check the response against.

`ScopeAwareBearerTokenResponse` adds the scope back via the `response_type_class` extension point already supported by `league/oauth2-server-bundle`. It's picked up automatically by the existing `Security/**` service glob in `config/services.php` — no explicit service registration needed.

**2. Wrong role name checked for `solving-times:write`**

`CreateSolvingTimeInput`/`UpdateSolvingTimeInput`'s write-scope security check compares against `ROLE_OAUTH2_SOLVING_TIMES:WRITE` (underscore), but the role `oauth2-server` actually grants is built by uppercasing the scope string verbatim (`OAuth2Token.php`: `strtoupper($rolePrefix . $scope)`, no punctuation normalization) — so a `solving-times:write` scope produces `ROLE_OAUTH2_SOLVING-TIMES:WRITE` (hyphen).

`solving-times` is the only hyphenated scope in the system, which is presumably why this was never caught — nothing else has ever exercised this exact path. An OAuth-scope-authenticated write to `/me/solving-times` has likely never worked; PAT-based writes are unaffected (`ROLE_PAT` is checked independently in the same `or` expression).

## Test plan

- [ ] Confirm a client-credentials/auth-code token issued with `solving-times:write` can now successfully `POST`/`PUT` `/api/v1/me/solving-times`
- [ ] Confirm the token exchange response (`/oauth2/token`) now includes a `scope` field listing the granted scopes