### PR TITLE
Rename puzzle_image to image on results responses

### DIFF
--- a/src/Api/V1/MyResultsResponseProvider.php
+++ b/src/Api/V1/MyResultsResponseProvider.php
@@ -54,7 +54,7 @@ final readonly class MyResultsResponseProvider implements ProviderInterface
                     time_seconds: $puzzle->time,
                     finished_at: $puzzle->finishedAt?->format('c'),
                     first_attempt: $puzzle->firstAttempt,
-                    puzzle_image: $puzzle->puzzleImage,
+                    image: $puzzle->puzzleImage,
                     comment: $puzzle->comment,
                 ),
                 $results,

--- a/src/Api/V1/PlayerResultResponse.php
+++ b/src/Api/V1/PlayerResultResponse.php
@@ -15,7 +15,7 @@ final class PlayerResultResponse
         public null|int $time_seconds,
         public null|string $finished_at,
         public bool $first_attempt,
-        public null|string $puzzle_image,
+        public null|string $image,
         public null|string $comment,
     ) {
     }

--- a/src/Api/V1/PlayerResultsResponseProvider.php
+++ b/src/Api/V1/PlayerResultsResponseProvider.php
@@ -62,7 +62,7 @@ final readonly class PlayerResultsResponseProvider implements ProviderInterface
                     time_seconds: $puzzle->time,
                     finished_at: $puzzle->finishedAt?->format('c'),
                     first_attempt: $puzzle->firstAttempt,
-                    puzzle_image: $puzzle->puzzleImage,
+                    image: $puzzle->puzzleImage,
                     comment: $puzzle->comment,
                 ),
                 $results,


### PR DESCRIPTION
## Summary

`MyResultsResponseProvider` and `PlayerResultsResponseProvider` were the only two API responses still calling this field `puzzle_image` — `CompetitionDetailResponseProvider` already maps the same underlying `$puzzle->puzzleImage` to `image` (live in production today), matching how `manufacturer_name` and `pieces_count` are already unprefixed in this same results response despite also being facts about the puzzle, not the result.

`puzzle_id` and `puzzle_name` keep their prefix since they'd otherwise be ambiguous against this response's own `time_id`, but nothing else in the payload could be confused with "image", so this fits the existing no-prefix pattern rather than introducing a new one.

## Test plan

- [ ] Confirm `GET /api/v1/me/results` and `GET /api/v1/players/{id}/results` now return `image` instead of `puzzle_image`