### PR TITLE
OAuth2 API: cover the write path, 403 machine tokens on /me, keep write scopes auth-code-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ Active feature flags are documented in `docs/features/feature_flags.md`. **Alway
 - **Two auth methods:** Personal Access Tokens (PAT) for own data, OAuth2 for third-party apps
 - **PAT:** `msp_pat_*` tokens, hashed in DB, `PatAuthenticator` on `api` firewall, `ROLE_PAT`, own data only (`/api/v1/me/*`)
 - **OAuth2:** `league/oauth2-server-bundle`, JWT Bearer tokens, scope-based roles
-- **Scopes:** `profile:read` (default), `results:read`, `statistics:read`, `collections:read`, `solving-times:write`, `collections:write`
+- **Scopes:** `profile:read` (default), `results:read`, `statistics:read`, `collections:read`, `solving-times:write`, `collections:write` — single source of truth is the `OAuth2Scope` enum (feeds the bundle config). Bundle role = `strtoupper('ROLE_OAUTH2_' . scope)` **with punctuation kept** (`ROLE_OAUTH2_SOLVING-TIMES:WRITE`) — use `OAuth2Scope::role()`, don't retype. Write scopes are stripped from `client_credentials` tokens (`OAuth2ClientCredentialsScopeSubscriber`); token responses carry the granted `scope` (`ScopeAwareBearerTokenResponse`); `^/api/v1/me` requires `ROLE_PAT`/`ROLE_OAUTH2_USER`, so a client-credentials token gets 403 there, not a 500
 - **Grants:** `authorization_code` (read+write), `client_credentials` (read-only), `refresh_token`
 - **"Me" endpoints:** `/api/v1/me/*` — PAT or OAuth2 with user context
 - **Player endpoints:** `/api/v1/players/{id}/*` — OAuth2 only

--- a/config/packages/league_oauth2_server.php
+++ b/config/packages/league_oauth2_server.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use SpeedPuzzling\Web\Security\OAuth2\ScopeAwareBearerTokenResponse;
+use SpeedPuzzling\Web\Value\OAuth2Scope;
 
 return App::config([
     'league_oauth2_server' => [
@@ -27,17 +28,12 @@ return App::config([
             'public_key' => '%env(OAUTH2_PUBLIC_KEY)%',
         ],
         'scopes' => [
-            'available' => [
-                'profile:read',
-                'email:read',
-                'results:read',
-                'statistics:read',
-                'collections:read',
-                'solving-times:write',
-                'collections:write',
-            ],
+            // Single source of truth is the OAuth2Scope enum - which scopes exist,
+            // and which of them are user-context only (stripped from
+            // client_credentials tokens by OAuth2ClientCredentialsScopeSubscriber).
+            'available' => OAuth2Scope::values(),
             'default' => [
-                'profile:read',
+                OAuth2Scope::ProfileRead->value,
             ],
         ],
         'persistence' => [

--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -15,9 +15,12 @@ use SpeedPuzzling\Web\Security\LoginFormAuthenticator;
 use SpeedPuzzling\Web\Security\LoginLinkFailureHandler;
 use SpeedPuzzling\Web\Security\LoginLinkSuccessHandler;
 use SpeedPuzzling\Web\Security\MigrationWindowAuth0Authenticator;
+use SpeedPuzzling\Web\Security\OAuth2User;
 use SpeedPuzzling\Web\Security\OAuth2UserProvider;
 use SpeedPuzzling\Web\Security\PatAuthenticator;
+use SpeedPuzzling\Web\Security\PatUser;
 use SpeedPuzzling\Web\Security\UserAccountProvider;
+use SpeedPuzzling\Web\Value\OAuth2Scope;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 
 return App::config([
@@ -202,21 +205,26 @@ return App::config([
                 'path' => '^/internal-api/',
                 'roles' => [InternalApiAuthenticator::ROLE],
             ],
+            // "Me" endpoints need a user behind the token: a PAT, or an OAuth2
+            // token issued through the authorization-code flow. A client_credentials
+            // token is authenticated too (as the bundle's ClientCredentialsUser, no
+            // roles) so IS_AUTHENTICATED_FULLY let it through to providers that
+            // assert an ApiUser - and it died with a 500 instead of this 403.
             [
                 'path' => '^/api/v1/me',
-                'roles' => [AuthenticatedVoter::IS_AUTHENTICATED_FULLY],
+                'roles' => [PatUser::ROLE, OAuth2User::ROLE],
             ],
             [
                 'path' => '^/api/v1/players/.*/results',
-                'roles' => ['ROLE_OAUTH2_RESULTS:READ'],
+                'roles' => [OAuth2Scope::ResultsRead->role()],
             ],
             [
                 'path' => '^/api/v1/players/.*/statistics',
-                'roles' => ['ROLE_OAUTH2_STATISTICS:READ'],
+                'roles' => [OAuth2Scope::StatisticsRead->role()],
             ],
             [
                 'path' => '^/api/v1/players/.*/collections',
-                'roles' => ['ROLE_OAUTH2_COLLECTIONS:READ'],
+                'roles' => [OAuth2Scope::CollectionsRead->role()],
             ],
             [
                 'path' => '^/api/v1/competitions',

--- a/docs/features/api/README.md
+++ b/docs/features/api/README.md
@@ -44,6 +44,24 @@ Built on `league/oauth2-server-bundle`. Supports two flows:
 | `solving-times:write` | Create and edit solving times | Yes | No |
 | `collections:write` | Create, edit, delete collections and items | Yes | No |
 
+The list lives in the `OAuth2Scope` enum (`src/Value/OAuth2Scope.php`), which also feeds
+`league_oauth2_server.scopes.available`. `OAuth2Scope::requiresUserContext()` marks the two write
+scopes as auth-code-only, and `OAuth2ClientCredentialsScopeSubscriber` (`OAuth2Events::SCOPE_RESOLVE`)
+**strips them from every `client_credentials` token** instead of failing the request — the bundle
+grants *everything the client holds* when no `scope` parameter is sent, so a hard error would break
+parameter-less machine-token calls from clients approved for write scopes (RFC 6749 §3.3 permits
+narrowing). The token response says what was actually granted:
+
+```json
+{"token_type":"Bearer","expires_in":3600,"access_token":"…","refresh_token":"…","scope":"profile:read results:read"}
+```
+
+`scope` is added by `ScopeAwareBearerTokenResponse` (`authorization_server.response_type_class`) —
+`league/oauth2-server` omits it by default. Roles are derived by the bundle as
+`strtoupper('ROLE_OAUTH2_' . scope)` with no punctuation normalisation, so `solving-times:write`
+grants `ROLE_OAUTH2_SOLVING-TIMES:WRITE` (hyphen kept) — `OAuth2Scope::role()` spells it right; a
+hand-typed `SOLVING_TIMES` variant silently matched nothing until 2026-08 (PR #184).
+
 ### Token TTLs
 
 - Access token: 1 hour (stateless JWT)
@@ -133,6 +151,7 @@ Puzzle difficulty and player skill tiers are included in responses only if the t
 
 - Missing/invalid/expired token: 401
 - Missing scope: 403
+- `client_credentials` token on any `/api/v1/me/*` endpoint: 403 (no user context)
 - Non-existent player UUID: 404
 - Membership required: 403 with message
 - Validation error: 422
@@ -189,7 +208,10 @@ PAT uses `Authorization: Token ...` (not `Bearer`) to avoid collision with the O
 Both `PatUser` and `OAuth2User` implement the `ApiUser` interface (`getPlayer(): Player`).
 
 Access control:
-- `^/api/v1/me` → `IS_AUTHENTICATED_FULLY` (PAT or OAuth2)
+- `^/api/v1/me` → `ROLE_PAT` or `ROLE_OAUTH2_USER` (`PatUser::ROLE` / `OAuth2User::ROLE`) — i.e. a token with a
+  player behind it. A `client_credentials` token is authenticated too (as the bundle's `ClientCredentialsUser`, no
+  roles), and under `IS_AUTHENTICATED_FULLY` it used to reach the providers, fail `assert($user instanceof ApiUser)`
+  and return 500; now it gets 403
 - `^/api/v1/players/.*/results` → `ROLE_OAUTH2_RESULTS:READ`
 - `^/api/v1/players/.*/statistics` → `ROLE_OAUTH2_STATISTICS:READ`
 - `^/api/v1/players/.*/collections` → `ROLE_OAUTH2_COLLECTIONS:READ`
@@ -268,6 +290,9 @@ Stub endpoints for in-app purchase verification (not implemented).
 | `src/FormType/RequestApiAccessFormType.php` | OAuth2 request Symfony form type |
 | `src/FormData/RequestApiAccessFormData.php` | OAuth2 request form data with validation |
 | `src/EventSubscriber/ApiTokenUsageSubscriber.php` | OAuth2 usage tracking |
+| `src/EventSubscriber/OAuth2ClientCredentialsScopeSubscriber.php` | Strips write scopes from `client_credentials` tokens |
+| `src/Security/OAuth2/ScopeAwareBearerTokenResponse.php` | Adds granted `scope` to the token response |
+| `src/Value/OAuth2Scope.php` | Scope enum: available list, auth-code-only flag, role name derivation |
 | `config/packages/security.php` | Firewalls and access control |
 | `config/packages/league_oauth2_server.php` | OAuth2 config (scopes, grants, TTLs) |
 | `config/packages/api_platform.php` | API Platform config and Swagger |

--- a/src/EventSubscriber/OAuth2ClientCredentialsScopeSubscriber.php
+++ b/src/EventSubscriber/OAuth2ClientCredentialsScopeSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\EventSubscriber;
+
+use League\Bundle\OAuth2ServerBundle\Event\ScopeResolveEvent;
+use League\Bundle\OAuth2ServerBundle\OAuth2Events;
+use League\Bundle\OAuth2ServerBundle\OAuth2Grants;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use SpeedPuzzling\Web\Value\OAuth2Scope;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Keeps user-context scopes (solving-times:write, collections:write) off
+ * client_credentials tokens, as the developer docs promise ("auth code only").
+ *
+ * The bundle finalises scopes purely against the client's own scope list, and
+ * with no "scope" parameter it hands out *everything* the client holds - so a
+ * client approved for write scopes would otherwise mint machine tokens that
+ * carry them. Rather than failing the whole token request (which would break
+ * every parameter-less client_credentials call such a client already makes),
+ * the scopes are silently dropped: RFC 6749 §3.3 allows the server to narrow
+ * the grant, and the token response's "scope" field tells the client what it
+ * actually got.
+ */
+final readonly class OAuth2ClientCredentialsScopeSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            OAuth2Events::SCOPE_RESOLVE => 'onScopeResolve',
+        ];
+    }
+
+    public function onScopeResolve(ScopeResolveEvent $event): void
+    {
+        if ((string) $event->getGrant() !== OAuth2Grants::CLIENT_CREDENTIALS) {
+            return;
+        }
+
+        $allowed = array_values(array_filter(
+            $event->getScopes(),
+            static function (Scope $scope): bool {
+                $known = OAuth2Scope::tryFrom((string) $scope);
+
+                // Unknown scopes are the bundle's business - leave them alone.
+                return $known === null || $known->requiresUserContext() === false;
+            },
+        ));
+
+        $event->setScopes(...$allowed);
+    }
+}

--- a/src/Security/OAuth2/ScopeAwareBearerTokenResponse.php
+++ b/src/Security/OAuth2/ScopeAwareBearerTokenResponse.php
@@ -5,14 +5,26 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Security\OAuth2;
 
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
+use SensitiveParameter;
 
+/**
+ * Adds the granted "scope" to the token response. league/oauth2-server leaves it
+ * out, yet RFC 6749 §5.1 requires it whenever the granted scope differs from the
+ * requested one - which happens here: a request without "scope" is granted every
+ * scope the client holds, and client_credentials tokens have their user-context
+ * scopes stripped (OAuth2ClientCredentialsScopeSubscriber). Wired in via
+ * league_oauth2_server.authorization_server.response_type_class.
+ */
 final class ScopeAwareBearerTokenResponse extends BearerTokenResponse
 {
-    protected function getExtraParams(AccessTokenEntityInterface $accessToken): array
-    {
+    protected function getExtraParams(
+        #[SensitiveParameter]
+        AccessTokenEntityInterface $accessToken,
+    ): array {
         $scopes = array_map(
-            static fn ($scope): string => $scope->getIdentifier(),
+            static fn (ScopeEntityInterface $scope): string => $scope->getIdentifier(),
             $accessToken->getScopes(),
         );
 

--- a/src/Security/OAuth2User.php
+++ b/src/Security/OAuth2User.php
@@ -8,6 +8,14 @@ use SpeedPuzzling\Web\Entity\Player;
 
 final readonly class OAuth2User implements ApiUser
 {
+    /**
+     * Marks a token that carries a real user (authorization-code flow). The
+     * bundle merges these roles into the scope roles, so access_control can
+     * tell "OAuth2 on behalf of a player" apart from a client_credentials token,
+     * which authenticates as ClientCredentialsUser with no roles at all.
+     */
+    public const string ROLE = 'ROLE_OAUTH2_USER';
+
     public function __construct(
         public Player $player,
     ) {
@@ -20,7 +28,7 @@ final readonly class OAuth2User implements ApiUser
 
     public function getRoles(): array
     {
-        return ['ROLE_OAUTH2_USER'];
+        return [self::ROLE];
     }
 
     public function eraseCredentials(): void

--- a/src/Security/PatUser.php
+++ b/src/Security/PatUser.php
@@ -8,6 +8,8 @@ use SpeedPuzzling\Web\Entity\Player;
 
 final readonly class PatUser implements ApiUser
 {
+    public const string ROLE = 'ROLE_PAT';
+
     public function __construct(
         private Player $player,
     ) {
@@ -20,7 +22,7 @@ final readonly class PatUser implements ApiUser
 
     public function getRoles(): array
     {
-        return ['ROLE_PAT'];
+        return [self::ROLE];
     }
 
     public function eraseCredentials(): void

--- a/src/Value/OAuth2Scope.php
+++ b/src/Value/OAuth2Scope.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+/**
+ * Every scope the OAuth2 server can grant. The list wired into
+ * config/packages/league_oauth2_server.php is built from these cases, so
+ * adding a scope here is the only step needed to make it grantable.
+ *
+ * The role league/oauth2-server-bundle grants for a scope is
+ * strtoupper('ROLE_OAUTH2_' . scope) with no punctuation normalisation - so
+ * "solving-times:write" becomes ROLE_OAUTH2_SOLVING-TIMES:WRITE, hyphen kept.
+ * Use role() in security expressions instead of retyping that by hand.
+ */
+enum OAuth2Scope: string
+{
+    case ProfileRead = 'profile:read';
+    case EmailRead = 'email:read';
+    case ResultsRead = 'results:read';
+    case StatisticsRead = 'statistics:read';
+    case CollectionsRead = 'collections:read';
+    case SolvingTimesWrite = 'solving-times:write';
+    case CollectionsWrite = 'collections:write';
+
+    public const string ROLE_PREFIX = 'ROLE_OAUTH2_';
+
+    /**
+     * @return list<non-empty-string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn (self $scope): string => $scope->value, self::cases());
+    }
+
+    /**
+     * Scopes that only make sense on behalf of a signed-in user - they unlock
+     * writes to /api/v1/me/*, which a client_credentials token (no user) can
+     * never reach. Such scopes are stripped from client_credentials tokens.
+     */
+    public function requiresUserContext(): bool
+    {
+        return match ($this) {
+            self::SolvingTimesWrite, self::CollectionsWrite => true,
+            self::ProfileRead, self::EmailRead, self::ResultsRead, self::StatisticsRead, self::CollectionsRead => false,
+        };
+    }
+
+    public function role(): string
+    {
+        return strtoupper(self::ROLE_PREFIX . $this->value);
+    }
+}

--- a/templates/for-developers.html.twig
+++ b/templates/for-developers.html.twig
@@ -140,7 +140,16 @@
   -d "code=AUTH_CODE_FROM_REDIRECT" \
   -d "redirect_uri=https://your-app.com/callback" \
   -d "client_id=YOUR_CLIENT_ID" \
-  -d "client_secret=YOUR_CLIENT_SECRET"</code></pre>
+  -d "client_secret=YOUR_CLIENT_SECRET"
+
+HTTP/1.1 200 OK
+{
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "access_token": "eyJ0eXAi...",
+  "refresh_token": "def50200...",
+  "scope": "profile:read results:read"
+}</code></pre>
                     <p class="mb-0">{{ 'for_developers.auth_code_step3'|trans|raw }}</p>
                     <pre class="bg-light p-3 rounded"><code>curl -H "Authorization: Bearer ACCESS_TOKEN" \
   https://myspeedpuzzling.com/api/v1/me/results</code></pre>
@@ -170,7 +179,15 @@
   -d "grant_type=client_credentials" \
   -d "client_id=YOUR_CLIENT_ID" \
   -d "client_secret=YOUR_CLIENT_SECRET" \
-  -d "scope=results:read statistics:read"</code></pre>
+  -d "scope=results:read statistics:read"
+
+HTTP/1.1 200 OK
+{
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "access_token": "eyJ0eXAi...",
+  "scope": "results:read statistics:read"
+}</code></pre>
                     <p class="mb-0">{{ 'for_developers.client_cred_step2'|trans|raw }}</p>
                     <pre class="bg-light p-3 rounded"><code>curl -H "Authorization: Bearer ACCESS_TOKEN" \
   https://myspeedpuzzling.com/api/v1/players/PLAYER_UUID/results</code></pre>

--- a/tests/Controller/Api/V1/CreateSolvingTimeEndpointTest.php
+++ b/tests/Controller/Api/V1/CreateSolvingTimeEndpointTest.php
@@ -7,8 +7,10 @@ namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
 use Doctrine\DBAL\Connection;
 use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionRoundFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
 use SpeedPuzzling\Web\Tests\PatTestHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -117,6 +119,103 @@ final class CreateSolvingTimeEndpointTest extends WebTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Pins the role name to what the bundle derives from the scope
+     * (ROLE_OAUTH2_SOLVING-TIMES:WRITE, hyphen kept). The check used to spell it
+     * with an underscore, so no OAuth2 token could ever write - and the PAT-only
+     * tests above never noticed, because ROLE_PAT short-circuits the "or".
+     */
+    public function testOAuth2TokenWithWriteScopeCanCreate(): void
+    {
+        $browser = self::createClient();
+
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::WRITE_CLIENT_ID,
+            PlayerFixture::PLAYER_REGULAR,
+            ['solving-times:write'],
+        );
+        OAuth2TestHelper::addBearerToken($browser, $token);
+
+        $browser->request(
+            'POST',
+            '/api/v1/me/solving-times',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode([
+                'puzzle_id' => PuzzleFixture::PUZZLE_500_01,
+                'time' => '10:00',
+            ]),
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $timeId = $this->extractTimeId($browser->getResponse()->getContent());
+
+        /** @var array{player_id: string}|false $row */
+        $row = $this->database()->fetchAssociative(
+            'SELECT player_id FROM puzzle_solving_time WHERE id = :id',
+            ['id' => $timeId],
+        );
+
+        self::assertNotFalse($row);
+        self::assertSame(PlayerFixture::PLAYER_REGULAR, $row['player_id']);
+    }
+
+    public function testOAuth2TokenWithoutWriteScopeReturnsForbidden(): void
+    {
+        $browser = self::createClient();
+
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::WRITE_CLIENT_ID,
+            PlayerFixture::PLAYER_REGULAR,
+            ['profile:read', 'results:read'],
+        );
+        OAuth2TestHelper::addBearerToken($browser, $token);
+
+        $browser->request(
+            'POST',
+            '/api/v1/me/solving-times',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode([
+                'puzzle_id' => PuzzleFixture::PUZZLE_500_01,
+                'time' => '10:00',
+            ]),
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * A client_credentials token has no user behind it, so it must never reach
+     * the processor (which asserts an ApiUser and would 500) - even when it
+     * somehow carries the write scope.
+     */
+    public function testClientCredentialsTokenReturnsForbidden(): void
+    {
+        $browser = self::createClient();
+
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::WRITE_CLIENT_ID,
+            OAuth2ClientFixture::WRITE_CLIENT_ID,
+            ['solving-times:write'],
+        );
+        OAuth2TestHelper::addBearerToken($browser, $token);
+
+        $browser->request(
+            'POST',
+            '/api/v1/me/solving-times',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode([
+                'puzzle_id' => PuzzleFixture::PUZZLE_500_01,
+                'time' => '10:00',
+            ]),
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     private function database(): Connection

--- a/tests/Controller/Api/V1/CurrentUserEndpointTest.php
+++ b/tests/Controller/Api/V1/CurrentUserEndpointTest.php
@@ -170,4 +170,31 @@ final class CurrentUserEndpointTest extends WebTestCase
         $this->assertSame(PlayerFixture::PLAYER_PRIVATE, $response['id']);
         $this->assertTrue($response['is_private']);
     }
+
+    /**
+     * A client_credentials token is authenticated (as the bundle's
+     * ClientCredentialsUser) but has no player behind it. It used to pass
+     * IS_AUTHENTICATED_FULLY and die on assert($user instanceof ApiUser) - 500.
+     */
+    public function testClientCredentialsTokenReturnsForbidden(): void
+    {
+        $browser = self::createClient();
+
+        $browser->request('POST', '/oauth2/token', [
+            'grant_type' => 'client_credentials',
+            'client_id' => OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            'client_secret' => OAuth2ClientFixture::CONFIDENTIAL_CLIENT_SECRET,
+            'scope' => 'profile:read',
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        /** @var array{access_token: string} $tokenResponse */
+        $tokenResponse = json_decode((string) $browser->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        OAuth2TestHelper::addBearerToken($browser, $tokenResponse['access_token']);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
 }

--- a/tests/Controller/Api/V1/UpdateSolvingTimeEndpointTest.php
+++ b/tests/Controller/Api/V1/UpdateSolvingTimeEndpointTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
 
 use Doctrine\DBAL\Connection;
+use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleSolvingTimeFixture;
+use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
 use SpeedPuzzling\Web\Tests\PatTestHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -78,5 +80,62 @@ final class UpdateSolvingTimeEndpointTest extends WebTestCase
         );
 
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testOAuth2TokenWithWriteScopeCanUpdateOwnTime(): void
+    {
+        $browser = self::createClient();
+
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::WRITE_CLIENT_ID,
+            PlayerFixture::PLAYER_REGULAR,
+            ['solving-times:write'],
+        );
+        OAuth2TestHelper::addBearerToken($browser, $token);
+
+        $browser->request(
+            'PUT',
+            '/api/v1/me/solving-times/' . PuzzleSolvingTimeFixture::TIME_01,
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode(['comment' => 'Updated via OAuth2']),
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        /** @var Connection $database */
+        $database = self::getContainer()->get(Connection::class);
+
+        /** @var array{player_id: string, comment: null|string}|false $row */
+        $row = $database->fetchAssociative(
+            'SELECT player_id, comment FROM puzzle_solving_time WHERE id = :id',
+            ['id' => PuzzleSolvingTimeFixture::TIME_01],
+        );
+
+        self::assertNotFalse($row);
+        self::assertSame(PlayerFixture::PLAYER_REGULAR, $row['player_id']);
+        self::assertSame('Updated via OAuth2', $row['comment']);
+    }
+
+    public function testOAuth2TokenWithoutWriteScopeReturnsForbidden(): void
+    {
+        $browser = self::createClient();
+
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::WRITE_CLIENT_ID,
+            PlayerFixture::PLAYER_REGULAR,
+            ['profile:read', 'results:read'],
+        );
+        OAuth2TestHelper::addBearerToken($browser, $token);
+
+        $browser->request(
+            'PUT',
+            '/api/v1/me/solving-times/' . PuzzleSolvingTimeFixture::TIME_01,
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode(['comment' => 'No write scope']),
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 }

--- a/tests/Controller/OAuth2/AuthorizationCodeFlowTest.php
+++ b/tests/Controller/OAuth2/AuthorizationCodeFlowTest.php
@@ -6,6 +6,7 @@ namespace SpeedPuzzling\Web\Tests\Controller\OAuth2;
 
 use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
 use SpeedPuzzling\Web\Tests\TestingLogin;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -198,6 +199,7 @@ final class AuthorizationCodeFlowTest extends WebTestCase
         $this->assertArrayHasKey('refresh_token', $response);
         $this->assertArrayHasKey('token_type', $response);
         $this->assertSame('Bearer', $response['token_type']);
+        $this->assertSame('profile:read', $response['scope'] ?? null);
     }
 
     public function testTokenCanBeUsedToAccessUserData(): void
@@ -451,6 +453,67 @@ final class AuthorizationCodeFlowTest extends WebTestCase
         );
 
         // Should show consent screen
+        $this->assertResponseIsSuccessful();
+    }
+
+    /**
+     * The whole journey a third-party app takes to record a solve on a player's
+     * behalf: consent for solving-times:write, code exchange, POST. This is the
+     * path that was broken until the role name matched the granted scope.
+     */
+    public function testWriteScopeGrantedThroughAuthCodeFlowCanCreateSolvingTime(): void
+    {
+        $browser = self::createClient();
+
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request(
+            'POST',
+            '/oauth2/authorize?' . http_build_query([
+                'client_id' => OAuth2ClientFixture::WRITE_CLIENT_ID,
+                'response_type' => 'code',
+                'redirect_uri' => OAuth2ClientFixture::REDIRECT_URI,
+                'scope' => 'profile:read solving-times:write',
+                'state' => 'test-state-write',
+            ]),
+            ['consent' => 'approve'],
+        );
+
+        $this->assertResponseRedirects();
+
+        $location = $browser->getResponse()->headers->get('Location');
+        $this->assertIsString($location);
+        $query = parse_url($location, PHP_URL_QUERY);
+        $this->assertIsString($query);
+        parse_str($query, $params);
+        $this->assertIsString($params['code'] ?? null);
+
+        $browser->request(
+            'POST',
+            '/oauth2/token',
+            [
+                'grant_type' => 'authorization_code',
+                'client_id' => OAuth2ClientFixture::WRITE_CLIENT_ID,
+                'client_secret' => OAuth2ClientFixture::WRITE_CLIENT_SECRET,
+                'redirect_uri' => OAuth2ClientFixture::REDIRECT_URI,
+                'code' => $params['code'],
+            ],
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        /** @var array{access_token: string, scope?: string} $tokenResponse */
+        $tokenResponse = json_decode((string) $browser->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('profile:read solving-times:write', $tokenResponse['scope'] ?? null);
+
+        $browser->setServerParameter('HTTP_AUTHORIZATION', 'Bearer ' . $tokenResponse['access_token']);
+        $browser->request(
+            'POST',
+            '/api/v1/me/solving-times',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode(['puzzle_id' => PuzzleFixture::PUZZLE_500_01, 'time' => '12:34']),
+        );
+
         $this->assertResponseIsSuccessful();
     }
 }

--- a/tests/Controller/OAuth2/ClientCredentialsFlowTest.php
+++ b/tests/Controller/OAuth2/ClientCredentialsFlowTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Tests\Controller\OAuth2;
 
 use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -39,6 +40,88 @@ final class ClientCredentialsFlowTest extends WebTestCase
         $this->assertSame('Bearer', $response['token_type']);
         $this->assertIsInt($response['expires_in']);
         $this->assertGreaterThan(0, $response['expires_in']);
+        // Granted scope is echoed back (ScopeAwareBearerTokenResponse)
+        $this->assertSame('profile:read results:read', $response['scope'] ?? null);
+    }
+
+    /**
+     * With no "scope" parameter the bundle grants everything the client holds -
+     * the response has to say so, or the client cannot know what it got.
+     */
+    public function testResponseScopeListsEverythingGrantedWhenNoneRequested(): void
+    {
+        $browser = self::createClient();
+
+        $browser->request(
+            'POST',
+            '/oauth2/token',
+            [
+                'grant_type' => 'client_credentials',
+                'client_id' => OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+                'client_secret' => OAuth2ClientFixture::CONFIDENTIAL_CLIENT_SECRET,
+            ],
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        /** @var array{scope?: string} $response */
+        $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('profile:read email:read results:read statistics:read', $response['scope'] ?? null);
+    }
+
+    public function testUserContextScopesAreStrippedFromClientCredentialsTokens(): void
+    {
+        $browser = self::createClient();
+
+        // Explicitly asking for the write scope does not fail the request; the
+        // scope is dropped and the response says what was actually granted.
+        $browser->request(
+            'POST',
+            '/oauth2/token',
+            [
+                'grant_type' => 'client_credentials',
+                'client_id' => OAuth2ClientFixture::WRITE_CLIENT_ID,
+                'client_secret' => OAuth2ClientFixture::WRITE_CLIENT_SECRET,
+                'scope' => 'profile:read solving-times:write collections:write results:read',
+            ],
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        /** @var array{access_token: string, scope?: string} $response */
+        $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('profile:read results:read', $response['scope'] ?? null);
+
+        // ...and neither does the parameter-less form, which grants "everything the client holds"
+        $browser->request(
+            'POST',
+            '/oauth2/token',
+            [
+                'grant_type' => 'client_credentials',
+                'client_id' => OAuth2ClientFixture::WRITE_CLIENT_ID,
+                'client_secret' => OAuth2ClientFixture::WRITE_CLIENT_SECRET,
+            ],
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        /** @var array{access_token: string, scope?: string} $response */
+        $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('profile:read email:read results:read statistics:read collections:read', $response['scope'] ?? null);
+
+        // The token itself does not carry the write role either
+        $browser->setServerParameter('HTTP_AUTHORIZATION', 'Bearer ' . $response['access_token']);
+        $browser->request(
+            'POST',
+            '/api/v1/me/solving-times',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode(['puzzle_id' => PuzzleFixture::PUZZLE_500_01, 'time' => '10:00']),
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     public function testClientCredentialsGrantWithInvalidClientIdFails(): void

--- a/tests/Controller/OAuth2/RefreshTokenFlowTest.php
+++ b/tests/Controller/OAuth2/RefreshTokenFlowTest.php
@@ -46,6 +46,7 @@ final class RefreshTokenFlowTest extends WebTestCase
         $this->assertArrayHasKey('token_type', $response);
         $this->assertArrayHasKey('expires_in', $response);
         $this->assertSame('Bearer', $response['token_type']);
+        $this->assertSame('profile:read', $response['scope'] ?? null);
     }
 
     public function testRefreshTokenGrantWithInvalidTokenFails(): void

--- a/tests/DataFixtures/OAuth2ClientFixture.php
+++ b/tests/DataFixtures/OAuth2ClientFixture.php
@@ -18,6 +18,8 @@ final class OAuth2ClientFixture extends Fixture
     public const string CONFIDENTIAL_CLIENT_ID = 'confidential-test-client';
     public const string CONFIDENTIAL_CLIENT_SECRET = 'test-secret-12345678901234567890123456789012';
     public const string FIRST_PARTY_CLIENT_ID = 'first-party-client';
+    public const string WRITE_CLIENT_ID = 'write-test-client';
+    public const string WRITE_CLIENT_SECRET = 'write-secret-1234567890123456789012345678';
     public const string REDIRECT_URI = 'https://example.com/callback';
 
     public function __construct(
@@ -86,5 +88,31 @@ final class OAuth2ClientFixture extends Fixture
         );
         $this->clientManager->save($firstPartyClient);
         $this->addReference(self::FIRST_PARTY_CLIENT_ID, $firstPartyClient);
+
+        // Client approved for the write scopes AND client_credentials - the shape
+        // of the real integrators' clients. Lets tests prove that write scopes
+        // work through the auth-code flow and are stripped from machine tokens.
+        $writeClient = new Client(
+            'Write Test Client',
+            self::WRITE_CLIENT_ID,
+            self::WRITE_CLIENT_SECRET,
+        );
+        $writeClient->setRedirectUris(new RedirectUri(self::REDIRECT_URI));
+        $writeClient->setGrants(
+            new Grant('authorization_code'),
+            new Grant('client_credentials'),
+            new Grant('refresh_token'),
+        );
+        $writeClient->setScopes(
+            new Scope('profile:read'),
+            new Scope('email:read'),
+            new Scope('results:read'),
+            new Scope('statistics:read'),
+            new Scope('collections:read'),
+            new Scope('solving-times:write'),
+            new Scope('collections:write'),
+        );
+        $this->clientManager->save($writeClient);
+        $this->addReference(self::WRITE_CLIENT_ID, $writeClient);
     }
 }

--- a/tests/OAuth2TestHelper.php
+++ b/tests/OAuth2TestHelper.php
@@ -19,6 +19,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 final readonly class OAuth2TestHelper
 {
     /**
+     * Pass the client id as $userIdentifier to get a client_credentials-shaped
+     * token (sub = aud = client id): that is exactly what ClientCredentialsGrant
+     * issues, and the bundle authenticates it as ClientCredentialsUser.
+     *
+     * @param non-empty-string $clientId
      * @param array<non-empty-string> $scopes
      */
     public static function createAccessToken(
@@ -66,6 +71,7 @@ final readonly class OAuth2TestHelper
     }
 
     /**
+     * @param non-empty-string $clientId
      * @param array<non-empty-string> $scopes
      */
     private static function generateJwt(
@@ -89,13 +95,17 @@ final readonly class OAuth2TestHelper
         /** @var non-empty-string $subject */
         $subject = $userIdentifier !== null && $userIdentifier !== '' ? $userIdentifier : 'anonymous';
 
+        // Same claim set league/oauth2-server issues (AccessTokenTrait::convertToJWT):
+        // the client id travels in "aud" - BearerTokenValidator reads it from there
+        // to set oauth_client_id, and the bundle's authenticator compares it with
+        // "sub" to recognise a client_credentials token.
         $builder = $configuration->builder()
+            ->permittedFor($clientId)
             ->identifiedBy($identifier !== '' ? $identifier : 'default')
             ->issuedAt($now)
             ->canOnlyBeUsedAfter($now)
             ->expiresAt($expiry)
             ->relatedTo($subject)
-            ->withClaim('client_id', $clientId)
             ->withClaim('scopes', $scopes);
 
         return $builder->getToken($configuration->signer(), $configuration->signingKey())->toString();

--- a/tests/Value/OAuth2ScopeTest.php
+++ b/tests/Value/OAuth2ScopeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Value;
+
+use League\Bundle\OAuth2ServerBundle\Security\Authentication\Token\OAuth2Token;
+use PHPUnit\Framework\TestCase;
+use SpeedPuzzling\Web\Security\OAuth2User;
+use SpeedPuzzling\Web\Value\OAuth2Scope;
+
+final class OAuth2ScopeTest extends TestCase
+{
+    /**
+     * role() must produce exactly the role the bundle grants for the scope -
+     * pinned against the bundle's own token class rather than a copy of its
+     * formula, so a bundle change shows up here.
+     */
+    public function testRoleMatchesWhatTheBundleGrants(): void
+    {
+        foreach (OAuth2Scope::cases() as $scope) {
+            $token = new OAuth2Token(null, 'token-id', 'client-id', [$scope->value], OAuth2Scope::ROLE_PREFIX);
+
+            self::assertSame([$scope->role()], $token->getRoleNames(), $scope->value);
+        }
+    }
+
+    /**
+     * Every ROLE_OAUTH2_* literal in the API resources has to be a role somebody
+     * can actually hold. Attribute strings cannot call role(), so this is the
+     * guard: the write check on /me/solving-times spelled the hyphenated scope
+     * with an underscore for months and silently matched nothing.
+     */
+    public function testEveryOAuth2RoleReferencedByApiResourcesIsGrantable(): void
+    {
+        $grantable = array_map(static fn (OAuth2Scope $scope): string => $scope->role(), OAuth2Scope::cases());
+        $grantable[] = OAuth2User::ROLE;
+
+        $files = glob(__DIR__ . '/../../src/Api/V1/*.php');
+        self::assertNotFalse($files);
+        self::assertNotEmpty($files);
+
+        $referenced = [];
+
+        foreach ($files as $file) {
+            $source = file_get_contents($file);
+            self::assertIsString($source);
+
+            preg_match_all('/ROLE_OAUTH2_[A-Z0-9:_-]+/', $source, $matches);
+
+            foreach ($matches[0] as $role) {
+                $referenced[$role] = basename($file);
+            }
+        }
+
+        self::assertNotEmpty($referenced, 'Expected the API resources to reference OAuth2 roles');
+
+        foreach ($referenced as $role => $file) {
+            self::assertContains($role, $grantable, sprintf('%s references %s, which no scope grants', $file, $role));
+        }
+    }
+
+    public function testWriteScopesRequireUserContext(): void
+    {
+        $userOnly = array_values(array_filter(
+            OAuth2Scope::cases(),
+            static fn (OAuth2Scope $scope): bool => $scope->requiresUserContext(),
+        ));
+
+        self::assertSame([OAuth2Scope::SolvingTimesWrite, OAuth2Scope::CollectionsWrite], $userOnly);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #184 (thanks @puzzlerushse), which fixed the `solving-times:write` role check and added `scope` to the token response. That bug could ship because every solving-time write test authenticated with a PAT — `ROLE_PAT` short-circuits the `or`, so the OAuth2 branch was never exercised. This closes that gap and the two related ones found while reviewing #184.

- **`OAuth2Scope` enum** — single source of truth: feeds `league_oauth2_server.scopes.available`, knows which scopes need a user (the two write scopes) and derives the role name the bundle actually grants (`strtoupper('ROLE_OAUTH2_' . scope)`, punctuation kept → `ROLE_OAUTH2_SOLVING-TIMES:WRITE`). A unit test pins `role()` against the bundle's own `OAuth2Token` and scans every `ROLE_OAUTH2_*` literal in `src/Api/V1` — it flags the old typo.
- **`^/api/v1/me` → `ROLE_PAT` or `ROLE_OAUTH2_USER`** (was `IS_AUTHENTICATED_FULLY`). A client-credentials token is authenticated too (bundle's `ClientCredentialsUser`, no roles) and reached the providers, failed `assert($user instanceof ApiUser)` and returned **500**; it now gets 403.
- **`OAuth2ClientCredentialsScopeSubscriber`** strips `solving-times:write` / `collections:write` from `client_credentials` tokens, as the docs and the developer page ("auth code only") already promise. Stripping rather than failing: the bundle grants *everything the client holds* when no `scope` parameter is sent, and both production clients approved for write scopes also hold the `client_credentials` grant — a hard `invalid_scope` would break their parameter-less token calls. RFC 6749 §3.3 permits narrowing; the response's `scope` field (from #184) reports what was granted.
- **Tests**: OAuth2 write with/without scope on `POST` and `PUT /me/solving-times`; client-credentials token on `/me` and on the write endpoint → 403; scope stripping (explicit and parameter-less); `scope` asserted on client-credentials, auth-code and refresh responses; full consent → exchange → `POST` journey with the write scope. New fixture client holds the write scopes + `client_credentials`, mirroring the real integrators. `OAuth2TestHelper` now issues the standard `aud` claim (was a custom `client_id` claim) — also removes the PHP warning `BearerTokenValidator` emitted in every OAuth2 API test.
- Nits from the #184 review: typed closure param + `#[SensitiveParameter]` on `ScopeAwareBearerTokenResponse`; `PatUser::ROLE` / `OAuth2User::ROLE`; docs (API README, CLAUDE.md, token-response examples on the developer page).

## Backward compatibility

- Auth-code / refresh tokens: unchanged.
- Client-credentials tokens: lose the two write scopes they could never use (every `/me/*` call 500'd), and get 403 instead of 500 on `/me/*`. Nothing else changes.

## Test plan

- [x] `composer run phpstan` (max) — no errors
- [x] `composer run cs` — clean
- [x] `lint:container`, `lint:twig`, `cache:warmup` (dev + test)
- [x] `vendor/bin/phpunit --testsuite "Project Test Suite"` — 1799 tests OK
- [x] Guard test proven: reintroducing `ROLE_OAUTH2_SOLVING_TIMES:WRITE` fails `OAuth2ScopeTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uH2n4Y6gPLiYASEJwNr3H