### PR TITLE
Puzzle Picker (3/4): precision filters, collection targeting, remembered filters, presets, share

### DIFF
--- a/docs/features/puzzle-picker/README.md
+++ b/docs/features/puzzle-picker/README.md
@@ -78,7 +78,7 @@ Grouped the way the filter sheet shows them. `★` = requested by Jan, `+` = pro
 - ★ Pieces: chips for the common counts (54, 100, 150, 200, 300, 500, 750, 1000, 1500, 2000+ — production distribution: 500 = 14k, 1000 = 11k, 300 = 3.5k) + custom min–max
 - ★ Brand / manufacturer: multi-select (TomSelect, same `puzzle_search_filter_options` endpoint the search page uses)
 - + "I have about **N** minutes" — time budget. Free: community solo average ≤ N; members: my predicted time ≤ N (same control, better engine, small "uses your prediction" badge). Fits the fortune-wheel mood perfectly ("it's 9 pm, I have an hour").
-- + Community results: "few results (≤ 5) — be a pioneer" / "popular (≥ 50)". `puzzle_statistics.solved_times_count`, indexed.
+- + Community results: "few results (≤ 5) — be a pioneer" / "rated (≥ 20, the MSP-rating threshold)" / "popular (≥ 50)". `puzzle_statistics.solved_times_solo_count` (solo solves, the number the card shows).
 - + (later) Tag — only 767 tag rows in prod, low value today.
 
 **Insights (members)**

--- a/docs/features/puzzle-picker/implementation-plan.md
+++ b/docs/features/puzzle-picker/implementation-plan.md
@@ -150,16 +150,74 @@ The controller computes `insightsAllowed` / `predictionsAllowed` once and hands 
 
 ## PR 3 — Precision filters, collection targeting, remembered filters, presets, share
 
-- Filters: solve-count range, "last solved more than N days/weeks/months ago" (never-solved included,
-  checkbox to require solved-before), my fastest/latest/first `<`/`>` hh:mm, community results
-  (few/popular), custom pieces min–max already in PR 1.
-- Specific collections (members): `collections[]` → `mi.collection_ids && :ids` (system collection =
-  `Collection::SYSTEM_ID` sentinel → `NULL`); "Pick from this collection" on `collections/detail.html.twig`.
-- Session-remembered filters (`puzzle_picker.filters`), auto-applied on bare visit, "Reset" chip.
-- Presets: "Surprise me", "Something new", "Quick one", "Dust off the shelf", "Rating grind" (free);
-  share button with the seeded URL.
-- Tests for each predicate (fixtures have lent/borrowed puzzles), collection multi-select incl. system
-  collection, session restore.
+Everything free unless said otherwise; the criteria strip what a guest / non-member may not use.
+
+- **Solve-count range** replaces the three-way `solved` enum inside the criteria: the state is one range
+  `[solvedMin, solvedMax]` — `solved=never` = [0, 0], `solved=before` = [1, ∞[, `solved_min` /
+  `solved_max` (0–999) refine or override it bound by bound (`solved=before&solved_max=5` → [1, 5];
+  a collision such as `solved=never&solved_min=2` keeps the explicit bound). The public `solved`
+  property is derived (Never / Before / Any — what the radio shows) and the canonical URL keeps
+  `solved=never|before` for the two named shapes, `solved_min` / `solved_max` otherwise. SQL:
+  `COALESCE(s.solve_count_any, 0) + COALESCE(ts.solve_count, 0) >= :solvedMin AND (:solvedMax::int IS NULL
+  OR … <= :solvedMax)`. One chip for the whole constraint (never / before / exact / between / at least /
+  at most), its × clears shape and bounds together.
+- **Not solved since**: `since=<1–999>&since_unit=d|w|m` (days default), `since_require_solved=1`. The
+  query turns it into a timestamp with the clock (`now->modify("-6 months")`) and compares it with my last
+  solve incl. team participation: `(:notSolvedSince::timestamp IS NULL OR GREATEST(s.last_solved_at,
+  ts.last_solved_at) IS NULL OR GREATEST(…) < :notSolvedSince::timestamp) AND (:sinceRequireSolved = 0 OR
+  GREATEST(…) IS NOT NULL)` — never-solved puzzles are included by default (§8 decision 6). Enum
+  `PuzzlePickerSinceUnit`. Chips `puzzle_picker.chips.since.{d,w,m}` / `since_solved.{d,w,m}` (pluralised).
+- **My time**: `my_time=fastest|latest|first`, `my_time_op=lt|gt` (`lt` default), `my_time_minutes`
+  (1–1440; the criteria expose `myTimeSeconds()`). Half a filter is no filter. SQL
+  `AND s.<fastest|latest|first>_seconds <|> :myTimeSeconds` — column and operator come from the enums
+  `PuzzlePickerMyTime` / `PuzzlePickerMyTimeOperator`, never from the request; puzzles without a solo time
+  never match (NULL comparison).
+- **Community results**: `community=few|rated|popular` (`PuzzlePickerCommunity`: solo solves ≤ 5 / ≥ 20 /
+  ≥ 50, `puzzle_statistics.solved_times_solo_count`, `COALESCE(…, 0)` for "few" so puzzles without a
+  statistics row count as few). `puzzle_statistics` is joined before the LIMIT once when either this
+  filter or the community time budget needs it. Free for guests too (puzzle attribute).
+- **Specific collections (members)**: `collections[]` = collection uuid and/or `Collection::SYSTEM_ID`
+  (`__system_collection__`), deduplicated, max 20, stripped for non-members and guests; when set the
+  source is implied `mine`. The `my_items` CTE aggregates `array_remove(array_agg(ci.collection_id),
+  NULL) AS collection_ids, bool_or(ci.collection_id IS NULL) AS has_system`; predicate
+  `((:includeSystemCollection = 1 AND mi.has_system) OR mi.collection_ids && :collectionIds::uuid[])`
+  (custom ids as a Postgres array literal). Borrowed puzzles are on the shelf but in no collection, so
+  they drop out; a foreign collection id matches nothing (only my own items are aggregated). Chips
+  `collection:<id>` replace the shelf chip; the filters modal shows a checkbox list (system first) built
+  by the controller from `GetPlayerCollectionsWithCounts` for members, the locked pattern (lock + members
+  modal button, no button for guests) otherwise. `collections/detail.html.twig` got "Pick from this
+  collection" (`.puzzle-picker-collection-link`) on the viewer's own collections: members deep-link with
+  `collections[]=<id|sentinel>`, non-members get `?source=mine`.
+- **Remembered filters (session)**: `PuzzlePickerController::SESSION_KEY = 'puzzle_picker.filters'`.
+  Signed-in players only — guests never touch the session (`$request->getSession()` is only called when
+  the profile is not null; a test pins "no cookie, session not started" for guest requests). Any request
+  with a query string (chips, form, presets, spin, even a seed-only URL) stores
+  `criteria->withSeed(null)->toQueryParams()`, an empty result removes the key. A bare visit with a stored
+  value builds the criteria from it (`PuzzlePickerCriteria::fromQuery()`), renders on the bare URL without
+  a redirect, shows a "Your last filters" marker (`.puzzle-picker-remembered`) and the "Reset" link
+  (`.puzzle-picker-reset`) points to `?reset=1`, which removes the key and renders the defaults (no
+  redirect). The modal footer / empty-state reset links use the same `reset_url` (bare URL for guests).
+  The empty state's "Pick from all puzzles" now keeps the other filters and only widens the source
+  (collections dropped, since they imply the shelf).
+- **Presets** (`PuzzlePickerPreset` enum, rendered from `presets` + `active_preset` passed by the
+  controller): Surprise me (`source=mine`), Something new (`source=mine&solved=never`), Quick one
+  (`predicted_max=60`), Dust off the shelf (`since=6&since_unit=m&since_require_solved=1`), Rating grind
+  (`pieces[]=500&solved=never&community=rated`), Beat my record (`solved=before&gap=slower&order=gap_slower`,
+  predictions only). `PuzzlePickerCriteria::activePreset()` compares the normalised query params
+  (seed aside), skipping presets the player is not eligible for; the bare default highlights "Surprise me".
+  Every chip is `rel="nofollow"`, `data-preset="<value>"`.
+- **Share**: `_share_button.html.twig` in `_results.html.twig` with `url('puzzle_picker',
+  criteria.toQueryParams(seed))` — the seeded URL of the current draw.
+- **Not shipped (roadmap)**: the free "longest not solved first" / "fewest solves first" pick orders from
+  README §3, hh:mm inputs for the my-time threshold (a minutes input is enough for now).
+- Tests: `tests/Value/PuzzlePickerCriteriaTest.php` (range grammar, since, my time, community, collections
+  gating, chips, presets), `tests/Query/GetPuzzlePickerSuggestionsTest.php` (every predicate against the
+  fixtures — PLAYER_REGULAR's 11 solved puzzles, PLAYER_PRIVATE's team participation, PLAYER_WITH_STRIPE's
+  collections incl. the system sentinel and borrowed / lent-out puzzles, community thresholds by editing
+  `puzzle_statistics` inside the test transaction), `tests/Controller/PuzzlePickerControllerTest.php`
+  (chips + form state, presets, share URL, session memory / reset / seed-only forgetting, guest
+  session-free, member collections list, locked list) and `tests/Controller/CollectionDetailControllerTest.php`
+  ("Pick from this collection" for member / non-member / other's collection / guest + the deep link).
 
 ## PR 4 — My times (+ predictions) in collections
 

--- a/src/Controller/PuzzlePickerController.php
+++ b/src/Controller/PuzzlePickerController.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace SpeedPuzzling\Web\Controller;
 
+use SpeedPuzzling\Web\Entity\Collection;
 use SpeedPuzzling\Web\Query\GetManufacturers;
+use SpeedPuzzling\Web\Query\GetPlayerCollectionsWithCounts;
 use SpeedPuzzling\Web\Query\GetPlayerPredictions;
 use SpeedPuzzling\Web\Query\GetPuzzlePickerSuggestions;
+use SpeedPuzzling\Web\Results\PlayerProfile;
 use SpeedPuzzling\Web\Results\PuzzlePickerSuggestion;
 use SpeedPuzzling\Web\Services\RetrieveLoggedUserProfile;
 use SpeedPuzzling\Web\Value\PuzzlePickerCriteria;
+use SpeedPuzzling\Web\Value\PuzzlePickerPreset;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * "What should I solve next?" — the puzzle picker.
@@ -22,20 +27,30 @@ use Symfony\Component\Routing\Attribute\Route;
  * shelf, their history, their filters); guests get an indexable landing page
  * with a live demo drawn from all approved puzzles. The seed is generated
  * server-side and never redirected into the URL, so the bare URL stays the
- * canonical one — it only travels in the "Pick another" links.
+ * canonical one — it only travels in the "Pick another" / share links.
  *
- * Insights layer: members get difficulty tiers; members who have not opted out
- * of time predictions additionally get the prediction row on the card and the
- * gap / order / personal-budget filters. Non-eligible input is stripped by the
- * criteria, so the gating lives in one place.
+ * Insights layer: members get difficulty tiers and specific collections;
+ * members who have not opted out of time predictions additionally get the
+ * prediction row on the card and the gap / order / personal-budget filters.
+ * Non-eligible input is stripped by the criteria, so the gating lives in one place.
+ *
+ * Remembered filters: for signed-in players the last used filters are kept in
+ * the session (`puzzle_picker.filters`) after every request that carries query
+ * parameters, and applied again on a bare visit — rendered on the bare URL, no
+ * redirect, with a "Reset" link to `?reset=1` that forgets them. Guests never
+ * touch the session: anonymous requests must stay session-free.
  */
 final class PuzzlePickerController extends AbstractController
 {
+    public const string SESSION_KEY = 'puzzle_picker.filters';
+
     public function __construct(
         readonly private RetrieveLoggedUserProfile $retrieveLoggedUserProfile,
         readonly private GetPuzzlePickerSuggestions $getPuzzlePickerSuggestions,
         readonly private GetPlayerPredictions $getPlayerPredictions,
         readonly private GetManufacturers $getManufacturers,
+        readonly private GetPlayerCollectionsWithCounts $getPlayerCollectionsWithCounts,
+        readonly private TranslatorInterface $translator,
     ) {
     }
 
@@ -63,6 +78,33 @@ final class PuzzlePickerController extends AbstractController
             insightsAllowed: $insightsAllowed,
             predictionsAllowed: $predictionsAllowed,
         );
+        $filtersRemembered = false;
+
+        if ($profile !== null) {
+            $session = $request->getSession();
+
+            if ($request->query->has('reset')) {
+                $session->remove(self::SESSION_KEY);
+            } elseif ($request->query->count() === 0) {
+                $stored = $session->get(self::SESSION_KEY);
+
+                if (is_array($stored) && $stored !== []) {
+                    $criteria = PuzzlePickerCriteria::fromQuery($stored, true, $insightsAllowed, $predictionsAllowed);
+                    $filtersRemembered = $criteria->isDefault() === false;
+                }
+            } else {
+                // Any query string is a filter change (chips, form, presets, spin) - remember it
+                // without the seed; a return to the bare defaults forgets the previous filters
+                $filters = $criteria->withSeed(null)->toQueryParams();
+
+                if ($filters === []) {
+                    $session->remove(self::SESSION_KEY);
+                } else {
+                    $session->set(self::SESSION_KEY, $filters);
+                }
+            }
+        }
+
         $seed = $criteria->seed ?? self::generateSeed();
 
         $pick = $this->getPuzzlePickerSuggestions->pick(
@@ -83,6 +125,13 @@ final class PuzzlePickerController extends AbstractController
             );
         }
 
+        $collections = $profile !== null && $insightsAllowed ? $this->collectionsOf($profile) : [];
+        $collectionNames = [];
+
+        foreach ($collections as $collection) {
+            $collectionNames[$collection['id']] = $collection['name'];
+        }
+
         return $this->render($profile !== null ? 'puzzle_picker/index.html.twig' : 'puzzle_picker/landing.html.twig', [
             'criteria' => $criteria,
             'seed' => $seed,
@@ -90,7 +139,47 @@ final class PuzzlePickerController extends AbstractController
             'pick' => $pick,
             'predictions' => $predictions,
             'brand_names' => $this->getManufacturers->namesByIds($criteria->brandIds),
+            'collections' => $collections,
+            'collection_names' => $collectionNames,
+            'presets' => PuzzlePickerPreset::cases(),
+            'active_preset' => $criteria->activePreset(),
+            'filters_remembered' => $filtersRemembered,
+            'reset_url' => $profile !== null
+                ? $this->generateUrl('puzzle_picker', ['reset' => 1])
+                : $this->generateUrl('puzzle_picker'),
         ]);
+    }
+
+    /**
+     * The player's collections for the "only these collections" checkbox list:
+     * the system collection first (its id is the sentinel - it has no row), then
+     * the custom ones.
+     *
+     * @return list<array{id: string, name: string, count: int, system: bool}>
+     */
+    private function collectionsOf(PlayerProfile $profile): array
+    {
+        $collections = [[
+            'id' => Collection::SYSTEM_ID,
+            'name' => $this->translator->trans('collections.system_name'),
+            'count' => $this->getPlayerCollectionsWithCounts->countSystemCollection($profile->playerId),
+            'system' => true,
+        ]];
+
+        foreach ($this->getPlayerCollectionsWithCounts->byPlayerId($profile->playerId) as $collection) {
+            if ($collection->collectionId === null) {
+                continue;
+            }
+
+            $collections[] = [
+                'id' => $collection->collectionId,
+                'name' => $collection->name,
+                'count' => $collection->itemCount,
+                'system' => false,
+            ];
+        }
+
+        return $collections;
     }
 
     private static function generateSeed(): string

--- a/src/Query/GetPuzzlePickerSuggestions.php
+++ b/src/Query/GetPuzzlePickerSuggestions.php
@@ -30,6 +30,15 @@ use SpeedPuzzling\Web\Value\PuzzlePickerOrder;
  * non-suspicious, timed solves; "when solved" = COALESCE(finished_at, tracked_at).
  * A null player (guest) leaves every personal CTE empty.
  *
+ * Precision filters (all null-tolerant, so an unset filter costs nothing):
+ * the solve-count range covers "never" / "solved before" / "between N and M";
+ * "not solved since" compares my last solve (incl. team solves) with a
+ * timestamp computed from the clock and keeps never-solved puzzles unless asked
+ * not to; "my time" compares one of my solo times with a threshold (no solo
+ * time = no match); "only these collections" reads the collection ids
+ * aggregated per item, the system collection being the NULL collection_id
+ * (has_system); "community results" needs puzzle_statistics before the LIMIT.
+ *
  * Insights layer (members, design doc §6.4): only when an insights filter is
  * active are puzzle_difficulty / player_baseline / puzzle_statistics joined
  * *before* the LIMIT. My personal predictions (bulk GetPlayerPredictions, PHP)
@@ -48,17 +57,42 @@ readonly final class GetPuzzlePickerSuggestions
 
     public function pick(PuzzlePickerCriteria $criteria, null|string $playerId, int $limit, int $offset = 0): PuzzlePickerPick
     {
+        $now = $this->clock->now();
         $params = [
-            'now' => $this->clock->now()->format('Y-m-d H:i:s'),
+            'now' => $now->format('Y-m-d H:i:s'),
             'playerId' => $playerId,
             'source' => $criteria->source->value,
-            'solved' => $criteria->solved->value,
             'includeLentOut' => $criteria->includeLentOut ? 1 : 0,
+            'solvedMin' => $criteria->solvedMin,
+            'solvedMax' => $criteria->solvedMax,
+            'notSolvedSince' => $criteria->sinceAmount !== null
+                ? $now->modify($criteria->sinceUnit->modifier($criteria->sinceAmount))->format('Y-m-d H:i:s')
+                : null,
+            'sinceRequireSolved' => $criteria->sinceRequireSolved ? 1 : 0,
             'seed' => $criteria->seed ?? '',
             'limit' => $limit,
             'offset' => $offset,
         ];
         $types = [];
+
+        // --- Free precision filters: my times, my collections, community results ---
+
+        $myTimeCondition = '';
+
+        if ($criteria->myTime !== null && $criteria->myTimeSeconds() !== null) {
+            // Column and operator come from enums, never from the request
+            $myTimeCondition = sprintf('AND s.%s %s :myTimeSeconds', $criteria->myTime->column(), $criteria->myTimeOperator->sql());
+            $params['myTimeSeconds'] = $criteria->myTimeSeconds();
+        }
+
+        $collectionsCondition = '';
+
+        if ($criteria->collectionIds !== []) {
+            // The system collection has no id (collection_id IS NULL), hence the has_system flag
+            $collectionsCondition = 'AND ((:includeSystemCollection = 1 AND mi.has_system) OR mi.collection_ids && :collectionIds::uuid[])';
+            $params['includeSystemCollection'] = $criteria->includesSystemCollection() ? 1 : 0;
+            $params['collectionIds'] = '{' . implode(',', $criteria->customCollectionIds()) . '}';
+        }
 
         $piecesCondition = '';
 
@@ -87,6 +121,7 @@ readonly final class GetPuzzlePickerSuggestions
         $needsPredictions = $playerId !== null && $criteria->needsPredictions();
         $needsDifficulty = $needsPredictions || $criteria->difficultyTiers !== [];
         $needsCommunityAverage = $criteria->predictedMaxMinutes !== null && $criteria->usesPersonalPrediction() === false;
+        $needsStatistics = $needsCommunityAverage || $criteria->community !== null;
 
         $insightsJoins = '';
         $insightsConditions = '';
@@ -104,10 +139,17 @@ readonly final class GetPuzzlePickerSuggestions
             $types['difficultyTiers'] = ArrayParameterType::INTEGER;
         }
 
-        if ($needsCommunityAverage) {
+        if ($needsStatistics) {
             $insightsJoins .= "\n    LEFT JOIN puzzle_statistics ps ON ps.puzzle_id = p.id";
+        }
+
+        if ($needsCommunityAverage) {
             $insightsConditions .= "\n        AND ps.average_time_solo <= :predictedMaxSeconds";
             $params['predictedMaxSeconds'] = $criteria->predictedMaxMinutes * 60;
+        }
+
+        if ($criteria->community !== null) {
+            $insightsConditions .= "\n        AND " . $criteria->community->sqlCondition('ps.solved_times_solo_count');
         }
 
         if ($playerId !== null && $needsPredictions) {
@@ -183,7 +225,10 @@ my_team_solves AS (
     GROUP BY pst.puzzle_id
 ),
 my_items AS (
-    SELECT ci.puzzle_id, array_agg(ci.collection_id) AS collection_ids
+    SELECT
+        ci.puzzle_id,
+        array_remove(array_agg(ci.collection_id), NULL) AS collection_ids,
+        bool_or(ci.collection_id IS NULL) AS has_system
     FROM collection_item ci
     WHERE :playerId::uuid IS NOT NULL
         AND ci.player_id = :playerId
@@ -229,11 +274,16 @@ picked AS (
             OR (:source = 'not_mine' AND mi.puzzle_id IS NULL)
         )
         AND (:includeLentOut = 1 OR lo.puzzle_id IS NULL)
+        {$collectionsCondition}
+        AND COALESCE(s.solve_count_any, 0) + COALESCE(ts.solve_count, 0) >= :solvedMin
+        AND (:solvedMax::int IS NULL OR COALESCE(s.solve_count_any, 0) + COALESCE(ts.solve_count, 0) <= :solvedMax)
         AND (
-            :solved = 'any'
-            OR (:solved = 'never' AND COALESCE(s.solve_count_any, 0) + COALESCE(ts.solve_count, 0) = 0)
-            OR (:solved = 'before' AND COALESCE(s.solve_count_any, 0) + COALESCE(ts.solve_count, 0) > 0)
+            :notSolvedSince::timestamp IS NULL
+            OR GREATEST(s.last_solved_at, ts.last_solved_at) IS NULL
+            OR GREATEST(s.last_solved_at, ts.last_solved_at) < :notSolvedSince::timestamp
         )
+        AND (:sinceRequireSolved = 0 OR GREATEST(s.last_solved_at, ts.last_solved_at) IS NOT NULL)
+        {$myTimeCondition}
         {$piecesCondition}
         {$brandCondition}{$insightsConditions}
     ORDER BY {$innerOrder}

--- a/src/Value/PuzzlePickerActiveFilter.php
+++ b/src/Value/PuzzlePickerActiveFilter.php
@@ -12,11 +12,11 @@ final readonly class PuzzlePickerActiveFilter
 {
     /**
      * @param string $key Unique within one criteria, e.g. "source", "pieces:500", "brand:<uuid>"
-     * @param string $type One of "source", "solved", "pieces", "brand", "lent", "predicted_max", "difficulty", "gap", "order"
-     * @param string $translationKey Chip label; brand chips render the manufacturer name instead
+     * @param string $type One of "collection", "source", "solved", "since", "my_time", "pieces", "brand", "lent", "community", "predicted_max", "difficulty", "gap", "order"
+     * @param string $translationKey Chip label; brand / collection chips render the manufacturer / collection name instead
      * @param array<string, int|string> $translationParameters
      * @param array<string, mixed> $queryParametersWithoutThis
-     * @param null|string $value Raw value for label lookups (manufacturer id for brand chips, tier value for difficulty chips)
+     * @param null|string $value Raw value for label lookups (manufacturer id for brand chips, collection id or system sentinel for collection chips, tier value for difficulty chips)
      */
     public function __construct(
         public string $key,

--- a/src/Value/PuzzlePickerCommunity.php
+++ b/src/Value/PuzzlePickerCommunity.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+/**
+ * "Community results" filter of the puzzle picker, on the number of solo
+ * solves the puzzle has (puzzle_statistics.solved_times_solo_count): few
+ * results = be a pioneer, rated = enough solvers for the MSP rating (the 20
+ * public solvers MspRatingCalculator asks for), popular = a well-known puzzle.
+ */
+enum PuzzlePickerCommunity: string
+{
+    case Few = 'few';
+    case Rated = 'rated';
+    case Popular = 'popular';
+
+    public const int FEW_MAX_SOLVES = 5;
+
+    public const int RATED_MIN_SOLVES = 20;
+
+    public const int POPULAR_MIN_SOLVES = 50;
+
+    /**
+     * SQL predicate on the given solo-solves column; a puzzle without a
+     * statistics row has zero solves and therefore counts as "few".
+     */
+    public function sqlCondition(string $column): string
+    {
+        return match ($this) {
+            self::Few => sprintf('COALESCE(%s, 0) <= %d', $column, self::FEW_MAX_SOLVES),
+            self::Rated => sprintf('%s >= %d', $column, self::RATED_MIN_SOLVES),
+            self::Popular => sprintf('%s >= %d', $column, self::POPULAR_MIN_SOLVES),
+        };
+    }
+
+    /**
+     * The number the chip / option label quotes.
+     */
+    public function threshold(): int
+    {
+        return match ($this) {
+            self::Few => self::FEW_MAX_SOLVES,
+            self::Rated => self::RATED_MIN_SOLVES,
+            self::Popular => self::POPULAR_MIN_SOLVES,
+        };
+    }
+}

--- a/src/Value/PuzzlePickerCriteria.php
+++ b/src/Value/PuzzlePickerCriteria.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Value;
 
 use Ramsey\Uuid\Uuid;
+use SpeedPuzzling\Web\Entity\Collection;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -21,11 +22,25 @@ use Symfony\Component\HttpFoundation\Request;
  * `-B` (at most). The filter form additionally posts `pieces_min` / `pieces_max`,
  * which are folded into the same list, so the canonical URL only ever uses `pieces[]`.
  *
+ * My history: the solved state is one solve-count range — `solved=never` is
+ * [0, 0], `solved=before` is [1, ∞[, and `solved_min` / `solved_max` refine or
+ * override it bound by bound (the canonical URL uses `solved=` for the two
+ * named shapes and the numeric bounds otherwise); `since` + `since_unit`
+ * (`d`|`w`|`m`) keep puzzles I have not solved for that long — never-solved
+ * puzzles included unless `since_require_solved=1`; `my_time` (fastest /
+ * latest / first) + `my_time_op` (`lt`|`gt`) + `my_time_minutes` compare one
+ * of my solo times with a threshold.
+ *
+ * Puzzle: `community` (`few`|`rated`|`popular`) on the number of solo solves the
+ * community has on the puzzle.
+ *
  * Insights layer (members): `difficulty[]` (tiers 1–6), `gap` + `gap_min` (my
- * fastest vs. my prediction, minutes), `order` (`gap_slower` / `gap_faster`) and
- * `predicted_max` — the "I have about N minutes" budget, which is free for
- * everyone but switches engine: my predicted time for members with predictions,
- * the community solo average otherwise (see usesPersonalPrediction()).
+ * fastest vs. my prediction, minutes), `order` (`gap_slower` / `gap_faster`),
+ * `collections[]` (only these collections of mine — a uuid or the system
+ * collection sentinel; implies source `mine`) and `predicted_max` — the "I have
+ * about N minutes" budget, which is free for everyone but switches engine: my
+ * predicted time for members with predictions, the community solo average
+ * otherwise (see usesPersonalPrediction()).
  */
 final readonly class PuzzlePickerCriteria
 {
@@ -35,7 +50,17 @@ final readonly class PuzzlePickerCriteria
 
     public const int MAX_BRANDS = 20;
 
+    public const int MAX_COLLECTIONS = 20;
+
     public const int MAX_PIECES = 100000;
+
+    public const int MAX_SOLVE_COUNT = 999;
+
+    public const int MAX_SINCE_AMOUNT = 999;
+
+    public const int MIN_MY_TIME_MINUTES = 1;
+
+    public const int MAX_MY_TIME_MINUTES = 1440;
 
     public const int MIN_GAP_MINUTES = 1;
 
@@ -51,16 +76,34 @@ final readonly class PuzzlePickerCriteria
     private const string SEED_PATTERN = '/^[a-z0-9]{4,16}$/';
 
     /**
+     * Named shape of the solve-count range: Never = [0, 0], Before = [1, ∞[,
+     * Any = everything else (the radio the filter form shows as checked).
+     */
+    public PuzzlePickerSolved $solved;
+
+    /**
+     * @param int $solvedMin Lower bound of my solve count (0 = no bound)
+     * @param null|int $solvedMax Upper bound of my solve count (null = no bound)
      * @param list<array{null|int, null|int}> $pieces
      * @param list<string> $brandIds
+     * @param list<string> $collectionIds Collection uuids and/or Collection::SYSTEM_ID
      * @param list<int> $difficultyTiers
      */
     private function __construct(
         public PuzzlePickerSource $source,
-        public PuzzlePickerSolved $solved,
+        public int $solvedMin,
+        public null|int $solvedMax,
+        public null|int $sinceAmount,
+        public PuzzlePickerSinceUnit $sinceUnit,
+        public bool $sinceRequireSolved,
+        public null|PuzzlePickerMyTime $myTime,
+        public PuzzlePickerMyTimeOperator $myTimeOperator,
+        public null|int $myTimeMinutes,
         public array $pieces,
         public array $brandIds,
         public bool $includeLentOut,
+        public array $collectionIds,
+        public null|PuzzlePickerCommunity $community,
         public array $difficultyTiers,
         public null|PuzzlePickerGap $gap,
         public null|int $gapMinMinutes,
@@ -71,31 +114,51 @@ final readonly class PuzzlePickerCriteria
         public bool $insightsAllowed,
         public bool $predictionsAllowed,
     ) {
+        $this->solved = self::solvedShapeOf($solvedMin, $solvedMax);
     }
 
     /**
-     * @param bool $insightsAllowed Active membership: difficulty tiers
+     * @param bool $insightsAllowed Active membership: difficulty tiers, specific collections
      * @param bool $predictionsAllowed Active membership without the time-predictions opt-out: gap filter, gap orders, personal time budget
      */
     public static function fromRequest(Request $request, bool $isAuthenticated, bool $insightsAllowed = false, bool $predictionsAllowed = false): self
     {
-        $query = $request->query->all();
+        return self::fromQuery($request->query->all(), $isAuthenticated, $insightsAllowed, $predictionsAllowed);
+    }
 
+    /**
+     * Same as fromRequest() for a raw query array — the shape stored in the
+     * session by "remember my last filters".
+     *
+     * @param array<mixed> $query
+     */
+    public static function fromQuery(array $query, bool $isAuthenticated, bool $insightsAllowed = false, bool $predictionsAllowed = false): self
+    {
         return self::fromUserInput(
-            source: is_string($query['source'] ?? null) ? $query['source'] : null,
-            solved: is_string($query['solved'] ?? null) ? $query['solved'] : null,
+            source: self::stringInput($query['source'] ?? null),
+            solved: self::stringInput($query['solved'] ?? null),
             pieces: self::listInput($query['pieces'] ?? null),
-            piecesMin: is_string($query['pieces_min'] ?? null) ? $query['pieces_min'] : null,
-            piecesMax: is_string($query['pieces_max'] ?? null) ? $query['pieces_max'] : null,
+            piecesMin: self::stringInput($query['pieces_min'] ?? null),
+            piecesMax: self::stringInput($query['pieces_max'] ?? null),
             brandIds: self::listInput($query['brand'] ?? null),
             includeLentOut: ($query['lent'] ?? null) === '1',
-            difficultyTiers: self::listInput($query['difficulty'] ?? null),
-            gap: is_string($query['gap'] ?? null) ? $query['gap'] : null,
-            gapMinMinutes: is_string($query['gap_min'] ?? null) ? $query['gap_min'] : null,
-            predictedMaxMinutes: is_string($query['predicted_max'] ?? null) ? $query['predicted_max'] : null,
-            order: is_string($query['order'] ?? null) ? $query['order'] : null,
-            seed: is_string($query['seed'] ?? null) ? $query['seed'] : null,
+            seed: self::stringInput($query['seed'] ?? null),
             isAuthenticated: $isAuthenticated,
+            solvedMin: self::stringInput($query['solved_min'] ?? null),
+            solvedMax: self::stringInput($query['solved_max'] ?? null),
+            since: self::stringInput($query['since'] ?? null),
+            sinceUnit: self::stringInput($query['since_unit'] ?? null),
+            sinceRequireSolved: ($query['since_require_solved'] ?? null) === '1',
+            myTime: self::stringInput($query['my_time'] ?? null),
+            myTimeOperator: self::stringInput($query['my_time_op'] ?? null),
+            myTimeMinutes: self::stringInput($query['my_time_minutes'] ?? null),
+            collectionIds: self::listInput($query['collections'] ?? null),
+            community: self::stringInput($query['community'] ?? null),
+            difficultyTiers: self::listInput($query['difficulty'] ?? null),
+            gap: self::stringInput($query['gap'] ?? null),
+            gapMinMinutes: self::stringInput($query['gap_min'] ?? null),
+            predictedMaxMinutes: self::stringInput($query['predicted_max'] ?? null),
+            order: self::stringInput($query['order'] ?? null),
             insightsAllowed: $insightsAllowed,
             predictionsAllowed: $predictionsAllowed,
         );
@@ -104,6 +167,7 @@ final readonly class PuzzlePickerCriteria
     /**
      * @param array<mixed> $pieces
      * @param array<mixed> $brandIds
+     * @param array<mixed> $collectionIds
      * @param array<mixed> $difficultyTiers
      */
     public static function fromUserInput(
@@ -116,6 +180,16 @@ final readonly class PuzzlePickerCriteria
         bool $includeLentOut,
         null|string $seed,
         bool $isAuthenticated,
+        null|string $solvedMin = null,
+        null|string $solvedMax = null,
+        null|string $since = null,
+        null|string $sinceUnit = null,
+        bool $sinceRequireSolved = false,
+        null|string $myTime = null,
+        null|string $myTimeOperator = null,
+        null|string $myTimeMinutes = null,
+        array $collectionIds = [],
+        null|string $community = null,
         array $difficultyTiers = [],
         null|string $gap = null,
         null|string $gapMinMinutes = null,
@@ -126,17 +200,43 @@ final readonly class PuzzlePickerCriteria
     ): self {
         $defaultSource = self::defaultSourceFor($isAuthenticated);
         $sourceValue = $source !== null ? PuzzlePickerSource::tryFrom($source) ?? $defaultSource : $defaultSource;
-        $solvedValue = $solved !== null ? PuzzlePickerSolved::tryFrom($solved) ?? PuzzlePickerSolved::Any : PuzzlePickerSolved::Any;
+        [$solvedMinValue, $solvedMaxValue] = self::normalizeSolveCountRange($solved, $solvedMin, $solvedMax);
+        $sinceAmountValue = self::parseInt($since, 1, self::MAX_SINCE_AMOUNT);
+        $sinceUnitValue = $sinceUnit !== null ? PuzzlePickerSinceUnit::tryFrom($sinceUnit) ?? PuzzlePickerSinceUnit::Day : PuzzlePickerSinceUnit::Day;
+        $myTimeValue = $myTime !== null ? PuzzlePickerMyTime::tryFrom($myTime) : null;
+        $myTimeOperatorValue = $myTimeOperator !== null ? PuzzlePickerMyTimeOperator::tryFrom($myTimeOperator) ?? PuzzlePickerMyTimeOperator::Under : PuzzlePickerMyTimeOperator::Under;
+        $myTimeMinutesValue = self::parseInt($myTimeMinutes, self::MIN_MY_TIME_MINUTES, self::MAX_MY_TIME_MINUTES);
+        $communityValue = $community !== null ? PuzzlePickerCommunity::tryFrom($community) : null;
         $gapValue = $gap !== null ? PuzzlePickerGap::tryFrom($gap) : null;
         $orderValue = $order !== null ? PuzzlePickerOrder::tryFrom($order) ?? PuzzlePickerOrder::Random : PuzzlePickerOrder::Random;
-        $gapMinValue = $gapValue !== null ? self::parseMinutes($gapMinMinutes, self::MIN_GAP_MINUTES, self::MAX_GAP_MINUTES) : null;
-        $predictedMaxValue = self::parseMinutes($predictedMaxMinutes, self::MIN_PREDICTED_MINUTES, self::MAX_PREDICTED_MINUTES);
+        $gapMinValue = $gapValue !== null ? self::parseInt($gapMinMinutes, self::MIN_GAP_MINUTES, self::MAX_GAP_MINUTES) : null;
+        $predictedMaxValue = self::parseInt($predictedMaxMinutes, self::MIN_PREDICTED_MINUTES, self::MAX_PREDICTED_MINUTES);
+
+        // The "my time" filter needs both the metric and the threshold; the
+        // "since" checkbox is meaningless without a period.
+        if ($myTimeValue === null || $myTimeMinutesValue === null) {
+            $myTimeValue = null;
+            $myTimeMinutesValue = null;
+            $myTimeOperatorValue = PuzzlePickerMyTimeOperator::Under;
+        }
+
+        if ($sinceAmountValue === null) {
+            $sinceUnitValue = PuzzlePickerSinceUnit::Day;
+            $sinceRequireSolved = false;
+        }
 
         // Guests have no shelf and no history: personal filters are dropped
         // server-side, so a crafted URL cannot reach the personal branches.
         if ($isAuthenticated === false) {
             $sourceValue = PuzzlePickerSource::Any;
-            $solvedValue = PuzzlePickerSolved::Any;
+            $solvedMinValue = 0;
+            $solvedMaxValue = null;
+            $sinceAmountValue = null;
+            $sinceUnitValue = PuzzlePickerSinceUnit::Day;
+            $sinceRequireSolved = false;
+            $myTimeValue = null;
+            $myTimeOperatorValue = PuzzlePickerMyTimeOperator::Under;
+            $myTimeMinutesValue = null;
             $includeLentOut = false;
             $insightsAllowed = false;
         }
@@ -146,6 +246,7 @@ final readonly class PuzzlePickerCriteria
         // The time budget survives — it just runs on the community engine.
         if ($insightsAllowed === false) {
             $difficultyTiers = [];
+            $collectionIds = [];
             $predictionsAllowed = false;
         }
 
@@ -155,12 +256,28 @@ final readonly class PuzzlePickerCriteria
             $orderValue = PuzzlePickerOrder::Random;
         }
 
+        $collectionIdsValue = self::normalizeCollectionIds($collectionIds);
+
+        // Specific collections are a subset of my shelf
+        if ($collectionIdsValue !== []) {
+            $sourceValue = PuzzlePickerSource::Mine;
+        }
+
         return new self(
             source: $sourceValue,
-            solved: $solvedValue,
+            solvedMin: $solvedMinValue,
+            solvedMax: $solvedMaxValue,
+            sinceAmount: $sinceAmountValue,
+            sinceUnit: $sinceUnitValue,
+            sinceRequireSolved: $sinceRequireSolved,
+            myTime: $myTimeValue,
+            myTimeOperator: $myTimeOperatorValue,
+            myTimeMinutes: $myTimeMinutesValue,
             pieces: self::normalizePieces($pieces, $piecesMin, $piecesMax),
             brandIds: self::normalizeBrandIds($brandIds),
             includeLentOut: $includeLentOut,
+            collectionIds: $collectionIdsValue,
+            community: $communityValue,
             difficultyTiers: self::normalizeDifficultyTiers($difficultyTiers),
             gap: $gapValue,
             gapMinMinutes: $gapMinValue,
@@ -175,31 +292,21 @@ final readonly class PuzzlePickerCriteria
 
     public function withSeed(null|string $seed): self
     {
-        return new self(
-            source: $this->source,
-            solved: $this->solved,
-            pieces: $this->pieces,
-            brandIds: $this->brandIds,
-            includeLentOut: $this->includeLentOut,
-            difficultyTiers: $this->difficultyTiers,
-            gap: $this->gap,
-            gapMinMinutes: $this->gapMinMinutes,
-            predictedMaxMinutes: $this->predictedMaxMinutes,
-            order: $this->order,
-            seed: $seed,
-            isAuthenticated: $this->isAuthenticated,
-            insightsAllowed: $this->insightsAllowed,
-            predictionsAllowed: $this->predictionsAllowed,
-        );
+        return $this->with(seed: $seed, replaceSeed: true);
     }
 
     public function isDefault(): bool
     {
         return $this->source === $this->defaultSource()
-            && $this->solved === PuzzlePickerSolved::Any
+            && $this->solvedMin === 0
+            && $this->solvedMax === null
+            && $this->sinceAmount === null
+            && $this->myTime === null
             && $this->pieces === []
             && $this->brandIds === []
             && $this->includeLentOut === false
+            && $this->collectionIds === []
+            && $this->community === null
             && $this->difficultyTiers === []
             && $this->gap === null
             && $this->predictedMaxMinutes === null
@@ -214,8 +321,12 @@ final readonly class PuzzlePickerCriteria
     public function hasPersonalFilters(): bool
     {
         return $this->source !== PuzzlePickerSource::Any
-            || $this->solved !== PuzzlePickerSolved::Any
+            || $this->solvedMin !== 0
+            || $this->solvedMax !== null
+            || $this->sinceAmount !== null
+            || $this->myTime !== null
             || $this->includeLentOut
+            || $this->collectionIds !== []
             || $this->gap !== null
             || $this->order->isGapOrder();
     }
@@ -249,6 +360,61 @@ final readonly class PuzzlePickerCriteria
     }
 
     /**
+     * Threshold of the "my time" filter in seconds, null when the filter is off.
+     */
+    public function myTimeSeconds(): null|int
+    {
+        return $this->myTimeMinutes !== null ? $this->myTimeMinutes * 60 : null;
+    }
+
+    /**
+     * True when the system collection ("My puzzles") is among the picked collections.
+     */
+    public function includesSystemCollection(): bool
+    {
+        return in_array(Collection::SYSTEM_ID, $this->collectionIds, true);
+    }
+
+    /**
+     * The picked custom collections (uuids only, without the system sentinel).
+     *
+     * @return list<string>
+     */
+    public function customCollectionIds(): array
+    {
+        return array_values(array_filter($this->collectionIds, static fn (string $id): bool => $id !== Collection::SYSTEM_ID));
+    }
+
+    /**
+     * The preset whose filters equal the current criteria (seed aside), if
+     * any — the chip to highlight. Presets a player is not eligible for are
+     * never reported, so a stripped "Beat my record" cannot masquerade as
+     * plain "solved before".
+     */
+    public function activePreset(): null|PuzzlePickerPreset
+    {
+        if ($this->isAuthenticated === false) {
+            return null;
+        }
+
+        $current = $this->withSeed(null)->toQueryParams();
+
+        foreach (PuzzlePickerPreset::cases() as $preset) {
+            if ($preset->requiresPredictions() && $this->predictionsAllowed === false) {
+                continue;
+            }
+
+            $presetCriteria = self::fromQuery($preset->queryParams(), $this->isAuthenticated, $this->insightsAllowed, $this->predictionsAllowed);
+
+            if ($presetCriteria->toQueryParams() === $current) {
+                return $preset;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Query parameters reproducing this state. Only non-default values are
      * emitted, so bare defaults produce an empty array (the canonical URL).
      *
@@ -262,8 +428,40 @@ final readonly class PuzzlePickerCriteria
             $parameters['source'] = $this->source->value;
         }
 
+        // The two named shapes keep their short spelling; every other range
+        // is spelled out bound by bound
         if ($this->solved !== PuzzlePickerSolved::Any) {
             $parameters['solved'] = $this->solved->value;
+        } else {
+            if ($this->solvedMin !== 0) {
+                $parameters['solved_min'] = (string) $this->solvedMin;
+            }
+
+            if ($this->solvedMax !== null) {
+                $parameters['solved_max'] = (string) $this->solvedMax;
+            }
+        }
+
+        if ($this->sinceAmount !== null) {
+            $parameters['since'] = (string) $this->sinceAmount;
+
+            if ($this->sinceUnit !== PuzzlePickerSinceUnit::Day) {
+                $parameters['since_unit'] = $this->sinceUnit->value;
+            }
+
+            if ($this->sinceRequireSolved) {
+                $parameters['since_require_solved'] = '1';
+            }
+        }
+
+        if ($this->myTime !== null && $this->myTimeMinutes !== null) {
+            $parameters['my_time'] = $this->myTime->value;
+
+            if ($this->myTimeOperator !== PuzzlePickerMyTimeOperator::Under) {
+                $parameters['my_time_op'] = $this->myTimeOperator->value;
+            }
+
+            $parameters['my_time_minutes'] = (string) $this->myTimeMinutes;
         }
 
         if ($this->pieces !== []) {
@@ -276,6 +474,14 @@ final readonly class PuzzlePickerCriteria
 
         if ($this->includeLentOut) {
             $parameters['lent'] = '1';
+        }
+
+        if ($this->collectionIds !== []) {
+            $parameters['collections'] = $this->collectionIds;
+        }
+
+        if ($this->community !== null) {
+            $parameters['community'] = $this->community->value;
         }
 
         if ($this->difficultyTiers !== []) {
@@ -316,7 +522,19 @@ final readonly class PuzzlePickerCriteria
     {
         $filters = [];
 
-        if ($this->source !== PuzzlePickerSource::Any) {
+        // Specific collections replace the shelf chip - they are the shelf
+        if ($this->collectionIds !== []) {
+            foreach ($this->collectionIds as $collectionId) {
+                $filters[] = new PuzzlePickerActiveFilter(
+                    key: 'collection:' . $collectionId,
+                    type: 'collection',
+                    translationKey: $collectionId === Collection::SYSTEM_ID ? 'collections.system_name' : 'puzzle_picker.chips.collection',
+                    translationParameters: [],
+                    queryParametersWithoutThis: $this->with(collectionIds: array_values(array_diff($this->collectionIds, [$collectionId])))->toQueryParams(),
+                    value: $collectionId,
+                );
+            }
+        } elseif ($this->source !== PuzzlePickerSource::Any) {
             $filters[] = new PuzzlePickerActiveFilter(
                 key: 'source',
                 type: 'source',
@@ -326,13 +544,43 @@ final readonly class PuzzlePickerCriteria
             );
         }
 
-        if ($this->solved !== PuzzlePickerSolved::Any) {
+        // One chip for the whole solve-count constraint, whatever its shape
+        if ($this->solvedMin !== 0 || $this->solvedMax !== null) {
+            [$translationKey, $translationParameters] = match (true) {
+                $this->solved === PuzzlePickerSolved::Never => ['puzzle_picker.chips.solved.never', []],
+                $this->solved === PuzzlePickerSolved::Before => ['puzzle_picker.chips.solved.before', []],
+                $this->solvedMax !== null && $this->solvedMin === $this->solvedMax => ['puzzle_picker.chips.solved.exact', ['%count%' => $this->solvedMin]],
+                $this->solvedMax === null => ['puzzle_picker.chips.solved.at_least', ['%min%' => $this->solvedMin]],
+                $this->solvedMin === 0 => ['puzzle_picker.chips.solved.at_most', ['%max%' => $this->solvedMax]],
+                default => ['puzzle_picker.chips.solved.between', ['%min%' => $this->solvedMin, '%max%' => $this->solvedMax]],
+            };
+
             $filters[] = new PuzzlePickerActiveFilter(
                 key: 'solved',
                 type: 'solved',
-                translationKey: 'puzzle_picker.chips.solved.' . $this->solved->value,
-                translationParameters: [],
-                queryParametersWithoutThis: $this->with(solved: PuzzlePickerSolved::Any)->toQueryParams(),
+                translationKey: $translationKey,
+                translationParameters: $translationParameters,
+                queryParametersWithoutThis: $this->with(clearSolved: true)->toQueryParams(),
+            );
+        }
+
+        if ($this->sinceAmount !== null) {
+            $filters[] = new PuzzlePickerActiveFilter(
+                key: 'since',
+                type: 'since',
+                translationKey: 'puzzle_picker.chips.' . ($this->sinceRequireSolved ? 'since_solved' : 'since') . '.' . $this->sinceUnit->value,
+                translationParameters: ['%count%' => $this->sinceAmount],
+                queryParametersWithoutThis: $this->with(clearSince: true)->toQueryParams(),
+            );
+        }
+
+        if ($this->myTime !== null && $this->myTimeMinutes !== null) {
+            $filters[] = new PuzzlePickerActiveFilter(
+                key: 'my_time',
+                type: 'my_time',
+                translationKey: 'puzzle_picker.chips.my_time.' . $this->myTime->value . '_' . $this->myTimeOperator->value,
+                translationParameters: ['%minutes%' => $this->myTimeMinutes],
+                queryParametersWithoutThis: $this->with(clearMyTime: true)->toQueryParams(),
             );
         }
 
@@ -374,6 +622,16 @@ final readonly class PuzzlePickerCriteria
                 translationKey: 'puzzle_picker.chips.include_lent_out',
                 translationParameters: [],
                 queryParametersWithoutThis: $this->with(includeLentOut: false)->toQueryParams(),
+            );
+        }
+
+        if ($this->community !== null) {
+            $filters[] = new PuzzlePickerActiveFilter(
+                key: 'community',
+                type: 'community',
+                translationKey: 'puzzle_picker.chips.community.' . $this->community->value,
+                translationParameters: ['%count%' => $this->community->threshold()],
+                queryParametersWithoutThis: $this->with(clearCommunity: true)->toQueryParams(),
             );
         }
 
@@ -477,40 +735,116 @@ final readonly class PuzzlePickerCriteria
     }
 
     /**
-     * Copy with some fields replaced. Nullable fields (gap, budget) cannot be
-     * "set to null" through a null argument, hence the explicit clear flags.
+     * Copy with some fields replaced. Nullable fields cannot be "set to null"
+     * through a null argument, hence the explicit clear flags.
      *
      * @param list<array{null|int, null|int}>|null $pieces
      * @param list<string>|null $brandIds
+     * @param list<string>|null $collectionIds
      * @param list<int>|null $difficultyTiers
      */
     private function with(
         null|PuzzlePickerSource $source = null,
-        null|PuzzlePickerSolved $solved = null,
+        bool $clearSolved = false,
+        bool $clearSince = false,
+        bool $clearMyTime = false,
         null|array $pieces = null,
         null|array $brandIds = null,
         null|bool $includeLentOut = null,
+        null|array $collectionIds = null,
+        bool $clearCommunity = false,
         null|array $difficultyTiers = null,
         null|PuzzlePickerOrder $order = null,
         bool $clearGap = false,
         bool $clearPredictedMax = false,
+        null|string $seed = null,
+        bool $replaceSeed = false,
     ): self {
         return new self(
             source: $source ?? $this->source,
-            solved: $solved ?? $this->solved,
+            solvedMin: $clearSolved ? 0 : $this->solvedMin,
+            solvedMax: $clearSolved ? null : $this->solvedMax,
+            sinceAmount: $clearSince ? null : $this->sinceAmount,
+            sinceUnit: $clearSince ? PuzzlePickerSinceUnit::Day : $this->sinceUnit,
+            sinceRequireSolved: $clearSince ? false : $this->sinceRequireSolved,
+            myTime: $clearMyTime ? null : $this->myTime,
+            myTimeOperator: $clearMyTime ? PuzzlePickerMyTimeOperator::Under : $this->myTimeOperator,
+            myTimeMinutes: $clearMyTime ? null : $this->myTimeMinutes,
             pieces: $pieces ?? $this->pieces,
             brandIds: $brandIds ?? $this->brandIds,
             includeLentOut: $includeLentOut ?? $this->includeLentOut,
+            collectionIds: $collectionIds ?? $this->collectionIds,
+            community: $clearCommunity ? null : $this->community,
             difficultyTiers: $difficultyTiers ?? $this->difficultyTiers,
             gap: $clearGap ? null : $this->gap,
             gapMinMinutes: $clearGap ? null : $this->gapMinMinutes,
             predictedMaxMinutes: $clearPredictedMax ? null : $this->predictedMaxMinutes,
             order: $order ?? $this->order,
-            seed: $this->seed,
+            seed: $replaceSeed ? $seed : $this->seed,
             isAuthenticated: $this->isAuthenticated,
             insightsAllowed: $this->insightsAllowed,
             predictionsAllowed: $this->predictionsAllowed,
         );
+    }
+
+    /**
+     * Named shape of a solve-count range (see the $solved property).
+     */
+    private static function solvedShapeOf(int $min, null|int $max): PuzzlePickerSolved
+    {
+        if ($max === 0) {
+            return PuzzlePickerSolved::Never;
+        }
+
+        if ($min === 1 && $max === null) {
+            return PuzzlePickerSolved::Before;
+        }
+
+        return PuzzlePickerSolved::Any;
+    }
+
+    /**
+     * The solve-count range from the named shape and the explicit bounds. An
+     * explicit bound wins over the shape's own bound; when the two collide
+     * (`solved=never&solved_min=2`, `solved=before&solved_max=0`) the explicit
+     * one is kept and the shape's bound is dropped.
+     *
+     * @return array{int, null|int}
+     */
+    private static function normalizeSolveCountRange(null|string $solved, null|string $solvedMin, null|string $solvedMax): array
+    {
+        $shape = $solved !== null ? PuzzlePickerSolved::tryFrom($solved) ?? PuzzlePickerSolved::Any : PuzzlePickerSolved::Any;
+
+        [$lower, $upper] = match ($shape) {
+            PuzzlePickerSolved::Never => [0, 0],
+            PuzzlePickerSolved::Before => [1, null],
+            PuzzlePickerSolved::Any => [0, null],
+        };
+
+        $min = self::parseInt($solvedMin, 0, self::MAX_SOLVE_COUNT);
+        $max = self::parseInt($solvedMax, 0, self::MAX_SOLVE_COUNT);
+
+        if ($min !== null && $max !== null && $min > $max) {
+            [$min, $max] = [$max, $min];
+        }
+
+        if ($min !== null) {
+            $lower = $min;
+        }
+
+        if ($max !== null) {
+            $upper = $max;
+        }
+
+        if ($upper !== null && $lower > $upper) {
+            if ($min !== null) {
+                $upper = null;
+            } else {
+                $lower = 0;
+            }
+        }
+
+        return [$lower, $upper];
     }
 
     /**
@@ -530,6 +864,11 @@ final readonly class PuzzlePickerCriteria
         }
 
         return [];
+    }
+
+    private static function stringInput(mixed $value): null|string
+    {
+        return is_string($value) ? $value : null;
     }
 
     /**
@@ -621,6 +960,33 @@ final readonly class PuzzlePickerCriteria
     }
 
     /**
+     * Collection uuids and/or the system collection sentinel, deduplicated;
+     * anything else is dropped. Ownership is not checked here — the query
+     * only ever looks at the player's own collection items, so a foreign id
+     * simply matches nothing.
+     *
+     * @param array<mixed> $collectionIds
+     *
+     * @return list<string>
+     */
+    private static function normalizeCollectionIds(array $collectionIds): array
+    {
+        $normalized = [];
+
+        foreach ($collectionIds as $collectionId) {
+            if (is_string($collectionId) === false || in_array($collectionId, $normalized, true)) {
+                continue;
+            }
+
+            if ($collectionId === Collection::SYSTEM_ID || Uuid::isValid($collectionId)) {
+                $normalized[] = $collectionId;
+            }
+        }
+
+        return array_slice($normalized, 0, self::MAX_COLLECTIONS);
+    }
+
+    /**
      * Difficulty tiers 1–6 (DifficultyTier values), deduplicated and sorted;
      * anything else is dropped.
      *
@@ -644,16 +1010,16 @@ final readonly class PuzzlePickerCriteria
     }
 
     /**
-     * Whole minutes within [min, max]; anything else (blank, text, out of range) is null.
+     * Whole number within [min, max]; anything else (blank, text, out of range) is null.
      */
-    private static function parseMinutes(null|string $value, int $min, int $max): null|int
+    private static function parseInt(null|string $value, int $min, int $max): null|int
     {
         if ($value === null || preg_match('/^\d{1,5}$/', trim($value)) !== 1) {
             return null;
         }
 
-        $minutes = (int) trim($value);
+        $number = (int) trim($value);
 
-        return $minutes >= $min && $minutes <= $max ? $minutes : null;
+        return $number >= $min && $number <= $max ? $number : null;
     }
 }

--- a/src/Value/PuzzlePickerMyTime.php
+++ b/src/Value/PuzzlePickerMyTime.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+/**
+ * Which of my solo times the "my time is under / over N minutes" filter of the
+ * puzzle picker compares: my fastest, my latest or my first. Puzzles without a
+ * solo time never match.
+ */
+enum PuzzlePickerMyTime: string
+{
+    case Fastest = 'fastest';
+    case Latest = 'latest';
+    case First = 'first';
+
+    /**
+     * Column of the picker's my_solves CTE holding this time.
+     */
+    public function column(): string
+    {
+        return match ($this) {
+            self::Fastest => 'fastest_seconds',
+            self::Latest => 'latest_seconds',
+            self::First => 'first_seconds',
+        };
+    }
+}

--- a/src/Value/PuzzlePickerMyTimeOperator.php
+++ b/src/Value/PuzzlePickerMyTimeOperator.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+/**
+ * Direction of the "my time is under / over N minutes" filter of the puzzle picker.
+ */
+enum PuzzlePickerMyTimeOperator: string
+{
+    case Under = 'lt';
+    case Over = 'gt';
+
+    public function sql(): string
+    {
+        return match ($this) {
+            self::Under => '<',
+            self::Over => '>',
+        };
+    }
+}

--- a/src/Value/PuzzlePickerPreset.php
+++ b/src/Value/PuzzlePickerPreset.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+/**
+ * One-tap presets above the picker card. A preset is nothing but a set of
+ * query parameters that fills the filter form - no backend concept beyond
+ * this list. "Beat my record" needs my predictions (members without the
+ * time-predictions opt-out); everything else is built from free filters.
+ */
+enum PuzzlePickerPreset: string
+{
+    case SurpriseMe = 'surprise_me';
+    case SomethingNew = 'something_new';
+    case QuickOne = 'quick_one';
+    case DustOffTheShelf = 'dust_off';
+    case RatingGrind = 'rating_grind';
+    case BeatMyRecord = 'beat_my_record';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function queryParams(): array
+    {
+        return match ($this) {
+            self::SurpriseMe => ['source' => PuzzlePickerSource::Mine->value],
+            self::SomethingNew => ['source' => PuzzlePickerSource::Mine->value, 'solved' => PuzzlePickerSolved::Never->value],
+            self::QuickOne => ['predicted_max' => '60'],
+            self::DustOffTheShelf => ['since' => '6', 'since_unit' => PuzzlePickerSinceUnit::Month->value, 'since_require_solved' => '1'],
+            self::RatingGrind => ['pieces' => ['500'], 'solved' => PuzzlePickerSolved::Never->value, 'community' => PuzzlePickerCommunity::Rated->value],
+            self::BeatMyRecord => ['solved' => PuzzlePickerSolved::Before->value, 'gap' => PuzzlePickerGap::Slower->value, 'order' => PuzzlePickerOrder::GapSlower->value],
+        };
+    }
+
+    public function requiresPredictions(): bool
+    {
+        return $this === self::BeatMyRecord;
+    }
+
+    /**
+     * Bootstrap icon class of the chip.
+     */
+    public function icon(): string
+    {
+        return match ($this) {
+            self::SurpriseMe => 'bi-shuffle',
+            self::SomethingNew => 'bi-stars',
+            self::QuickOne => 'bi-lightning-charge',
+            self::DustOffTheShelf => 'bi-hourglass-split',
+            self::RatingGrind => 'bi-graph-up-arrow',
+            self::BeatMyRecord => 'bi-trophy',
+        };
+    }
+}

--- a/src/Value/PuzzlePickerSinceUnit.php
+++ b/src/Value/PuzzlePickerSinceUnit.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+/**
+ * Unit of the "last solved more than N ... ago" filter of the puzzle picker.
+ */
+enum PuzzlePickerSinceUnit: string
+{
+    case Day = 'd';
+    case Week = 'w';
+    case Month = 'm';
+
+    /**
+     * DateTime modifier taking `now` back by N units, e.g. "-6 months".
+     */
+    public function modifier(int $amount): string
+    {
+        return match ($this) {
+            self::Day => "-{$amount} days",
+            self::Week => "-{$amount} weeks",
+            self::Month => "-{$amount} months",
+        };
+    }
+}

--- a/templates/collections/detail.html.twig
+++ b/templates/collections/detail.html.twig
@@ -40,6 +40,11 @@
                 {% endif %}
             {% endif %}
             {% if logged_user.profile is not null and logged_user.profile.playerId == collection.playerId %}
+                {# Puzzle picker deep link: members get this very collection preselected (system
+                   collection = sentinel id), everybody else the whole shelf #}
+                <a href="{{ path('puzzle_picker', logged_user.profile.activeMembership ? {collections: [collection.collectionId ?? system_collection_id]} : {source: 'mine'}) }}" class="btn btn-sm btn-outline-primary puzzle-picker-collection-link" rel="nofollow" title="{{ 'puzzle_picker.pick_from_collection'|trans }}">
+                    <i class="bi bi-shuffle me-1"></i> {{ 'puzzle_picker.pick_from_collection'|trans }}
+                </a>
                 {% if collection.collectionId %}
                     <a href="{{ path('puzzle_add') }}?mode=collection&collection={{ collection.collectionId }}" class="btn btn-sm btn-outline-primary">
                         <i class="bi bi-puzzle me-1"></i> {{ 'collections.add_puzzle_here.button'|trans }}

--- a/templates/puzzle_picker/_empty_state.html.twig
+++ b/templates/puzzle_picker/_empty_state.html.twig
@@ -1,6 +1,6 @@
 {# Nothing to pick. Two cases: the default view of a player with an empty shelf (nothing to
-   filter yet -> add puzzles / widen to all), or filters that leave no candidate (loosen).
-   Expects: criteria #}
+   filter yet -> add puzzles / widen to all), or filters that leave no candidate (loosen: reset,
+   or keep the filters and widen the pool to every puzzle). Expects: criteria, reset_url #}
 {% set empty_shelf = criteria.isAuthenticated and criteria.isDefault and criteria.source.value == 'mine' %}
 <div class="row justify-content-center">
     <div class="col-12 col-md-8 col-lg-6">
@@ -21,11 +21,12 @@
                 <h2 class="h5">{{ 'puzzle_picker.empty.nothing_title'|trans }}</h2>
                 <p class="fs-sm text-muted mb-3">{{ 'puzzle_picker.empty.nothing_text'|trans }}</p>
                 <div class="d-flex flex-wrap justify-content-center gap-2">
-                    <a class="btn btn-primary btn-sm" rel="nofollow" href="{{ path('puzzle_picker') }}">
+                    <a class="btn btn-primary btn-sm" rel="nofollow" href="{{ reset_url|default(path('puzzle_picker')) }}">
                         <i class="bi bi-arrow-counterclockwise me-1"></i>{{ 'puzzle_picker.empty.reset'|trans }}
                     </a>
                     {% if criteria.isAuthenticated and criteria.source.value != 'any' %}
-                        <a class="btn btn-outline-primary btn-sm" rel="nofollow" href="{{ path('puzzle_picker', {source: 'any'}) }}">
+                        {# Widen the pool but keep the mood: the other filters (and the seed) stay #}
+                        <a class="btn btn-outline-primary btn-sm" rel="nofollow" href="{{ path('puzzle_picker', criteria.toQueryParams|filter((value, key) => key != 'collections')|merge({source: 'any'})) }}">
                             <i class="bi bi-globe2 me-1"></i>{{ 'puzzle_picker.empty.pick_from_all'|trans }}
                         </a>
                     {% endif %}

--- a/templates/puzzle_picker/_filter_bar.html.twig
+++ b/templates/puzzle_picker/_filter_bar.html.twig
@@ -1,5 +1,8 @@
 {# Filter button + active-filter chips. Every link here is a throw-away variant of the page
-   (noindex), hence rel="nofollow" on all of them. Expects: criteria, brand_names #}
+   (noindex), hence rel="nofollow" on all of them. When the filters were restored from the session
+   (bare visit of a signed-in player) a small marker says so - remembered filters must never feel
+   sticky-by-surprise - and "Reset" forgets them (?reset=1). Expects: criteria, brand_names,
+   collection_names, filters_remembered, reset_url #}
 {% set active_filters = criteria.activeFilters %}
 <div class="d-flex flex-wrap align-items-center gap-2 mb-3 puzzle-picker-filter-bar">
     <button type="button" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#puzzlePickerFilters">
@@ -13,6 +16,8 @@
            title="{{ 'puzzle_picker.chips.remove'|trans }}">
             {% if filter.type == 'brand' %}
                 {{ brand_names[filter.value] ?? filter.translationKey|trans }}
+            {% elseif filter.type == 'collection' %}
+                <i class="bi bi-collection me-1"></i>{{ collection_names[filter.value] ?? filter.translationKey|trans }}
             {% elseif filter.type == 'difficulty' %}
                 {{ 'puzzle_intelligence.difficulty.tier_label'|trans }}: {{ filter.translationKey|trans }}
             {% else %}
@@ -22,7 +27,10 @@
         </a>
     {% endfor %}
 
+    {% if filters_remembered|default(false) %}
+        <span class="fs-sm text-muted puzzle-picker-remembered" title="{{ 'puzzle_picker.filters.remembered_title'|trans }}"><i class="bi bi-clock-history me-1"></i>{{ 'puzzle_picker.filters.remembered'|trans }}</span>
+    {% endif %}
     {% if not criteria.isDefault %}
-        <a class="fs-sm text-muted" rel="nofollow" href="{{ path('puzzle_picker') }}">{{ 'puzzle_picker.filters.reset'|trans }}</a>
+        <a class="fs-sm text-muted puzzle-picker-reset" rel="nofollow" href="{{ reset_url|default(path('puzzle_picker')) }}">{{ 'puzzle_picker.filters.reset'|trans }}</a>
     {% endif %}
 </div>

--- a/templates/puzzle_picker/_filters_modal.html.twig
+++ b/templates/puzzle_picker/_filters_modal.html.twig
@@ -1,8 +1,9 @@
 {# Filter sheet: a plain GET form - Apply submits, the URL is the state (bookmarkable, back
    button works). Personal groups (shelf, history, lent-out) are disabled for guests with a
-   sign-in note; the "Insights (members)" group is one locked block for non-members and its
-   prediction controls are disabled for members who opted out of predictions. The server drops
-   every non-eligible value anyway. Expects: criteria, brand_names #}
+   sign-in note; the "only these collections" list and the "Insights (members)" group are locked
+   for non-members and the prediction controls are disabled for members who opted out of
+   predictions. The server drops every non-eligible value anyway.
+   Expects: criteria, brand_names, collections (member's collections, system first), reset_url #}
 {% set is_guest = not criteria.isAuthenticated %}
 {% set is_member = criteria.insightsAllowed %}
 {% set predictions_on = criteria.predictionsAllowed %}
@@ -15,6 +16,12 @@
     {value: 4, name: 'challenging', icon: 'diff-challenging'},
     {value: 5, name: 'hard', icon: 'diff-hard'},
     {value: 6, name: 'veryhard', icon: 'diff-very-hard'},
+] %}
+{% set community_options = [
+    {value: '', key: 'any'},
+    {value: 'few', key: 'few', count: constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCommunity::FEW_MAX_SOLVES')},
+    {value: 'rated', key: 'rated', count: constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCommunity::RATED_MIN_SOLVES')},
+    {value: 'popular', key: 'popular', count: constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCommunity::POPULAR_MIN_SOLVES')},
 ] %}
 <div class="modal fade" id="puzzlePickerFilters" tabindex="-1" aria-labelledby="puzzlePickerFiltersLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-sm-down">
@@ -43,6 +50,37 @@
                                 </div>
                             {% endfor %}
                         </div>
+
+                        {# Specific collections (members): checkbox list, system collection first. Ticking
+                           any of them narrows "my collection" down to those; nothing ticked = whole shelf. #}
+                        <div class="mt-2 puzzle-picker-collections {{ not is_member ? 'puzzle-picker-collections-locked' }}">
+                            <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+                                <span class="fs-sm text-muted">
+                                    {% if not is_member %}<i class="ci-locked me-1"></i>{% endif %}{{ 'puzzle_picker.filters.source.collections_label'|trans }}
+                                </span>
+                                {% if not is_member and not is_guest %}
+                                    <button type="button" class="btn btn-outline-secondary btn-xs" data-bs-toggle="modal" data-bs-target="#membersExclusiveModal">
+                                        <i class="ci-locked me-1"></i>{{ 'membership.members_exclusive_short'|trans }}
+                                    </button>
+                                {% endif %}
+                            </div>
+                            {% if is_member %}
+                                <div class="d-flex flex-wrap align-items-center gap-1">
+                                    {% for collection in collections %}
+                                        <div class="form-check form-option form-check-inline mb-0">
+                                            <input type="checkbox" class="form-check-input" name="collections[]" id="picker-collection-{{ loop.index }}" value="{{ collection.id }}" {{ collection.id in criteria.collectionIds ? 'checked' }}>
+                                            <label class="form-option-label" for="picker-collection-{{ loop.index }}">
+                                                <i class="bi {{ collection.system ? 'bi-puzzle' : 'bi-collection' }} me-1"></i>{{ collection.name }} <span class="text-muted">({{ collection.count }})</span>
+                                            </label>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                                <div class="form-text">{{ 'puzzle_picker.filters.source.collections_note'|trans }}</div>
+                            {% else %}
+                                <div class="form-text opacity-75">{{ 'puzzle_picker.filters.source.collections_locked'|trans }}</div>
+                            {% endif %}
+                        </div>
+
                         <div class="form-check mt-2 mb-0">
                             <input class="form-check-input" type="checkbox" name="lent" value="1" id="picker-lent" {{ criteria.includeLentOut ? 'checked' }}>
                             <label class="form-check-label fs-sm" for="picker-lent">{{ 'puzzle_picker.filters.source.include_lent_out'|trans }}</label>
@@ -59,6 +97,55 @@
                                 </div>
                             {% endfor %}
                         </div>
+
+                        {# Solve-count range: refines the radio bound by bound (never = 0-0, before = 1+) #}
+                        {% set show_count_min = criteria.solved.value == 'any' and criteria.solvedMin > 0 %}
+                        {% set show_count_max = criteria.solvedMax is not null and criteria.solved.value != 'never' %}
+                        <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                            <label class="fs-sm text-muted mb-0" for="picker-solved-min">{{ 'puzzle_picker.filters.solved.between'|trans }}</label>
+                            <input type="number" class="form-control form-control-sm" style="max-width: 5rem;" id="picker-solved-min" name="solved_min" min="0" max="{{ constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCriteria::MAX_SOLVE_COUNT') }}" step="1" inputmode="numeric" value="{{ show_count_min ? criteria.solvedMin : '' }}">
+                            <label class="fs-sm text-muted mb-0" for="picker-solved-max">{{ 'puzzle_picker.filters.solved.and'|trans }}</label>
+                            <input type="number" class="form-control form-control-sm" style="max-width: 5rem;" id="picker-solved-max" name="solved_max" min="0" max="{{ constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCriteria::MAX_SOLVE_COUNT') }}" step="1" inputmode="numeric" value="{{ show_count_max ? criteria.solvedMax : '' }}">
+                            <span class="fs-sm text-muted">{{ 'puzzle_picker.filters.solved.times'|trans }}</span>
+                        </div>
+
+                        {# Last solved more than N days / weeks / months ago - never-solved included by default #}
+                        <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
+                            <label class="fs-sm text-muted mb-0" for="picker-since">{{ 'puzzle_picker.filters.since.label'|trans }}</label>
+                            <input type="number" class="form-control form-control-sm" style="max-width: 5rem;" id="picker-since" name="since" min="1" max="{{ constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCriteria::MAX_SINCE_AMOUNT') }}" step="1" inputmode="numeric" placeholder="6" value="{{ criteria.sinceAmount ?? '' }}">
+                            <label class="visually-hidden" for="picker-since-unit">{{ 'puzzle_picker.filters.since.unit'|trans }}</label>
+                            <select class="form-select form-select-sm" style="max-width: 8rem;" id="picker-since-unit" name="since_unit">
+                                {% for unit in ['d', 'w', 'm'] %}
+                                    <option value="{{ unit }}" {{ (criteria.sinceAmount is not null ? criteria.sinceUnit.value : 'm') == unit ? 'selected' }}>{{ ('puzzle_picker.filters.since.units.' ~ unit)|trans }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="form-check mt-1 mb-0">
+                            <input class="form-check-input" type="checkbox" name="since_require_solved" value="1" id="picker-since-require-solved" {{ criteria.sinceRequireSolved ? 'checked' }}>
+                            <label class="form-check-label fs-sm" for="picker-since-require-solved">{{ 'puzzle_picker.filters.since.require_solved'|trans }}</label>
+                        </div>
+                        <div class="form-text">{{ 'puzzle_picker.filters.since.note'|trans }}</div>
+
+                        {# My fastest / latest / first time is under / over N minutes (solo times only) #}
+                        <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
+                            <label class="fs-sm text-muted mb-0" for="picker-my-time">{{ 'puzzle_picker.filters.my_time.label'|trans }}</label>
+                            <select class="form-select form-select-sm" style="max-width: 9rem;" id="picker-my-time" name="my_time">
+                                <option value="" {{ criteria.myTime is null ? 'selected' }}>{{ 'puzzle_picker.filters.my_time.off'|trans }}</option>
+                                {% for metric in ['fastest', 'latest', 'first'] %}
+                                    <option value="{{ metric }}" {{ criteria.myTime is not null and criteria.myTime.value == metric ? 'selected' }}>{{ ('puzzle_picker.filters.my_time.' ~ metric)|trans }}</option>
+                                {% endfor %}
+                            </select>
+                            <label class="visually-hidden" for="picker-my-time-op">{{ 'puzzle_picker.filters.my_time.op_label'|trans }}</label>
+                            <select class="form-select form-select-sm" style="max-width: 8rem;" id="picker-my-time-op" name="my_time_op">
+                                {% for op in ['lt', 'gt'] %}
+                                    <option value="{{ op }}" {{ criteria.myTimeOperator.value == op ? 'selected' }}>{{ ('puzzle_picker.filters.my_time.' ~ op)|trans }}</option>
+                                {% endfor %}
+                            </select>
+                            <label class="visually-hidden" for="picker-my-time-minutes">{{ 'puzzle_picker.filters.budget.minutes'|trans }}</label>
+                            <input type="number" class="form-control form-control-sm" style="max-width: 6rem;" id="picker-my-time-minutes" name="my_time_minutes" min="{{ constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCriteria::MIN_MY_TIME_MINUTES') }}" max="{{ constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCriteria::MAX_MY_TIME_MINUTES') }}" step="1" inputmode="numeric" placeholder="60" value="{{ criteria.myTimeMinutes ?? '' }}">
+                            <span class="fs-sm text-muted">{{ 'puzzle_picker.filters.budget.minutes'|trans }}</span>
+                        </div>
+                        <div class="form-text">{{ 'puzzle_picker.filters.my_time.note'|trans }}</div>
                     </fieldset>
 
                     <fieldset class="mb-3">
@@ -101,6 +188,19 @@
                                 <option value="{{ brand_id }}" selected>{{ brand_names[brand_id] ?? brand_id }}</option>
                             {% endfor %}
                         </select>
+                    </fieldset>
+
+                    {# Community results: how many solo solves the puzzle has - free, from puzzle_statistics #}
+                    <fieldset class="mb-3">
+                        <legend class="fs-sm fw-bold mb-1">{{ 'puzzle_picker.filters.community.label'|trans }}</legend>
+                        <div class="d-flex flex-wrap align-items-center gap-1">
+                            {% for option in community_options %}
+                                <div class="form-check form-option form-check-inline mb-0">
+                                    <input type="radio" class="form-check-input" name="community" id="picker-community-{{ option.key }}" value="{{ option.value }}" {{ (option.value == '' ? criteria.community is null : (criteria.community is not null and criteria.community.value == option.value)) ? 'checked' }}>
+                                    <label class="form-option-label" for="picker-community-{{ option.key }}">{{ ('puzzle_picker.filters.community.' ~ option.key)|trans({'%count%': option.count|default(0)}) }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
                     </fieldset>
 
                     {# Time budget - free for everyone, the engine differs: my prediction for members
@@ -191,7 +291,7 @@
                 </div>
 
                 <div class="modal-footer justify-content-between">
-                    <a class="btn btn-link btn-sm text-muted" rel="nofollow" href="{{ path('puzzle_picker') }}">{{ 'puzzle_picker.filters.reset'|trans }}</a>
+                    <a class="btn btn-link btn-sm text-muted" rel="nofollow" href="{{ reset_url|default(path('puzzle_picker')) }}">{{ 'puzzle_picker.filters.reset'|trans }}</a>
                     <button type="submit" class="btn btn-primary">
                         <i class="bi bi-shuffle me-1"></i>{{ 'puzzle_picker.filters.apply'|trans }}
                     </button>

--- a/templates/puzzle_picker/_presets.html.twig
+++ b/templates/puzzle_picker/_presets.html.twig
@@ -1,23 +1,29 @@
 {# One-tap presets above the filter bar. Each preset only fills the filter form (query params) -
-   no backend concept. "Beat my record" needs predictions: members get the link, members who
-   opted out see it muted, non-members get the lock (-> members modal). Expects: criteria #}
-{% set beat_params = {solved: 'before', gap: 'slower', order: 'gap_slower'} %}
-{% set beat_active = criteria.solved.value == 'before' and criteria.gap is not null and criteria.gap.value == 'slower' and criteria.order.value == 'gap_slower' %}
+   no backend concept beyond the PuzzlePickerPreset list. The free presets are plain links; "Beat my
+   record" needs predictions: members get the link, members who opted out see it muted, non-members
+   get the lock (-> members modal). The preset whose filters equal the current criteria is
+   highlighted. Expects: criteria, presets (list of PuzzlePickerPreset), active_preset #}
 <div class="d-flex flex-wrap align-items-center gap-2 mb-2 puzzle-picker-presets">
     <span class="fs-sm text-muted">{{ 'puzzle_picker.presets.label'|trans }}</span>
-    {% if criteria.predictionsAllowed %}
-        <a class="badge rounded-pill {{ beat_active ? 'bg-primary text-white' : 'bg-secondary text-dark' }} fw-normal text-decoration-none py-2 px-3 puzzle-picker-preset"
-           rel="nofollow"
-           href="{{ path('puzzle_picker', beat_params) }}">
-            <i class="bi bi-trophy me-1"></i>{{ 'puzzle_picker.presets.beat_my_record'|trans }}
-        </a>
-    {% elseif criteria.insightsAllowed %}
-        <span class="badge rounded-pill bg-secondary text-muted fw-normal py-2 px-3 puzzle-picker-preset" title="{{ 'puzzle_intelligence.prediction.time_predictions_opted_out'|trans }}">
-            <i class="bi bi-eye-slash me-1"></i>{{ 'puzzle_picker.presets.beat_my_record'|trans }}
-        </span>
-    {% else %}
-        <button type="button" class="badge rounded-pill bg-secondary text-muted fw-normal py-2 px-3 border-0 puzzle-picker-preset" data-bs-toggle="modal" data-bs-target="#membersExclusiveModal">
-            <i class="ci-locked me-1"></i>{{ 'puzzle_picker.presets.beat_my_record'|trans }}
-        </button>
-    {% endif %}
+    {% for preset in presets %}
+        {% set is_active = active_preset is not null and active_preset.value == preset.value %}
+        {% set label = ('puzzle_picker.presets.' ~ preset.value)|trans %}
+        {% if not preset.requiresPredictions or criteria.predictionsAllowed %}
+            <a class="badge rounded-pill {{ is_active ? 'bg-primary text-white' : 'bg-secondary text-dark' }} fw-normal text-decoration-none py-2 px-3 puzzle-picker-preset"
+               rel="nofollow"
+               data-preset="{{ preset.value }}"
+               {% if is_active %}aria-current="true"{% endif %}
+               href="{{ path('puzzle_picker', preset.queryParams) }}">
+                <i class="bi {{ preset.icon }} me-1"></i>{{ label }}
+            </a>
+        {% elseif criteria.insightsAllowed %}
+            <span class="badge rounded-pill bg-secondary text-muted fw-normal py-2 px-3 puzzle-picker-preset" data-preset="{{ preset.value }}" title="{{ 'puzzle_intelligence.prediction.time_predictions_opted_out'|trans }}">
+                <i class="bi bi-eye-slash me-1"></i>{{ label }}
+            </span>
+        {% else %}
+            <button type="button" class="badge rounded-pill bg-secondary text-muted fw-normal py-2 px-3 border-0 puzzle-picker-preset" data-preset="{{ preset.value }}" data-bs-toggle="modal" data-bs-target="#membersExclusiveModal">
+                <i class="ci-locked me-1"></i>{{ label }}
+            </button>
+        {% endif %}
+    {% endfor %}
 </div>

--- a/templates/puzzle_picker/_results.html.twig
+++ b/templates/puzzle_picker/_results.html.twig
@@ -1,6 +1,7 @@
 {# The draw: one visible card, the rest hidden until "Show N more" (over-fetched in the same
-   query - zero extra requests), the "1 of N matching" counter and the spin button.
-   Expects: pick, criteria, next_seed #}
+   query - zero extra requests), the "1 of N matching" counter, the spin button and the share
+   button (the seeded URL of this very draw - "look what the wheel gave me").
+   Expects: pick, criteria, seed, next_seed #}
 {% if pick.isEmpty %}
     {{ include('puzzle_picker/_empty_state.html.twig') }}
 {% else %}
@@ -20,7 +21,7 @@
                 })|raw }}
             </p>
 
-            <div class="d-flex flex-wrap justify-content-center gap-2">
+            <div class="d-flex flex-wrap justify-content-center align-items-center gap-2">
                 {% if pick.totalMatching > 1 %}
                     <a class="btn btn-primary" rel="nofollow" href="{{ path('puzzle_picker', criteria.toQueryParams(next_seed)) }}">
                         <i class="bi bi-shuffle me-1"></i>{{ 'puzzle_picker.results.pick_another'|trans }}
@@ -31,6 +32,9 @@
                         <i class="bi bi-chevron-down me-1"></i>{{ 'puzzle_picker.results.show_more'|trans({'%count%': hidden_count}) }}
                     </button>
                 {% endif %}
+                <div class="puzzle-picker-share">
+                    {{ include('_share_button.html.twig', {share_url: url('puzzle_picker', criteria.toQueryParams(seed))}) }}
+                </div>
             </div>
         </div>
     </div>

--- a/tests/Controller/CollectionDetailControllerTest.php
+++ b/tests/Controller/CollectionDetailControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpeedPuzzling\Web\Tests\Controller;
 
+use SpeedPuzzling\Web\Entity\Collection;
 use SpeedPuzzling\Web\Tests\DataFixtures\CollectionFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\TestingLogin;
@@ -29,5 +30,52 @@ final class CollectionDetailControllerTest extends WebTestCase
         $browser->request('GET', '/en/collection/' . CollectionFixture::COLLECTION_PUBLIC);
 
         $this->assertResponseIsSuccessful();
+    }
+
+    public function testOwnCollectionPagesLinkToThePuzzlePicker(): void
+    {
+        $browser = self::createClient();
+
+        // Guest: no button
+        $crawler = $browser->request('GET', '/en/collection/' . CollectionFixture::COLLECTION_PUBLIC);
+        $this->assertResponseIsSuccessful();
+        self::assertCount(0, $crawler->filter('.puzzle-picker-collection-link'));
+
+        // Member on her own custom collection: the picker with this very collection preselected
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $crawler = $browser->request('GET', '/en/collection/' . CollectionFixture::COLLECTION_PUBLIC);
+        $this->assertResponseIsSuccessful();
+        $link = $crawler->filter('.puzzle-picker-collection-link');
+        self::assertCount(1, $link);
+        self::assertSame('/en/what-to-solve-next?collections%5B0%5D=' . CollectionFixture::COLLECTION_PUBLIC, $link->attr('href'));
+        self::assertSame('nofollow', $link->attr('rel'));
+        self::assertStringContainsString('Pick from this collection', $link->text());
+
+        // ... and on her system collection: the sentinel id
+        $crawler = $browser->request('GET', '/en/puzzle-collection/' . PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->assertResponseIsSuccessful();
+        self::assertSame('/en/what-to-solve-next?collections%5B0%5D=' . rawurlencode(Collection::SYSTEM_ID), $crawler->filter('.puzzle-picker-collection-link')->attr('href'));
+
+        // Somebody else's collection: no button
+        $crawler = $browser->request('GET', '/en/puzzle-collection/' . PlayerFixture::PLAYER_REGULAR);
+        $this->assertResponseIsSuccessful();
+        self::assertCount(0, $crawler->filter('.puzzle-picker-collection-link'));
+
+        // Non-member on his own collection: specific collections are members-only, so the whole shelf
+        self::ensureKernelShutdown();
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_REGULAR);
+        $crawler = $browser->request('GET', '/en/collection/' . CollectionFixture::COLLECTION_PRIVATE);
+        $this->assertResponseIsSuccessful();
+        self::assertSame('/en/what-to-solve-next?source=mine', $crawler->filter('.puzzle-picker-collection-link')->attr('href'));
+
+        // The deep link really lands on a picker restricted to that collection
+        self::ensureKernelShutdown();
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?collections%5B0%5D=' . CollectionFixture::COLLECTION_STRIPE_TREFL);
+        $this->assertResponseIsSuccessful();
+        self::assertStringContainsString('of 3 matching puzzles', (string) $browser->getResponse()->getContent());
+        self::assertCount(1, $crawler->filter('.puzzle-picker-filter-bar a[title="Remove this filter"]:contains("My Trefl Collection")'));
     }
 }

--- a/tests/Controller/PuzzlePickerControllerTest.php
+++ b/tests/Controller/PuzzlePickerControllerTest.php
@@ -6,7 +6,9 @@ namespace SpeedPuzzling\Web\Tests\Controller;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SpeedPuzzling\Web\Entity\Collection;
 use SpeedPuzzling\Web\Services\PuzzleIntelligence\PuzzleIntelligenceRecalculator;
+use SpeedPuzzling\Web\Tests\DataFixtures\CollectionFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\ManufacturerFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\TestingLogin;
@@ -166,8 +168,9 @@ final class PuzzlePickerControllerTest extends WebTestCase
 
         self::assertCount(0, $crawler->filter('.puzzle-picker-card'));
         self::assertStringContainsString('Nothing matches these filters', $content);
-        self::assertCount(1, $crawler->filter('.card a[href="/en/what-to-solve-next"]:contains("Reset filters")'));
-        self::assertCount(1, $crawler->filter('.card a[href="/en/what-to-solve-next?source=any"]:contains("Pick from all puzzles")'));
+        // Reset forgets the remembered filters (?reset=1); "all puzzles" keeps the mood and only widens the pool
+        self::assertCount(1, $crawler->filter('.card a[href="/en/what-to-solve-next?reset=1"]:contains("Reset filters")'));
+        self::assertCount(1, $crawler->filter('.card a[href="/en/what-to-solve-next?solved=never&source=any"]:contains("Pick from all puzzles")'));
     }
 
     public function testBorrowedPuzzlesAreTheShelfOfAPlayerWithoutCollectionItems(): void
@@ -272,8 +275,9 @@ final class PuzzlePickerControllerTest extends WebTestCase
         self::assertStringContainsString('Based on your own predicted time', $crawler->filter('.puzzle-picker-budget-engine')->text());
         self::assertStringContainsString('only puzzles with enough data', strtolower($content));
 
-        // "Beat my record" preset is a real link
-        $preset = $crawler->filter('a.puzzle-picker-preset');
+        // "Beat my record" preset is a real link (next to the five free presets)
+        self::assertCount(6, $crawler->filter('a.puzzle-picker-preset'));
+        $preset = $crawler->filter('a.puzzle-picker-preset[data-preset="beat_my_record"]');
         self::assertCount(1, $preset);
         self::assertStringContainsString('solved=before', (string) $preset->attr('href'));
         self::assertStringContainsString('gap=slower', (string) $preset->attr('href'));
@@ -311,10 +315,11 @@ final class PuzzlePickerControllerTest extends WebTestCase
         self::assertSame('2', $crawler->filter('#puzzlePickerFilters input[name="gap_min"]')->attr('value'));
         self::assertSame('90', $crawler->filter('#puzzlePickerFilters input[name="predicted_max"]')->attr('value'));
 
-        // The preset chip is highlighted when its filters are active
+        // The preset chip is highlighted when its filters are active - and only that one
         $crawler = $browser->request('GET', '/en/what-to-solve-next?solved=before&gap=slower&order=gap_slower');
         $this->assertResponseIsSuccessful();
-        self::assertStringContainsString('bg-primary', (string) $crawler->filter('a.puzzle-picker-preset')->attr('class'));
+        self::assertStringContainsString('bg-primary', (string) $crawler->filter('a.puzzle-picker-preset[data-preset="beat_my_record"]')->attr('class'));
+        self::assertCount(1, $crawler->filter('a.puzzle-picker-preset.bg-primary'));
     }
 
     public function testNonMemberGetsOneLockedPredictionRowPerCardAndALockedInsightsGroup(): void
@@ -350,9 +355,10 @@ final class PuzzlePickerControllerTest extends WebTestCase
         self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="predicted_max"]:not([disabled])'), 'The time budget stays free');
         self::assertStringContainsString('community average', $crawler->filter('.puzzle-picker-budget-engine')->text());
 
-        // Preset chip is the lock -> members modal, not a link
-        self::assertCount(0, $crawler->filter('a.puzzle-picker-preset'));
-        self::assertCount(1, $crawler->filter('button.puzzle-picker-preset[data-bs-target="#membersExclusiveModal"]'));
+        // "Beat my record" is the lock -> members modal, not a link; the free presets stay links
+        self::assertCount(0, $crawler->filter('a.puzzle-picker-preset[data-preset="beat_my_record"]'));
+        self::assertCount(1, $crawler->filter('button.puzzle-picker-preset[data-preset="beat_my_record"][data-bs-target="#membersExclusiveModal"]'));
+        self::assertCount(5, $crawler->filter('a.puzzle-picker-preset'));
     }
 
     public function testGuestSeesNeitherPredictionNorLockOnTheCards(): void
@@ -414,10 +420,269 @@ final class PuzzlePickerControllerTest extends WebTestCase
         self::assertCount(1, $crawler->filter('#puzzlePickerFilters .puzzle-picker-insights-opted-out'));
         self::assertStringContainsString('community average', $crawler->filter('.puzzle-picker-budget-engine')->text());
 
-        // Preset chip is muted, neither a link nor the members lock
-        self::assertCount(0, $crawler->filter('a.puzzle-picker-preset'));
+        // "Beat my record" is muted, neither a link nor the members lock; the free presets stay links
+        self::assertCount(0, $crawler->filter('a.puzzle-picker-preset[data-preset="beat_my_record"]'));
         self::assertCount(0, $crawler->filter('button.puzzle-picker-preset'));
-        self::assertCount(1, $crawler->filter('span.puzzle-picker-preset'));
+        self::assertCount(1, $crawler->filter('span.puzzle-picker-preset[data-preset="beat_my_record"]'));
+        self::assertCount(5, $crawler->filter('a.puzzle-picker-preset'));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Precision filters, collections, remembered filters, presets, share
+    // ---------------------------------------------------------------------------------------------
+
+    public function testPrecisionFiltersRenderAsChipsAndFillTheForm(): void
+    {
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?source=any&lent=1&solved_min=2&solved_max=5&since=6&since_unit=m&since_require_solved=1&my_time=fastest&my_time_op=gt&my_time_minutes=45&community=few&seed=abcd1234');
+
+        $this->assertResponseIsSuccessful();
+
+        self::assertEqualsCanonicalizing(
+            ['Solved 2–5×', 'Solved, but not in the last 6 months', 'Fastest over 45 min', 'Incl. lent out', 'Few results (≤ 5)'],
+            self::chipLabels($crawler),
+        );
+
+        // Every chip removes exactly itself
+        $chips = $crawler->filter('.puzzle-picker-filter-bar a[title="Remove this filter"]');
+        $chips->each(static function (Crawler $chip): void {
+            self::assertSame('nofollow', $chip->attr('rel'));
+        });
+        $withoutSince = $chips->reduce(static fn (Crawler $chip): bool => str_contains($chip->text(), 'last 6 months'))->attr('href');
+        self::assertStringNotContainsString('since', (string) $withoutSince);
+        self::assertStringContainsString('my_time=fastest', (string) $withoutSince);
+        self::assertStringContainsString('solved_min=2', (string) $withoutSince);
+        self::assertStringContainsString('community=few', (string) $withoutSince);
+
+        // The form shows the state back
+        self::assertSame('2', $crawler->filter('#puzzlePickerFilters input[name="solved_min"]')->attr('value'));
+        self::assertSame('5', $crawler->filter('#puzzlePickerFilters input[name="solved_max"]')->attr('value'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="solved"][value="any"][checked]'));
+        self::assertSame('6', $crawler->filter('#puzzlePickerFilters input[name="since"]')->attr('value'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters select[name="since_unit"] option[value="m"][selected]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="since_require_solved"][checked]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters select[name="my_time"] option[value="fastest"][selected]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters select[name="my_time_op"] option[value="gt"][selected]'));
+        self::assertSame('45', $crawler->filter('#puzzlePickerFilters input[name="my_time_minutes"]')->attr('value'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="community"][value="few"][checked]'));
+        self::assertCount(4, $crawler->filter('#puzzlePickerFilters input[name="community"]'));
+
+        // The named shapes keep their radio; the count inputs stay blank
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?solved=never&since=10');
+        $this->assertResponseIsSuccessful();
+        self::assertEqualsCanonicalizing(['My collection', 'Never solved', 'Not solved in the last 10 days'], self::chipLabels($crawler));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="solved"][value="never"][checked]'));
+        self::assertSame('', $crawler->filter('#puzzlePickerFilters input[name="solved_min"]')->attr('value'));
+        self::assertSame('', $crawler->filter('#puzzlePickerFilters input[name="solved_max"]')->attr('value'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters select[name="since_unit"] option[value="d"][selected]'));
+    }
+
+    public function testFreePresetsAreLinksAndTheActiveOneIsHighlighted(): void
+    {
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $crawler = $browser->request('GET', '/en/what-to-solve-next');
+        $this->assertResponseIsSuccessful();
+
+        $presets = $crawler->filter('.puzzle-picker-presets .puzzle-picker-preset');
+        self::assertCount(6, $presets);
+        self::assertSame(
+            ['surprise_me', 'something_new', 'quick_one', 'dust_off', 'rating_grind', 'beat_my_record'],
+            $presets->each(static fn (Crawler $preset): string => (string) $preset->attr('data-preset')),
+        );
+        self::assertSame(['Surprise me', 'Something new', 'Quick one', 'Dust off the shelf', 'Rating grind', 'Beat my record'], $presets->each(static fn (Crawler $preset): string => trim($preset->text())));
+
+        $crawler->filter('a.puzzle-picker-preset')->each(static function (Crawler $preset): void {
+            self::assertSame('nofollow', $preset->attr('rel'));
+        });
+
+        // The bare default *is* "Surprise me"
+        self::assertStringContainsString('bg-primary', (string) $crawler->filter('a.puzzle-picker-preset[data-preset="surprise_me"]')->attr('class'));
+        self::assertCount(1, $crawler->filter('.puzzle-picker-preset.bg-primary'));
+
+        self::assertStringContainsString('predicted_max=60', (string) $crawler->filter('a.puzzle-picker-preset[data-preset="quick_one"]')->attr('href'));
+        self::assertStringContainsString('since=6', (string) $crawler->filter('a.puzzle-picker-preset[data-preset="dust_off"]')->attr('href'));
+        self::assertStringContainsString('since_unit=m', (string) $crawler->filter('a.puzzle-picker-preset[data-preset="dust_off"]')->attr('href'));
+        self::assertStringContainsString('community=rated', (string) $crawler->filter('a.puzzle-picker-preset[data-preset="rating_grind"]')->attr('href'));
+
+        // Following a preset highlights it (and only it)
+        $crawler = $browser->click($crawler->filter('a.puzzle-picker-preset[data-preset="dust_off"]')->link());
+        $this->assertResponseIsSuccessful();
+        self::assertStringContainsString('bg-primary', (string) $crawler->filter('.puzzle-picker-preset[data-preset="dust_off"]')->attr('class'));
+        self::assertCount(1, $crawler->filter('.puzzle-picker-preset.bg-primary'));
+        self::assertContains('Solved, but not in the last 6 months', self::chipLabels($crawler));
+
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?solved=never&pieces[]=500&community=rated&seed=abcd1234');
+        self::assertStringContainsString('bg-primary', (string) $crawler->filter('.puzzle-picker-preset[data-preset="rating_grind"]')->attr('class'));
+
+        // A tweak on top of a preset switches the highlight off
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?solved=never&pieces[]=500&pieces[]=1000&community=rated');
+        self::assertCount(0, $crawler->filter('.puzzle-picker-preset.bg-primary'));
+    }
+
+    public function testShareButtonCarriesTheSeededUrlOfTheCurrentPick(): void
+    {
+        $browser = self::createClient();
+
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?pieces[]=500&seed=abcd1234');
+
+        $this->assertResponseIsSuccessful();
+        $shareInput = $crawler->filter('.puzzle-picker-share input[readonly]');
+        self::assertCount(1, $shareInput);
+        self::assertSame('http://localhost/en/what-to-solve-next?pieces%5B0%5D=500&seed=abcd1234', $shareInput->attr('value'));
+
+        // Without a seed in the URL the generated one is shared, so the link reproduces this very draw
+        $crawler = $browser->request('GET', '/en/what-to-solve-next');
+        $shared = (string) $crawler->filter('.puzzle-picker-share input[readonly]')->attr('value');
+        self::assertMatchesRegularExpression('#^http://localhost/en/what-to-solve-next\?seed=[a-z0-9]{8}$#', $shared);
+
+        $sharedCrawler = $browser->request('GET', substr($shared, strlen('http://localhost')));
+        self::assertSame(
+            $crawler->filter('.puzzle-picker-card a.h5')->first()->attr('href'),
+            $sharedCrawler->filter('.puzzle-picker-card a.h5')->first()->attr('href'),
+            'The shared link shows the same first card',
+        );
+    }
+
+    public function testFiltersAreRememberedInTheSessionAndResetForgetsThem(): void
+    {
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_REGULAR);
+
+        // A filtered visit ...
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?pieces[]=500&solved=before&seed=abcd1234');
+        $this->assertResponseIsSuccessful();
+        self::assertEqualsCanonicalizing(['My collection', 'Solved before', '500 pieces'], self::chipLabels($crawler));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-remembered'));
+        self::assertStringContainsString('of 3 matching puzzles', (string) $browser->getResponse()->getContent());
+
+        // ... is applied again on the bare URL - no redirect, marker + reset link, seed not remembered
+        $crawler = $browser->request('GET', '/en/what-to-solve-next');
+        $this->assertResponseIsSuccessful();
+        self::assertSame('/en/what-to-solve-next', $browser->getRequest()->getRequestUri());
+        self::assertEqualsCanonicalizing(['My collection', 'Solved before', '500 pieces'], self::chipLabels($crawler));
+        self::assertCount(1, $crawler->filter('.puzzle-picker-remembered'));
+        self::assertStringContainsString('Your last filters', $crawler->filter('.puzzle-picker-remembered')->text());
+        self::assertCount(1, $crawler->filter('.puzzle-picker-filter-bar a.puzzle-picker-reset[href="/en/what-to-solve-next?reset=1"]'));
+        self::assertStringContainsString('of 3 matching puzzles', (string) $browser->getResponse()->getContent());
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="pieces[]"][value="500"][checked]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="solved"][value="before"][checked]'));
+        self::assertStringContainsString('<meta name="robots" content="index, follow">', (string) $browser->getResponse()->getContent(), 'Still the bare canonical URL');
+
+        $spin = $crawler->filter('a:contains("Pick another")');
+        self::assertStringContainsString('pieces', (string) $spin->attr('href'), 'Spinning keeps the remembered filters');
+        self::assertStringNotContainsString('abcd1234', (string) $spin->attr('href'));
+
+        // Changing a filter replaces the memory
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?pieces[]=1000');
+        $crawler = $browser->request('GET', '/en/what-to-solve-next');
+        self::assertEqualsCanonicalizing(['My collection', '1000 pieces'], self::chipLabels($crawler));
+
+        // Reset forgets it and renders the defaults; the next bare visit is bare again
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?reset=1');
+        $this->assertResponseIsSuccessful();
+        self::assertEqualsCanonicalizing(['My collection'], self::chipLabels($crawler));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-remembered'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-filter-bar a.puzzle-picker-reset'));
+        self::assertStringContainsString('of 7 matching puzzles', (string) $browser->getResponse()->getContent());
+
+        $crawler = $browser->request('GET', '/en/what-to-solve-next');
+        self::assertEqualsCanonicalizing(['My collection'], self::chipLabels($crawler));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-remembered'));
+
+        // Removing the last chip (a seed-only URL) forgets too - what you see is what is remembered
+        $browser->request('GET', '/en/what-to-solve-next?solved=before');
+        $browser->request('GET', '/en/what-to-solve-next?seed=abcd1234');
+        $crawler = $browser->request('GET', '/en/what-to-solve-next');
+        self::assertEqualsCanonicalizing(['My collection'], self::chipLabels($crawler));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-remembered'));
+    }
+
+    public function testGuestsNeverGetASessionFromThePicker(): void
+    {
+        $browser = self::createClient();
+
+        foreach (['/en/what-to-solve-next', '/en/what-to-solve-next?since=6&since_unit=m&pieces[]=500', '/en/what-to-solve-next?reset=1'] as $url) {
+            $browser->request('GET', $url);
+
+            $this->assertResponseIsSuccessful();
+            self::assertSame([], $browser->getResponse()->headers->getCookies(), "{$url} must not set a cookie");
+            self::assertFalse($browser->getRequest()->hasSession() && $browser->getRequest()->getSession()->isStarted(), "{$url} must not start a session");
+        }
+
+        // ... and are never shown remembered filters; their reset link is the bare URL, not ?reset=1
+        $crawler = $browser->request('GET', '/en/what-to-solve-next');
+        self::assertCount(0, $crawler->filter('.puzzle-picker-remembered'));
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?pieces[]=500');
+        self::assertCount(0, $crawler->filter('.puzzle-picker-remembered'));
+        self::assertCount(1, $crawler->filter('.puzzle-picker-filter-bar a.puzzle-picker-reset[href="/en/what-to-solve-next"]'), 'Guest reset link is the bare URL');
+    }
+
+    public function testMemberPicksFromSpecificCollections(): void
+    {
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        // System collection (sentinel) + "My Trefl Collection": 1000_02, 500_02, 1000_04, 1000_05
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?collections[]=' . Collection::SYSTEM_ID . '&collections[]=' . CollectionFixture::COLLECTION_STRIPE_TREFL . '&seed=abcd1234');
+
+        $this->assertResponseIsSuccessful();
+        $content = (string) $browser->getResponse()->getContent();
+
+        self::assertCount(4, $crawler->filter('.puzzle-picker-card'));
+        self::assertStringContainsString('of 4 matching puzzles', $content);
+        self::assertEqualsCanonicalizing(['Puzzle Collection', 'My Trefl Collection'], self::chipLabels($crawler), 'Collection chips replace the shelf chip');
+
+        // Chips remove one collection at a time
+        $treflChip = $crawler->filter('.puzzle-picker-filter-bar a[title="Remove this filter"]')->reduce(static fn (Crawler $chip): bool => str_contains($chip->text(), 'Trefl'));
+        self::assertStringContainsString(rawurlencode(Collection::SYSTEM_ID), (string) $treflChip->attr('href'));
+        self::assertStringNotContainsString(CollectionFixture::COLLECTION_STRIPE_TREFL, (string) $treflChip->attr('href'));
+
+        // Filters modal: checkbox list, system first, the two picked ones checked
+        $checkboxes = $crawler->filter('#puzzlePickerFilters input[name="collections[]"]');
+        self::assertCount(3, $checkboxes);
+        self::assertSame(Collection::SYSTEM_ID, $checkboxes->first()->attr('value'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="collections[]"][value="' . Collection::SYSTEM_ID . '"][checked]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="collections[]"][value="' . CollectionFixture::COLLECTION_STRIPE_TREFL . '"][checked]'));
+        self::assertCount(0, $crawler->filter('#puzzlePickerFilters input[name="collections[]"][value="' . CollectionFixture::COLLECTION_PUBLIC . '"][checked]'));
+        self::assertStringContainsString('Puzzle Collection', $crawler->filter('#puzzlePickerFilters .puzzle-picker-collections')->text());
+        self::assertStringContainsString('My Ravensburger Collection', $crawler->filter('#puzzlePickerFilters .puzzle-picker-collections')->text());
+        self::assertCount(0, $crawler->filter('#puzzlePickerFilters .puzzle-picker-collections-locked'));
+
+        // The empty state's "all puzzles" keeps the mood but drops the collections (they imply the shelf)
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?collections[]=' . CollectionFixture::COLLECTION_STRIPE_TREFL . '&pieces[]=9000');
+        self::assertCount(0, $crawler->filter('.puzzle-picker-card'));
+        $widen = $crawler->filter('.card a:contains("Pick from all puzzles")');
+        self::assertCount(1, $widen);
+        self::assertStringContainsString('source=any', (string) $widen->attr('href'));
+        self::assertStringContainsString('pieces', (string) $widen->attr('href'));
+        self::assertStringNotContainsString('collections', (string) $widen->attr('href'));
+    }
+
+    public function testNonMembersAndGuestsSeeTheCollectionsFilterLocked(): void
+    {
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_REGULAR);
+
+        // A crafted URL is ignored: the whole shelf, no collection chips
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?collections[]=' . CollectionFixture::COLLECTION_PRIVATE . '&seed=abcd1234');
+        $this->assertResponseIsSuccessful();
+        self::assertStringContainsString('of 7 matching puzzles', (string) $browser->getResponse()->getContent());
+        self::assertEqualsCanonicalizing(['My collection'], self::chipLabels($crawler));
+        self::assertCount(0, $crawler->filter('#puzzlePickerFilters input[name="collections[]"]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters .puzzle-picker-collections-locked'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters .puzzle-picker-collections button[data-bs-target="#membersExclusiveModal"]'));
+
+        self::ensureKernelShutdown();
+        $browser = self::createClient();
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?collections[]=' . Collection::SYSTEM_ID);
+        $this->assertResponseIsSuccessful();
+        self::assertCount(0, $crawler->filter('#puzzlePickerFilters input[name="collections[]"]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters .puzzle-picker-collections-locked'));
+        self::assertCount(0, $crawler->filter('#puzzlePickerFilters .puzzle-picker-collections button[data-bs-target="#membersExclusiveModal"]'), 'No members button for somebody who is not even signed in');
     }
 
     /**

--- a/tests/Query/GetPuzzlePickerSuggestionsTest.php
+++ b/tests/Query/GetPuzzlePickerSuggestionsTest.php
@@ -9,7 +9,9 @@ use SpeedPuzzling\Web\Query\GetPlayerPredictions;
 use SpeedPuzzling\Web\Query\GetPuzzlePickerSuggestions;
 use SpeedPuzzling\Web\Results\PuzzlePickerPick;
 use SpeedPuzzling\Web\Results\PuzzlePickerSuggestion;
+use SpeedPuzzling\Web\Entity\Collection;
 use SpeedPuzzling\Web\Services\PuzzleIntelligence\PuzzleIntelligenceRecalculator;
+use SpeedPuzzling\Web\Tests\DataFixtures\CollectionFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionApiFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\ManufacturerFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
@@ -429,6 +431,333 @@ final class GetPuzzlePickerSuggestionsTest extends KernelTestCase
         self::assertSame(0, $none->totalMatching);
     }
 
+
+    // ---------------------------------------------------------------------------------------------
+    // Precision filters: solve-count range, not solved since, my time thresholds, community results
+    // ---------------------------------------------------------------------------------------------
+
+    public function testSolveCountRangeCoversNeverBeforeAndBetween(): void
+    {
+        // PLAYER_REGULAR (all types counted, incl. the duo / team rows she owns and the untimed
+        // relax row): 3× on 500_01, 500_02, 500_03 and 1000_02; 1× on 1000_01, 1000_03, 1500_01,
+        // 2000, 300, INTEL_A and INTEL_B - 11 solved puzzles
+        $playerId = PlayerFixture::PLAYER_REGULAR;
+        $all = $this->pickAll(['source' => 'any', 'lent' => '1'], $playerId);
+        $threeTimes = [PuzzleFixture::PUZZLE_500_01, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_03, PuzzleFixture::PUZZLE_1000_02];
+        $once = [
+            PuzzleFixture::PUZZLE_1000_01,
+            PuzzleFixture::PUZZLE_1000_03,
+            PuzzleFixture::PUZZLE_1500_01,
+            PuzzleFixture::PUZZLE_2000,
+            PuzzleFixture::PUZZLE_300,
+            PuzzleIntelligenceFixture::INTEL_PUZZLE_A,
+            PuzzleIntelligenceFixture::INTEL_PUZZLE_B,
+        ];
+
+        self::assertEqualsCanonicalizing($threeTimes, self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'solved_min' => '3'], $playerId)));
+        self::assertEqualsCanonicalizing($threeTimes, self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'solved_min' => '3', 'solved_max' => '3'], $playerId)));
+        self::assertEqualsCanonicalizing($once, self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'solved_min' => '1', 'solved_max' => '1'], $playerId)));
+        self::assertEqualsCanonicalizing([...$threeTimes, ...$once], self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'solved_min' => '1'], $playerId)));
+        self::assertTrue($this->pickAll(['source' => 'any', 'lent' => '1', 'solved_min' => '2', 'solved_max' => '2'], $playerId)->isEmpty(), 'Nobody solved anything exactly twice');
+        self::assertTrue($this->pickAll(['source' => 'any', 'lent' => '1', 'solved_min' => '4'], $playerId)->isEmpty());
+
+        // "at most 2" = everything but the four 3× puzzles (never-solved included)
+        $atMostTwo = $this->pickAll(['source' => 'any', 'lent' => '1', 'solved_max' => '2'], $playerId);
+        self::assertSame($all->totalMatching - 4, $atMostTwo->totalMatching);
+        self::assertSame([], array_intersect($threeTimes, self::ids($atMostTwo)));
+
+        // The named shapes are the same ranges spelled short
+        self::assertSame(
+            self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'solved' => 'never'], $playerId)),
+            self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'solved_max' => '0'], $playerId)),
+        );
+        self::assertSame(
+            self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'solved' => 'before'], $playerId)),
+            self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'solved_min' => '1'], $playerId)),
+        );
+
+        foreach ($this->pickAll(['source' => 'any', 'lent' => '1', 'solved_min' => '1', 'solved_max' => '2'], $playerId)->suggestions as $suggestion) {
+            self::assertSame(1, $suggestion->mySolveCountAny);
+        }
+
+        // Guests: no history, the range is ignored
+        self::assertSame($this->pickAll([], null)->totalMatching, $this->pickAll(['solved_min' => '3'], null)->totalMatching);
+    }
+
+    public function testNotSolvedSinceKeepsNeverSolvedPuzzlesUnlessAskedNotTo(): void
+    {
+        // PLAYER_REGULAR's last solves: 500_01 3 d, 500_03 5 d, 1000_02 3 d (untimed relax row),
+        // 500_02 10 d, 1000_01 12 d (duo), 1000_03 8 d (team owner), 1500_01 30 d, 2000 35 d,
+        // 300 28 d, INTEL_A 36 d, INTEL_B 31 d
+        $playerId = PlayerFixture::PLAYER_REGULAR;
+        $all = $this->pickAll(['source' => 'any', 'lent' => '1'], $playerId);
+        $solvedCount = 11;
+        $olderThanThreeWeeks = [
+            PuzzleFixture::PUZZLE_1500_01,
+            PuzzleFixture::PUZZLE_2000,
+            PuzzleFixture::PUZZLE_300,
+            PuzzleIntelligenceFixture::INTEL_PUZZLE_A,
+            PuzzleIntelligenceFixture::INTEL_PUZZLE_B,
+        ];
+        $olderThanSixDays = [...$olderThanThreeWeeks, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_1000_01, PuzzleFixture::PUZZLE_1000_03];
+
+        // Never-solved puzzles are "not solved since forever" and included by default
+        $weeks = $this->pickAll(['source' => 'any', 'lent' => '1', 'since' => '3', 'since_unit' => 'w'], $playerId);
+        self::assertSame($all->totalMatching - $solvedCount + count($olderThanThreeWeeks), $weeks->totalMatching);
+
+        foreach ($olderThanThreeWeeks as $puzzleId) {
+            self::assertContains($puzzleId, self::ids($weeks));
+        }
+
+        foreach ([PuzzleFixture::PUZZLE_500_01, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_03, PuzzleFixture::PUZZLE_1000_01, PuzzleFixture::PUZZLE_1000_02, PuzzleFixture::PUZZLE_1000_03] as $puzzleId) {
+            self::assertNotContains($puzzleId, self::ids($weeks), 'Solved within the last three weeks');
+        }
+
+        self::assertContains(PuzzleFixture::PUZZLE_9000, self::ids($weeks), 'Never solved');
+
+        // ... unless only puzzles solved before are wanted
+        self::assertEqualsCanonicalizing($olderThanThreeWeeks, self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'since' => '3', 'since_unit' => 'w', 'since_require_solved' => '1'], $playerId)));
+        self::assertEqualsCanonicalizing($olderThanSixDays, self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'since' => '6', 'since_require_solved' => '1'], $playerId)), 'Days are the default unit');
+        self::assertEqualsCanonicalizing($olderThanSixDays, self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'since' => '6', 'since_unit' => 'd', 'since_require_solved' => '1'], $playerId)));
+
+        // Months go through the same clock arithmetic as the query
+        /** @var list<string> $olderThanAMonth */
+        $olderThanAMonth = $this->database->fetchFirstColumn(
+            'SELECT puzzle_id FROM puzzle_solving_time WHERE player_id = :playerId GROUP BY puzzle_id HAVING max(COALESCE(finished_at, tracked_at)) < :threshold',
+            ['playerId' => $playerId, 'threshold' => (new \DateTimeImmutable())->modify('-1 months')->format('Y-m-d H:i:s')],
+        );
+        self::assertNotSame([], $olderThanAMonth);
+        self::assertEqualsCanonicalizing($olderThanAMonth, self::ids($this->pickAll(['source' => 'any', 'lent' => '1', 'since' => '1', 'since_unit' => 'm', 'since_require_solved' => '1'], $playerId)));
+
+        // "Dust off the shelf": my shelf, solved before, not in the last 6 months - PLAYER_REGULAR
+        // solved everything on her shelf within the last five weeks
+        self::assertTrue($this->pickAll(['since' => '6', 'since_unit' => 'm', 'since_require_solved' => '1'], $playerId)->isEmpty());
+        self::assertSame(2, $this->pickAll(['since' => '4', 'since_unit' => 'w', 'since_require_solved' => '1'], $playerId)->totalMatching, '1500_01 (30 d) and 2000 (35 d) on the shelf');
+
+        // Guests: no history, the period is ignored
+        self::assertSame($this->pickAll([], null)->totalMatching, $this->pickAll(['since' => '3', 'since_unit' => 'w', 'since_require_solved' => '1'], null)->totalMatching);
+    }
+
+    public function testNotSolvedSinceCountsTeamSolvesWhereIAmOnlyAParticipant(): void
+    {
+        // PLAYER_PRIVATE is a participant of team-002 on PUZZLE_1000_03 (8 days ago) and owns
+        // no row on that puzzle: her "last solved" is the team date
+        $playerId = PlayerFixture::PLAYER_PRIVATE;
+
+        self::assertContains(PuzzleFixture::PUZZLE_1000_03, self::ids($this->pickAll(['source' => 'any', 'since' => '6', 'since_require_solved' => '1'], $playerId)), 'Solved 8 days ago = not in the last 6 days, and solved before');
+        self::assertNotContains(PuzzleFixture::PUZZLE_1000_03, self::ids($this->pickAll(['source' => 'any', 'since' => '10', 'since_require_solved' => '1'], $playerId)));
+        self::assertContains(PuzzleFixture::PUZZLE_1000_03, self::ids($this->pickAll(['source' => 'any', 'since' => '6'], $playerId)));
+        self::assertNotContains(PuzzleFixture::PUZZLE_1000_03, self::ids($this->pickAll(['source' => 'any', 'since' => '10'], $playerId)), 'Team participation counts as a recent solve - the puzzle is not "never solved"');
+
+        // team-001 on PUZZLE_1000_01: her own solo row is 22 days old, the team row 12 days old
+        self::assertNotContains(PuzzleFixture::PUZZLE_1000_01, self::ids($this->pickAll(['source' => 'any', 'since' => '2', 'since_unit' => 'w', 'since_require_solved' => '1'], $playerId)), 'The newer team date wins over the older own row');
+        self::assertContains(PuzzleFixture::PUZZLE_1000_01, self::ids($this->pickAll(['source' => 'any', 'since' => '11', 'since_require_solved' => '1'], $playerId)));
+    }
+
+    public function testMyTimeThresholdsCompareOneOfMySoloTimesAndSkipPuzzlesWithoutOne(): void
+    {
+        // PLAYER_REGULAR solo times (fastest / first / latest, seconds):
+        // 500_01 1750 / 1800 / 1750, 500_02 1700 / 2200 / 1700, 500_03 1700 / 1950 / 1700,
+        // 1000_02 3950 / 3950 / 4500, 1500_01 7200, 2000 10800, 300 800, INTEL_A 1900, INTEL_B 1850;
+        // 1000_01 and 1000_03 are solved but have no solo time
+        $playerId = PlayerFixture::PLAYER_REGULAR;
+        $base = ['source' => 'any', 'lent' => '1'];
+
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_500_01, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_03, PuzzleFixture::PUZZLE_300],
+            self::ids($this->pickAll($base + ['my_time' => 'fastest', 'my_time_op' => 'lt', 'my_time_minutes' => '30'], $playerId)),
+        );
+        self::assertEqualsCanonicalizing(
+            [PuzzleIntelligenceFixture::INTEL_PUZZLE_A, PuzzleFixture::PUZZLE_1000_02, PuzzleFixture::PUZZLE_1500_01, PuzzleFixture::PUZZLE_2000],
+            self::ids($this->pickAll($base + ['my_time' => 'fastest', 'my_time_op' => 'gt', 'my_time_minutes' => '31'], $playerId)),
+        );
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_500_01, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_03, PuzzleFixture::PUZZLE_300, PuzzleIntelligenceFixture::INTEL_PUZZLE_B],
+            self::ids($this->pickAll($base + ['my_time' => 'latest', 'my_time_minutes' => '31'], $playerId)),
+            '"under" is the default operator',
+        );
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_1000_02, PuzzleFixture::PUZZLE_1500_01, PuzzleFixture::PUZZLE_2000],
+            self::ids($this->pickAll($base + ['my_time' => 'latest', 'my_time_op' => 'gt', 'my_time_minutes' => '60'], $playerId)),
+        );
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_500_01, PuzzleIntelligenceFixture::INTEL_PUZZLE_B, PuzzleFixture::PUZZLE_300],
+            self::ids($this->pickAll($base + ['my_time' => 'first', 'my_time_op' => 'lt', 'my_time_minutes' => '31'], $playerId)),
+        );
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_03, PuzzleIntelligenceFixture::INTEL_PUZZLE_A, PuzzleFixture::PUZZLE_1000_02, PuzzleFixture::PUZZLE_1500_01, PuzzleFixture::PUZZLE_2000],
+            self::ids($this->pickAll($base + ['my_time' => 'first', 'my_time_op' => 'gt', 'my_time_minutes' => '31'], $playerId)),
+        );
+
+        // Puzzles without a solo time never match, whatever the direction
+        foreach (['lt', 'gt'] as $op) {
+            $ids = self::ids($this->pickAll($base + ['my_time' => 'fastest', 'my_time_op' => $op, 'my_time_minutes' => '600'], $playerId));
+            self::assertNotContains(PuzzleFixture::PUZZLE_1000_01, $ids);
+            self::assertNotContains(PuzzleFixture::PUZZLE_1000_03, $ids);
+            self::assertNotContains(PuzzleFixture::PUZZLE_9000, $ids);
+        }
+
+        // Combines with the other filters
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_500_01, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_03],
+            self::ids($this->pickAll($base + ['my_time' => 'fastest', 'my_time_minutes' => '30', 'pieces' => ['500']], $playerId)),
+        );
+
+        // Guests: no times, the threshold is ignored
+        self::assertSame($this->pickAll([], null)->totalMatching, $this->pickAll(['my_time' => 'fastest', 'my_time_minutes' => '30'], null)->totalMatching);
+    }
+
+    public function testCommunityResultsThresholdsUseTheSoloSolveCount(): void
+    {
+        /** @var list<string> $expectedFew */
+        $expectedFew = $this->database->fetchFirstColumn(
+            'SELECT p.id FROM puzzle p LEFT JOIN puzzle_statistics ps ON ps.puzzle_id = p.id WHERE p.approved = true AND (p.hide_until IS NULL OR p.hide_until < now()) AND COALESCE(ps.solved_times_solo_count, 0) <= 5',
+        );
+        $few = $this->pickAll(['community' => 'few'], null);
+
+        self::assertEqualsCanonicalizing($expectedFew, self::ids($few));
+        self::assertContains(PuzzleFixture::PUZZLE_9000, self::ids($few), 'No statistics row = zero solves = few');
+        self::assertContains(PuzzleFixture::PUZZLE_1500_02, self::ids($few), 'One solo solve');
+        self::assertNotContains(PuzzleFixture::PUZZLE_500_01, self::ids($few), 'Eleven solo solves');
+        self::assertLessThan($this->pickAll([], null)->totalMatching, $few->totalMatching);
+
+        foreach ($few->suggestions as $suggestion) {
+            self::assertLessThanOrEqual(5, $suggestion->communitySolvedCountSolo);
+        }
+
+        // Nothing in the fixtures reaches 20 solo solves - until we say so
+        self::assertTrue($this->pickAll(['community' => 'rated'], null)->isEmpty());
+        self::assertTrue($this->pickAll(['community' => 'popular'], null)->isEmpty());
+
+        $this->database->executeStatement('UPDATE puzzle_statistics SET solved_times_solo_count = 20 WHERE puzzle_id = :id', ['id' => PuzzleFixture::PUZZLE_500_02]);
+        self::assertSame([PuzzleFixture::PUZZLE_500_02], self::ids($this->pickAll(['community' => 'rated'], null)));
+        self::assertTrue($this->pickAll(['community' => 'popular'], null)->isEmpty(), '20 is rated, not yet popular');
+        self::assertNotContains(PuzzleFixture::PUZZLE_500_02, self::ids($this->pickAll(['community' => 'few'], null)));
+
+        $this->database->executeStatement('UPDATE puzzle_statistics SET solved_times_solo_count = 49 WHERE puzzle_id = :id', ['id' => PuzzleFixture::PUZZLE_500_02]);
+        self::assertTrue($this->pickAll(['community' => 'popular'], null)->isEmpty());
+
+        $this->database->executeStatement('UPDATE puzzle_statistics SET solved_times_solo_count = 50 WHERE puzzle_id = :id', ['id' => PuzzleFixture::PUZZLE_500_02]);
+        self::assertSame([PuzzleFixture::PUZZLE_500_02], self::ids($this->pickAll(['community' => 'popular'], null)));
+        self::assertSame([PuzzleFixture::PUZZLE_500_02], self::ids($this->pickAll(['community' => 'rated'], null)), 'Popular is also rated');
+
+        // "Rating grind": 500 pieces, never solved by me, rated - every fixture player solved
+        // 500_02, so a second rated puzzle is needed: 500_05 (solved by PLAYER_ADMIN and
+        // PLAYER_PRIVATE only)
+        $this->database->executeStatement('UPDATE puzzle_statistics SET solved_times_solo_count = 20 WHERE puzzle_id = :id', ['id' => PuzzleFixture::PUZZLE_500_05]);
+        self::assertEqualsCanonicalizing([PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_05], self::ids($this->pickAll(['pieces' => ['500'], 'community' => 'rated'], null)));
+        self::assertTrue($this->pickAll(['source' => 'any', 'pieces' => ['500'], 'solved' => 'never', 'community' => 'rated'], PlayerFixture::PLAYER_PRIVATE)->isEmpty(), 'PLAYER_PRIVATE solved both');
+        self::assertSame([PuzzleFixture::PUZZLE_500_05], self::ids($this->pickAll(['source' => 'any', 'pieces' => ['500'], 'solved' => 'never', 'community' => 'rated', 'lent' => '1'], PlayerFixture::PLAYER_WITH_FAVORITES)), 'PLAYER_WITH_FAVORITES never solved 500_05');
+
+        // Statistics are joined once even when the community budget needs them too
+        $fewNow = $this->pickAll(['community' => 'few'], null);
+        $budgetAndFew = $this->pickAll(['community' => 'few', 'predicted_max' => '60'], null);
+        $budget = $this->pickAll(['predicted_max' => '60'], null);
+        self::assertNotSame([], self::ids($budgetAndFew));
+        self::assertEqualsCanonicalizing(array_values(array_intersect(self::ids($budget), self::ids($fewNow))), self::ids($budgetAndFew));
+        self::assertSame(array_values(array_unique(self::ids($budgetAndFew))), self::ids($budgetAndFew), 'No duplicate rows from the single statistics join');
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Specific collections (members)
+    // ---------------------------------------------------------------------------------------------
+
+    public function testMembersCanPickFromSpecificCollectionsIncludingTheSystemOne(): void
+    {
+        // PLAYER_WITH_STRIPE (member): COLLECTION_PUBLIC = 500_01, 500_02, 1000_01, 1000_03,
+        // 1000_05, 300, 500_04, 500_05; COLLECTION_STRIPE_TREFL = 1000_04, 500_02, 1000_05;
+        // system collection = 500_03, 1000_02, 1500_01, 2000, 500_02. Lent out (hidden by
+        // default): 2000, 1500_01, 1000_01 (returned row still counts), 500_03. Borrowed:
+        // 1500_02, 3000.
+        $playerId = PlayerFixture::PLAYER_WITH_STRIPE;
+
+        $public = $this->pickAll(['collections' => [CollectionFixture::COLLECTION_PUBLIC]], $playerId, member: true);
+        self::assertEqualsCanonicalizing([
+            PuzzleFixture::PUZZLE_500_01,
+            PuzzleFixture::PUZZLE_500_02,
+            PuzzleFixture::PUZZLE_1000_03,
+            PuzzleFixture::PUZZLE_1000_05,
+            PuzzleFixture::PUZZLE_300,
+            PuzzleFixture::PUZZLE_500_04,
+            PuzzleFixture::PUZZLE_500_05,
+        ], self::ids($public));
+        self::assertSame(7, $public->totalMatching);
+
+        foreach ($public->suggestions as $suggestion) {
+            self::assertTrue($suggestion->inMyCollection);
+        }
+
+        // Lent-out items of the collection come back when asked for
+        self::assertEqualsCanonicalizing(
+            [...self::ids($public), PuzzleFixture::PUZZLE_1000_01],
+            self::ids($this->pickAll(['collections' => [CollectionFixture::COLLECTION_PUBLIC], 'lent' => '1'], $playerId, member: true)),
+        );
+
+        $trefl = $this->pickAll(['collections' => [CollectionFixture::COLLECTION_STRIPE_TREFL]], $playerId, member: true);
+        self::assertEqualsCanonicalizing([PuzzleFixture::PUZZLE_1000_04, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_1000_05], self::ids($trefl));
+
+        // Several collections are OR-ed (500_02 and 1000_05 are in both - once each)
+        $both = $this->pickAll(['collections' => [CollectionFixture::COLLECTION_PUBLIC, CollectionFixture::COLLECTION_STRIPE_TREFL]], $playerId, member: true);
+        self::assertEqualsCanonicalizing(array_values(array_unique([...self::ids($public), ...self::ids($trefl)])), self::ids($both));
+        self::assertSame(8, $both->totalMatching);
+
+        // The system collection is the sentinel id (its items have collection_id NULL)
+        $system = $this->pickAll(['collections' => [Collection::SYSTEM_ID]], $playerId, member: true);
+        self::assertEqualsCanonicalizing([PuzzleFixture::PUZZLE_1000_02, PuzzleFixture::PUZZLE_500_02], self::ids($system));
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_1000_02, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_03, PuzzleFixture::PUZZLE_1500_01, PuzzleFixture::PUZZLE_2000],
+            self::ids($this->pickAll(['collections' => [Collection::SYSTEM_ID], 'lent' => '1'], $playerId, member: true)),
+        );
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_1000_02, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_1000_04, PuzzleFixture::PUZZLE_1000_05],
+            self::ids($this->pickAll(['collections' => [Collection::SYSTEM_ID, CollectionFixture::COLLECTION_STRIPE_TREFL]], $playerId, member: true)),
+            'System sentinel and a custom collection together',
+        );
+
+        // Borrowed puzzles are on my shelf but in none of my collections
+        $mine = $this->pickAll(['source' => 'mine'], $playerId, member: true);
+        self::assertContains(PuzzleFixture::PUZZLE_1500_02, self::ids($mine));
+        self::assertContains(PuzzleFixture::PUZZLE_3000, self::ids($mine));
+        self::assertNotContains(PuzzleFixture::PUZZLE_1500_02, self::ids($system));
+        self::assertNotContains(PuzzleFixture::PUZZLE_3000, self::ids($both));
+        self::assertEqualsCanonicalizing(
+            self::ids($mine),
+            array_values(array_unique([...self::ids($both), ...self::ids($system), PuzzleFixture::PUZZLE_1500_02, PuzzleFixture::PUZZLE_3000])),
+            'All collections + borrowed = my shelf',
+        );
+
+        // Collections imply my shelf, whatever the source parameter says
+        self::assertSame(
+            self::ids($trefl),
+            self::ids($this->pickAll(['source' => 'any', 'collections' => [CollectionFixture::COLLECTION_STRIPE_TREFL]], $playerId, member: true)),
+        );
+
+        // Somebody else's collection matches nothing (only my own items are looked at)
+        self::assertTrue($this->pickAll(['collections' => [CollectionFixture::COLLECTION_PRIVATE]], $playerId, member: true)->isEmpty());
+
+        // Combines with the free filters
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_500_01, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_04, PuzzleFixture::PUZZLE_500_05],
+            self::ids($this->pickAll(['collections' => [CollectionFixture::COLLECTION_PUBLIC], 'pieces' => ['500']], $playerId, member: true)),
+        );
+        self::assertEqualsCanonicalizing(
+            [PuzzleFixture::PUZZLE_1000_03, PuzzleFixture::PUZZLE_1000_05, PuzzleFixture::PUZZLE_300, PuzzleFixture::PUZZLE_500_04, PuzzleFixture::PUZZLE_500_05],
+            self::ids($this->pickAll(['collections' => [CollectionFixture::COLLECTION_PUBLIC], 'solved' => 'never'], $playerId, member: true)),
+            'Something new from this collection',
+        );
+    }
+
+    public function testCollectionsAreIgnoredForNonMembers(): void
+    {
+        // PLAYER_REGULAR is no member: her whole 7-puzzle shelf, not just COLLECTION_PRIVATE
+        $stripped = $this->pickAll(['collections' => [CollectionFixture::COLLECTION_PRIVATE]], PlayerFixture::PLAYER_REGULAR);
+
+        self::assertSame(7, $stripped->totalMatching);
+        self::assertSame(self::ids($this->pickAll(['source' => 'mine'], PlayerFixture::PLAYER_REGULAR)), self::ids($stripped));
+
+        // ... and for guests
+        self::assertSame($this->pickAll([], null)->totalMatching, $this->pickAll(['collections' => [Collection::SYSTEM_ID]], null)->totalMatching);
+    }
 
     // ---------------------------------------------------------------------------------------------
     // Insights layer (members): difficulty tiers, gap vs. my prediction, gap orders, time budget

--- a/tests/Value/PuzzlePickerCriteriaTest.php
+++ b/tests/Value/PuzzlePickerCriteriaTest.php
@@ -6,9 +6,15 @@ namespace SpeedPuzzling\Web\Tests\Value;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use SpeedPuzzling\Web\Entity\Collection;
+use SpeedPuzzling\Web\Value\PuzzlePickerCommunity;
 use SpeedPuzzling\Web\Value\PuzzlePickerCriteria;
 use SpeedPuzzling\Web\Value\PuzzlePickerGap;
+use SpeedPuzzling\Web\Value\PuzzlePickerMyTime;
+use SpeedPuzzling\Web\Value\PuzzlePickerMyTimeOperator;
 use SpeedPuzzling\Web\Value\PuzzlePickerOrder;
+use SpeedPuzzling\Web\Value\PuzzlePickerPreset;
+use SpeedPuzzling\Web\Value\PuzzlePickerSinceUnit;
 use SpeedPuzzling\Web\Value\PuzzlePickerSolved;
 use SpeedPuzzling\Web\Value\PuzzlePickerSource;
 use Symfony\Component\HttpFoundation\Request;
@@ -564,5 +570,322 @@ final class PuzzlePickerCriteriaTest extends TestCase
         // Gap chip without a minimum
         $plain = PuzzlePickerCriteria::fromRequest(new Request(['gap' => 'faster']), true, true, true)->activeFilters();
         self::assertSame('puzzle_picker.chips.gap.faster', $plain[1]->translationKey);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Precision filters: solve-count range, "not solved since", my time, community results
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array{int, null|int} $expectedRange
+     * @param array<string, mixed> $expectedParams
+     */
+    #[DataProvider('provideSolveCountRanges')]
+    public function testSolvedStateIsOneSolveCountRange(array $query, array $expectedRange, PuzzlePickerSolved $expectedShape, array $expectedParams): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request($query), isAuthenticated: true);
+
+        self::assertSame($expectedRange, [$criteria->solvedMin, $criteria->solvedMax]);
+        self::assertSame($expectedShape, $criteria->solved);
+        self::assertSame($expectedParams, $criteria->toQueryParams());
+        self::assertEquals($criteria, PuzzlePickerCriteria::fromRequest(new Request($criteria->toQueryParams()), true), 'Round trip');
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, array{int, null|int}, PuzzlePickerSolved, array<string, mixed>}>
+     */
+    public static function provideSolveCountRanges(): iterable
+    {
+        yield 'any' => [[], [0, null], PuzzlePickerSolved::Any, []];
+        yield 'never' => [['solved' => 'never'], [0, 0], PuzzlePickerSolved::Never, ['solved' => 'never']];
+        yield 'before' => [['solved' => 'before'], [1, null], PuzzlePickerSolved::Before, ['solved' => 'before']];
+        yield 'explicit never' => [['solved_max' => '0'], [0, 0], PuzzlePickerSolved::Never, ['solved' => 'never']];
+        yield 'explicit before' => [['solved_min' => '1'], [1, null], PuzzlePickerSolved::Before, ['solved' => 'before']];
+        yield 'between' => [['solved_min' => '2', 'solved_max' => '5'], [2, 5], PuzzlePickerSolved::Any, ['solved_min' => '2', 'solved_max' => '5']];
+        yield 'between reversed is normalized' => [['solved_min' => '5', 'solved_max' => '2'], [2, 5], PuzzlePickerSolved::Any, ['solved_min' => '2', 'solved_max' => '5']];
+        yield 'at least' => [['solved_min' => '3'], [3, null], PuzzlePickerSolved::Any, ['solved_min' => '3']];
+        yield 'at most' => [['solved_max' => '3'], [0, 3], PuzzlePickerSolved::Any, ['solved_max' => '3']];
+        yield 'before refined by a maximum' => [['solved' => 'before', 'solved_max' => '5'], [1, 5], PuzzlePickerSolved::Any, ['solved_min' => '1', 'solved_max' => '5']];
+        yield 'before refined by a minimum' => [['solved' => 'before', 'solved_min' => '2'], [2, null], PuzzlePickerSolved::Any, ['solved_min' => '2']];
+        yield 'explicit minimum wins over never' => [['solved' => 'never', 'solved_min' => '2'], [2, null], PuzzlePickerSolved::Any, ['solved_min' => '2']];
+        yield 'explicit maximum wins over before' => [['solved' => 'before', 'solved_max' => '0'], [0, 0], PuzzlePickerSolved::Never, ['solved' => 'never']];
+        yield 'zero minimum is no bound' => [['solved_min' => '0'], [0, null], PuzzlePickerSolved::Any, []];
+        yield 'blank inputs from the form' => [['solved' => 'any', 'solved_min' => '', 'solved_max' => ''], [0, null], PuzzlePickerSolved::Any, []];
+        yield 'garbage is dropped' => [['solved_min' => 'many', 'solved_max' => '1000'], [0, null], PuzzlePickerSolved::Any, []];
+    }
+
+    public function testSolveCountChipDescribesTheWholeRangeAndClearsItAtOnce(): void
+    {
+        $chip = static function (array $query): \SpeedPuzzling\Web\Value\PuzzlePickerActiveFilter {
+            $filters = PuzzlePickerCriteria::fromRequest(new Request(['source' => 'any'] + $query), true)->activeFilters();
+            self::assertCount(1, $filters);
+
+            return $filters[0];
+        };
+
+        self::assertSame('puzzle_picker.chips.solved.never', $chip(['solved' => 'never'])->translationKey);
+        self::assertSame('puzzle_picker.chips.solved.before', $chip(['solved' => 'before'])->translationKey);
+        self::assertSame('puzzle_picker.chips.solved.exact', $chip(['solved_min' => '3', 'solved_max' => '3'])->translationKey);
+        self::assertSame(['%count%' => 3], $chip(['solved_min' => '3', 'solved_max' => '3'])->translationParameters);
+        self::assertSame('puzzle_picker.chips.solved.between', $chip(['solved_min' => '2', 'solved_max' => '5'])->translationKey);
+        self::assertSame(['%min%' => 2, '%max%' => 5], $chip(['solved_min' => '2', 'solved_max' => '5'])->translationParameters);
+        self::assertSame('puzzle_picker.chips.solved.at_least', $chip(['solved_min' => '2'])->translationKey);
+        self::assertSame('puzzle_picker.chips.solved.at_most', $chip(['solved_max' => '4'])->translationKey);
+        self::assertSame(['%max%' => 4], $chip(['solved_max' => '4'])->translationParameters);
+
+        self::assertSame('solved', $chip(['solved' => 'before', 'solved_max' => '5'])->key);
+        self::assertSame(['source' => 'any'], $chip(['solved' => 'before', 'solved_max' => '5'])->queryParametersWithoutThis, 'The × drops the shape and both bounds');
+
+        self::assertSame([], PuzzlePickerCriteria::fromRequest(new Request(['source' => 'any', 'solved_min' => '0']), true)->activeFilters());
+    }
+
+    public function testNotSolvedSinceParsesAmountUnitAndTheSolvedOnlySwitch(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request(['since' => '6', 'since_unit' => 'm', 'since_require_solved' => '1']), true);
+
+        self::assertSame(6, $criteria->sinceAmount);
+        self::assertSame(PuzzlePickerSinceUnit::Month, $criteria->sinceUnit);
+        self::assertTrue($criteria->sinceRequireSolved);
+        self::assertTrue($criteria->hasPersonalFilters());
+        self::assertFalse($criteria->isDefault());
+        self::assertSame(['since' => '6', 'since_unit' => 'm', 'since_require_solved' => '1'], $criteria->toQueryParams());
+        self::assertEquals($criteria, PuzzlePickerCriteria::fromRequest(new Request($criteria->toQueryParams()), true));
+
+        // Days are the default unit and are not spelled out; unknown units fall back to days
+        self::assertSame(['since' => '30'], PuzzlePickerCriteria::fromRequest(new Request(['since' => '30']), true)->toQueryParams());
+        self::assertSame(PuzzlePickerSinceUnit::Day, PuzzlePickerCriteria::fromRequest(new Request(['since' => '30', 'since_unit' => 'y']), true)->sinceUnit);
+        self::assertSame(['since' => '2', 'since_unit' => 'w'], PuzzlePickerCriteria::fromRequest(new Request(['since' => '2', 'since_unit' => 'w']), true)->toQueryParams());
+
+        // Without a period the unit and the checkbox mean nothing
+        $none = PuzzlePickerCriteria::fromRequest(new Request(['since_unit' => 'm', 'since_require_solved' => '1']), true);
+        self::assertNull($none->sinceAmount);
+        self::assertFalse($none->sinceRequireSolved);
+        self::assertTrue($none->isDefault());
+
+        foreach (['0', '-3', '1000', 'six', ''] as $invalid) {
+            self::assertNull(PuzzlePickerCriteria::fromRequest(new Request(['since' => $invalid, 'since_unit' => 'm']), true)->sinceAmount, "since={$invalid}");
+        }
+
+        // Guests have no history
+        self::assertNull(PuzzlePickerCriteria::fromRequest(new Request(['since' => '6', 'since_unit' => 'm']), false)->sinceAmount);
+        self::assertSame([], PuzzlePickerCriteria::fromRequest(new Request(['since' => '6', 'since_unit' => 'm']), false)->toQueryParams());
+
+        self::assertSame('-6 months', PuzzlePickerSinceUnit::Month->modifier(6));
+        self::assertSame('-2 weeks', PuzzlePickerSinceUnit::Week->modifier(2));
+        self::assertSame('-30 days', PuzzlePickerSinceUnit::Day->modifier(30));
+    }
+
+    public function testNotSolvedSinceChips(): void
+    {
+        $filters = PuzzlePickerCriteria::fromRequest(new Request(['source' => 'any', 'since' => '6', 'since_unit' => 'm', 'seed' => 'abcd1234']), true)->activeFilters();
+        self::assertCount(1, $filters);
+        self::assertSame('since', $filters[0]->key);
+        self::assertSame('puzzle_picker.chips.since.m', $filters[0]->translationKey);
+        self::assertSame(['%count%' => 6], $filters[0]->translationParameters);
+        self::assertSame(['source' => 'any', 'seed' => 'abcd1234'], $filters[0]->queryParametersWithoutThis);
+
+        $solvedOnly = PuzzlePickerCriteria::fromRequest(new Request(['source' => 'any', 'since' => '3', 'since_unit' => 'w', 'since_require_solved' => '1']), true)->activeFilters();
+        self::assertSame('puzzle_picker.chips.since_solved.w', $solvedOnly[0]->translationKey);
+        self::assertSame(['source' => 'any'], $solvedOnly[0]->queryParametersWithoutThis, 'The × drops the period, the unit and the switch together');
+
+        $days = PuzzlePickerCriteria::fromRequest(new Request(['source' => 'any', 'since' => '10']), true)->activeFilters();
+        self::assertSame('puzzle_picker.chips.since.d', $days[0]->translationKey);
+    }
+
+    public function testMyTimeThresholdNeedsMetricAndMinutes(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request(['my_time' => 'latest', 'my_time_op' => 'gt', 'my_time_minutes' => '90']), true);
+
+        self::assertSame(PuzzlePickerMyTime::Latest, $criteria->myTime);
+        self::assertSame(PuzzlePickerMyTimeOperator::Over, $criteria->myTimeOperator);
+        self::assertSame(90, $criteria->myTimeMinutes);
+        self::assertSame(5400, $criteria->myTimeSeconds());
+        self::assertTrue($criteria->hasPersonalFilters());
+        self::assertFalse($criteria->isDefault());
+        self::assertSame(['my_time' => 'latest', 'my_time_op' => 'gt', 'my_time_minutes' => '90'], $criteria->toQueryParams());
+        self::assertEquals($criteria, PuzzlePickerCriteria::fromRequest(new Request($criteria->toQueryParams()), true));
+
+        // "under" is the default operator and is not spelled out; unknown operators fall back to it
+        $under = PuzzlePickerCriteria::fromRequest(new Request(['my_time' => 'fastest', 'my_time_minutes' => '30']), true);
+        self::assertSame(PuzzlePickerMyTimeOperator::Under, $under->myTimeOperator);
+        self::assertSame(['my_time' => 'fastest', 'my_time_minutes' => '30'], $under->toQueryParams());
+        self::assertSame(PuzzlePickerMyTimeOperator::Under, PuzzlePickerCriteria::fromRequest(new Request(['my_time' => 'first', 'my_time_op' => 'eq', 'my_time_minutes' => '30']), true)->myTimeOperator);
+
+        // Half a filter is no filter
+        foreach (
+            [
+            ['my_time' => 'fastest'],
+            ['my_time_minutes' => '30'],
+            ['my_time' => 'fastest', 'my_time_minutes' => ''],
+            ['my_time' => '', 'my_time_op' => 'gt', 'my_time_minutes' => '30'],
+            ['my_time' => 'average', 'my_time_minutes' => '30'],
+            ['my_time' => 'fastest', 'my_time_minutes' => '0'],
+            ['my_time' => 'fastest', 'my_time_minutes' => '1441'],
+            ['my_time' => ['fastest'], 'my_time_minutes' => ['30']],
+            ] as $query
+        ) {
+            $none = PuzzlePickerCriteria::fromRequest(new Request($query), true);
+            self::assertNull($none->myTime, json_encode($query) ?: '');
+            self::assertNull($none->myTimeMinutes);
+            self::assertNull($none->myTimeSeconds());
+            self::assertTrue($none->isDefault());
+        }
+
+        // Guests have no times
+        self::assertNull(PuzzlePickerCriteria::fromRequest(new Request(['my_time' => 'fastest', 'my_time_minutes' => '30']), false)->myTime);
+
+        $chip = PuzzlePickerCriteria::fromRequest(new Request(['source' => 'any', 'my_time' => 'first', 'my_time_op' => 'gt', 'my_time_minutes' => '45', 'pieces' => ['500']]), true)->activeFilters();
+        self::assertSame(['my_time', 'pieces:500'], array_map(static fn ($filter) => $filter->key, $chip));
+        self::assertSame('puzzle_picker.chips.my_time.first_gt', $chip[0]->translationKey);
+        self::assertSame(['%minutes%' => 45], $chip[0]->translationParameters);
+        self::assertSame(['source' => 'any', 'pieces' => ['500']], $chip[0]->queryParametersWithoutThis, 'The × drops metric, operator and minutes together');
+        self::assertSame('puzzle_picker.chips.my_time.fastest_lt', $under->activeFilters()[1]->translationKey);
+    }
+
+    public function testCommunityResultsFilterIsFreeForEveryone(): void
+    {
+        foreach (['few' => PuzzlePickerCommunity::Few, 'rated' => PuzzlePickerCommunity::Rated, 'popular' => PuzzlePickerCommunity::Popular] as $value => $expected) {
+            self::assertSame($expected, PuzzlePickerCriteria::fromRequest(new Request(['community' => $value]), true)->community);
+            self::assertSame($expected, PuzzlePickerCriteria::fromRequest(new Request(['community' => $value]), false)->community, 'Guests keep the community filter');
+        }
+
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request(['community' => 'rated', 'seed' => 'abcd1234']), false);
+        self::assertSame(['community' => 'rated', 'seed' => 'abcd1234'], $criteria->toQueryParams());
+        self::assertFalse($criteria->isDefault());
+        self::assertFalse($criteria->hasPersonalFilters(), 'Community results are not a personal filter');
+
+        $chips = $criteria->activeFilters();
+        self::assertCount(1, $chips);
+        self::assertSame('community', $chips[0]->key);
+        self::assertSame('puzzle_picker.chips.community.rated', $chips[0]->translationKey);
+        self::assertSame(['%count%' => 20], $chips[0]->translationParameters);
+        self::assertSame(['seed' => 'abcd1234'], $chips[0]->queryParametersWithoutThis);
+
+        self::assertNull(PuzzlePickerCriteria::fromRequest(new Request(['community' => 'famous']), true)->community);
+        self::assertNull(PuzzlePickerCriteria::fromRequest(new Request(['community' => '']), true)->community);
+        self::assertNull(PuzzlePickerCriteria::fromRequest(new Request(['community' => ['few']]), true)->community);
+
+        self::assertSame('COALESCE(ps.solved_times_solo_count, 0) <= 5', PuzzlePickerCommunity::Few->sqlCondition('ps.solved_times_solo_count'));
+        self::assertSame('ps.solved_times_solo_count >= 20', PuzzlePickerCommunity::Rated->sqlCondition('ps.solved_times_solo_count'));
+        self::assertSame('ps.solved_times_solo_count >= 50', PuzzlePickerCommunity::Popular->sqlCondition('ps.solved_times_solo_count'));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Specific collections (members)
+    // ---------------------------------------------------------------------------------------------
+
+    private const string COLLECTION_A = '018d0008-0000-0000-0000-000000000001';
+    private const string COLLECTION_B = '018d0008-0000-0000-0000-000000000004';
+
+    public function testMembersCanPickFromSpecificCollectionsWhichImplyTheirShelf(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(
+            new Request(['source' => 'not_mine', 'collections' => [self::COLLECTION_A, Collection::SYSTEM_ID, self::COLLECTION_A, 'not-a-uuid', '', self::COLLECTION_B]]),
+            isAuthenticated: true,
+            insightsAllowed: true,
+        );
+
+        self::assertSame([self::COLLECTION_A, Collection::SYSTEM_ID, self::COLLECTION_B], $criteria->collectionIds, 'Deduplicated, invalid ids dropped, sentinel kept');
+        self::assertSame(PuzzlePickerSource::Mine, $criteria->source, 'Specific collections imply my shelf');
+        self::assertTrue($criteria->includesSystemCollection());
+        self::assertSame([self::COLLECTION_A, self::COLLECTION_B], $criteria->customCollectionIds());
+        self::assertTrue($criteria->hasPersonalFilters());
+        self::assertFalse($criteria->isDefault());
+        self::assertSame(['collections' => [self::COLLECTION_A, Collection::SYSTEM_ID, self::COLLECTION_B]], $criteria->toQueryParams(), 'Source mine is the default and stays implicit');
+        self::assertEquals($criteria, PuzzlePickerCriteria::fromRequest(new Request($criteria->toQueryParams()), true, true), 'Round trip');
+
+        // A single value is accepted as a string
+        self::assertSame([Collection::SYSTEM_ID], PuzzlePickerCriteria::fromRequest(new Request(['collections' => Collection::SYSTEM_ID]), true, true)->collectionIds);
+        self::assertFalse(PuzzlePickerCriteria::fromRequest(new Request(['collections' => [self::COLLECTION_A]]), true, true)->includesSystemCollection());
+
+        // Capped
+        $many = [];
+
+        for ($i = 1; $i <= 25; $i++) {
+            $many[] = sprintf('018d0008-0000-0000-0000-%012d', $i);
+        }
+
+        self::assertCount(PuzzlePickerCriteria::MAX_COLLECTIONS, PuzzlePickerCriteria::fromRequest(new Request(['collections' => $many]), true, true)->collectionIds);
+    }
+
+    public function testCollectionsAreStrippedForNonMembersAndGuests(): void
+    {
+        $nonMember = PuzzlePickerCriteria::fromRequest(new Request(['collections' => [self::COLLECTION_A]]), isAuthenticated: true);
+        self::assertSame([], $nonMember->collectionIds);
+        self::assertTrue($nonMember->isDefault());
+        self::assertSame([], $nonMember->toQueryParams());
+
+        $guest = PuzzlePickerCriteria::fromRequest(new Request(['collections' => [self::COLLECTION_A]]), isAuthenticated: false, insightsAllowed: true, predictionsAllowed: true);
+        self::assertSame([], $guest->collectionIds);
+        self::assertSame(PuzzlePickerSource::Any, $guest->source);
+    }
+
+    public function testCollectionChipsReplaceTheShelfChipAndRemoveThemselves(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(
+            new Request(['collections' => [Collection::SYSTEM_ID, self::COLLECTION_A], 'solved' => 'never']),
+            isAuthenticated: true,
+            insightsAllowed: true,
+        );
+
+        $filters = $criteria->activeFilters();
+        self::assertSame(['collection:' . Collection::SYSTEM_ID, 'collection:' . self::COLLECTION_A, 'solved'], array_map(static fn ($filter) => $filter->key, $filters), 'No separate "My collection" chip next to the collection chips');
+
+        self::assertSame('collection', $filters[0]->type);
+        self::assertSame(Collection::SYSTEM_ID, $filters[0]->value);
+        self::assertSame('collections.system_name', $filters[0]->translationKey, 'The system collection has a fixed name');
+        self::assertSame(['solved' => 'never', 'collections' => [self::COLLECTION_A]], $filters[0]->queryParametersWithoutThis);
+
+        self::assertSame('puzzle_picker.chips.collection', $filters[1]->translationKey);
+        self::assertSame(self::COLLECTION_A, $filters[1]->value);
+        self::assertSame(['solved' => 'never', 'collections' => [Collection::SYSTEM_ID]], $filters[1]->queryParametersWithoutThis);
+
+        // Removing the last collection chip falls back to the whole shelf - and its chip
+        $shelf = PuzzlePickerCriteria::fromRequest(new Request($filters[1]->queryParametersWithoutThis), true, true)->activeFilters()[0];
+        $shelfOnly = PuzzlePickerCriteria::fromRequest(new Request($shelf->queryParametersWithoutThis), true, true);
+        self::assertSame([], $shelfOnly->collectionIds);
+        self::assertSame(PuzzlePickerSource::Mine, $shelfOnly->source);
+        self::assertSame('puzzle_picker.chips.source.mine', $shelfOnly->activeFilters()[0]->translationKey);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Presets
+    // ---------------------------------------------------------------------------------------------
+
+    public function testActivePresetIsTheOneWhoseFiltersEqualTheCriteria(): void
+    {
+        $member = static fn (array $query): PuzzlePickerCriteria => PuzzlePickerCriteria::fromRequest(new Request($query), true, true, true);
+
+        foreach (PuzzlePickerPreset::cases() as $preset) {
+            self::assertSame($preset, $member($preset->queryParams())->activePreset(), $preset->value);
+            self::assertSame($preset, $member($preset->queryParams() + ['seed' => 'abcd1234'])->activePreset(), 'The seed does not count');
+        }
+
+        self::assertSame(PuzzlePickerPreset::SurpriseMe, $member([])->activePreset(), 'The bare default is "surprise me from my shelf"');
+        self::assertNull($member(['source' => 'any'])->activePreset());
+        self::assertNull($member(['solved' => 'never', 'pieces' => ['1000']])->activePreset(), 'A superset of a preset is not the preset');
+        self::assertNull($member(['pieces' => ['500'], 'solved' => 'never'])->activePreset(), 'A subset of a preset is not the preset');
+
+        // A player without predictions never has "Beat my record" active - the stripped
+        // criteria would otherwise look like plain "solved before"
+        $nonMember = PuzzlePickerCriteria::fromRequest(new Request(PuzzlePickerPreset::BeatMyRecord->queryParams()), true);
+        self::assertNull($nonMember->activePreset());
+        self::assertSame(PuzzlePickerPreset::SomethingNew, PuzzlePickerCriteria::fromRequest(new Request(PuzzlePickerPreset::SomethingNew->queryParams()), true)->activePreset(), 'Free presets work for non-members');
+        self::assertSame(PuzzlePickerPreset::RatingGrind, PuzzlePickerCriteria::fromRequest(new Request(PuzzlePickerPreset::RatingGrind->queryParams()), true)->activePreset());
+
+        self::assertNull(PuzzlePickerCriteria::fromRequest(new Request(), false)->activePreset(), 'Guests get no presets');
+        self::assertTrue(PuzzlePickerPreset::BeatMyRecord->requiresPredictions());
+        self::assertFalse(PuzzlePickerPreset::RatingGrind->requiresPredictions());
+    }
+
+    public function testPresetsAreBuiltFromFreeFilters(): void
+    {
+        self::assertSame(['source' => 'mine'], PuzzlePickerPreset::SurpriseMe->queryParams());
+        self::assertSame(['source' => 'mine', 'solved' => 'never'], PuzzlePickerPreset::SomethingNew->queryParams());
+        self::assertSame(['predicted_max' => '60'], PuzzlePickerPreset::QuickOne->queryParams());
+        self::assertSame(['since' => '6', 'since_unit' => 'm', 'since_require_solved' => '1'], PuzzlePickerPreset::DustOffTheShelf->queryParams());
+        self::assertSame(['pieces' => ['500'], 'solved' => 'never', 'community' => 'rated'], PuzzlePickerPreset::RatingGrind->queryParams());
+        self::assertSame(['solved' => 'before', 'gap' => 'slower', 'order' => 'gap_slower'], PuzzlePickerPreset::BeatMyRecord->queryParams());
     }
 }

--- a/translations/messages.cs.yml
+++ b/translations/messages.cs.yml
@@ -3127,11 +3127,14 @@ puzzle_picker:
     title: "Co skládat dál?"
     subtitle: "Řekněte, na co máte náladu, a já vyberu z vaší poličky."
     menu_label: "Co dál?"
+    pick_from_collection: "Vybrat z této kolekce"
     filters:
         button: "Filtry"
         title: "Filtry"
         apply: "Vybrat puzzle"
         reset: "Zrušit filtry"
+        remembered: "Vaše poslední filtry"
+        remembered_title: "Filtry z minula – použily se automaticky. Zrušte je a začněte nanovo."
         guest_note: "Přihlaste se a vybírejte z vlastní kolekce a historie."
         source:
             label: "Odkud vybírat"
@@ -3139,11 +3142,36 @@ puzzle_picker:
             not_mine: "Co v kolekci nemám"
             any: "Jakékoli puzzle"
             include_lent_out: "Včetně puzzlí, které jsem někomu půjčil/a"
+            collections_label: "Jen tyto kolekce"
+            collections_note: "Nic nezaškrtnuto = celá polička."
+            collections_locked: "Výběr z konkrétních kolekcí – pro členy."
         solved:
             label: "Moje historie"
             any: "Bez omezení"
             never: "Ještě neskládané"
             before: "Už poskládané"
+            between: "Poskládáno"
+            and: "až"
+            times: "krát"
+        since:
+            label: "Neskládané déle než"
+            unit: "Jednotka"
+            units:
+                d: "dní"
+                w: "týdnů"
+                m: "měsíců"
+            require_solved: "Jen puzzle, která jsem už skládal/a"
+            note: "Puzzle, která jste ještě neskládali, jsou zahrnuta – pokud nezaškrtnete políčko."
+        my_time:
+            label: "Můj čas"
+            off: "– bez omezení –"
+            fastest: "nejrychlejší"
+            latest: "poslední"
+            first: "první"
+            op_label: "Porovnání"
+            lt: "je pod"
+            gt: "je nad"
+            note: "Jen sólo časy – puzzle bez sólo času nikdy neprojde."
         pieces:
             label: "Počet dílků"
             custom: "Vlastní rozsah:"
@@ -3152,6 +3180,12 @@ puzzle_picker:
         brand:
             label: "Značka"
             placeholder: "Jakákoli značka"
+        community:
+            label: "Výsledky komunity"
+            any: "Bez omezení"
+            few: "Málo výsledků (do %count%) – buďte průkopník"
+            rated: "Hodnocené (%count%+ složení)"
+            popular: "Oblíbené (%count%+ složení)"
         budget:
             label: "Kolik mám času"
             i_have: "Mám zhruba"
@@ -3180,6 +3214,25 @@ puzzle_picker:
         solved:
             never: "Ještě neskládané"
             before: "Už poskládané"
+            exact: "Poskládáno %count%×"
+            between: "Poskládáno %min%–%max%×"
+            at_least: "Poskládáno %min%+×"
+            at_most: "Poskládáno max. %max%×"
+        since:
+            d: "Neskládané poslední %count% den|Neskládané poslední %count% dny|Neskládané posledních %count% dní"
+            w: "Neskládané poslední %count% týden|Neskládané poslední %count% týdny|Neskládané posledních %count% týdnů"
+            m: "Neskládané poslední %count% měsíc|Neskládané poslední %count% měsíce|Neskládané posledních %count% měsíců"
+        since_solved:
+            d: "Poskládané, ale ne poslední %count% den|Poskládané, ale ne poslední %count% dny|Poskládané, ale ne posledních %count% dní"
+            w: "Poskládané, ale ne poslední %count% týden|Poskládané, ale ne poslední %count% týdny|Poskládané, ale ne posledních %count% týdnů"
+            m: "Poskládané, ale ne poslední %count% měsíc|Poskládané, ale ne poslední %count% měsíce|Poskládané, ale ne posledních %count% měsíců"
+        my_time:
+            fastest_lt: "Nejrychlejší pod %minutes% min"
+            fastest_gt: "Nejrychlejší nad %minutes% min"
+            latest_lt: "Poslední pod %minutes% min"
+            latest_gt: "Poslední nad %minutes% min"
+            first_lt: "První pod %minutes% min"
+            first_gt: "První nad %minutes% min"
         pieces:
             exact: "%count% dílků"
             between: "%min%–%max% dílků"
@@ -3187,6 +3240,11 @@ puzzle_picker:
             at_most: "do %max% dílků"
         brand: "Značka"
         include_lent_out: "Vč. půjčených"
+        collection: "Kolekce"
+        community:
+            few: "Málo výsledků (≤ %count%)"
+            rated: "Hodnocené (%count%+ složení)"
+            popular: "Oblíbené (%count%+ složení)"
         remove: "Odebrat tento filtr"
         predicted_max: "Do %minutes% min"
         gap:
@@ -3200,6 +3258,11 @@ puzzle_picker:
     presets:
         label: "Předvolby:"
         beat_my_record: "Překonat svůj rekord"
+        surprise_me: "Překvap mě"
+        something_new: "Něco nového"
+        quick_one: "Rychlovka"
+        dust_off: "Oprášit poličku"
+        rating_grind: "Sbírání ratingu"
     results:
         matching: "%shown% z %total% odpovídajících puzzlí"
         pick_another: "Vybrat jiné"

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -3129,11 +3129,14 @@ puzzle_picker:
     title: "Welches Puzzle als Nächstes?"
     subtitle: "Sagen Sie mir, wonach Ihnen ist – ich wähle aus Ihrem Regal."
     menu_label: "Was als Nächstes?"
+    pick_from_collection: "Aus dieser Sammlung wählen"
     filters:
         button: "Filter"
         title: "Filter"
         apply: "Puzzle auswählen"
         reset: "Filter zurücksetzen"
+        remembered: "Ihre letzten Filter"
+        remembered_title: "Das sind die Filter vom letzten Mal – automatisch angewendet. Zurücksetzen, um neu zu beginnen."
         guest_note: "Melden Sie sich an, um aus Ihrem eigenen Regal und Ihrer Historie zu wählen."
         source:
             label: "Woraus wählen"
@@ -3141,11 +3144,36 @@ puzzle_picker:
             not_mine: "Nicht in meiner Sammlung"
             any: "Beliebiges Puzzle"
             include_lent_out: "Auch Puzzles, die ich verliehen habe"
+            collections_label: "Nur diese Sammlungen"
+            collections_note: "Nichts angehakt = das ganze Regal."
+            collections_locked: "Aus bestimmten Sammlungen wählen – für Mitglieder."
         solved:
             label: "Meine Historie"
             any: "Egal"
             never: "Noch nie gelegt"
             before: "Schon gelegt"
+            between: "Gelegt zwischen"
+            and: "und"
+            times: "Mal"
+        since:
+            label: "Nicht gelegt seit mehr als"
+            unit: "Einheit"
+            units:
+                d: "Tagen"
+                w: "Wochen"
+                m: "Monaten"
+            require_solved: "Nur Puzzles, die ich schon gelegt habe"
+            note: "Noch nie gelegte Puzzles sind enthalten, sofern Sie das Kästchen nicht anhaken."
+        my_time:
+            label: "Meine Zeit"
+            off: "– egal –"
+            fastest: "schnellste"
+            latest: "letzte"
+            first: "erste"
+            op_label: "Vergleich"
+            lt: "ist unter"
+            gt: "ist über"
+            note: "Nur Solo-Zeiten – Puzzles ohne Solo-Zeit passen nie."
         pieces:
             label: "Teile"
             custom: "Eigener Bereich:"
@@ -3154,6 +3182,12 @@ puzzle_picker:
         brand:
             label: "Marke"
             placeholder: "Beliebige Marke"
+        community:
+            label: "Community-Ergebnisse"
+            any: "Egal"
+            few: "Wenige Ergebnisse (bis %count%) – Pionier sein"
+            rated: "Bewertet (%count%+ Legungen)"
+            popular: "Beliebt (%count%+ Legungen)"
         budget:
             label: "Zeitbudget"
             i_have: "Ich habe etwa"
@@ -3182,6 +3216,25 @@ puzzle_picker:
         solved:
             never: "Noch nie gelegt"
             before: "Schon gelegt"
+            exact: "%count%× gelegt"
+            between: "%min%–%max%× gelegt"
+            at_least: "%min%+× gelegt"
+            at_most: "Bis %max%× gelegt"
+        since:
+            d: "Nicht gelegt im letzten Tag|Nicht gelegt in den letzten %count% Tagen"
+            w: "Nicht gelegt in der letzten Woche|Nicht gelegt in den letzten %count% Wochen"
+            m: "Nicht gelegt im letzten Monat|Nicht gelegt in den letzten %count% Monaten"
+        since_solved:
+            d: "Gelegt, aber nicht im letzten Tag|Gelegt, aber nicht in den letzten %count% Tagen"
+            w: "Gelegt, aber nicht in der letzten Woche|Gelegt, aber nicht in den letzten %count% Wochen"
+            m: "Gelegt, aber nicht im letzten Monat|Gelegt, aber nicht in den letzten %count% Monaten"
+        my_time:
+            fastest_lt: "Schnellste unter %minutes% Min."
+            fastest_gt: "Schnellste über %minutes% Min."
+            latest_lt: "Letzte unter %minutes% Min."
+            latest_gt: "Letzte über %minutes% Min."
+            first_lt: "Erste unter %minutes% Min."
+            first_gt: "Erste über %minutes% Min."
         pieces:
             exact: "%count% Teile"
             between: "%min%–%max% Teile"
@@ -3189,6 +3242,11 @@ puzzle_picker:
             at_most: "bis %max% Teile"
         brand: "Marke"
         include_lent_out: "Inkl. verliehen"
+        collection: "Sammlung"
+        community:
+            few: "Wenige Ergebnisse (≤ %count%)"
+            rated: "Bewertet (%count%+ Legungen)"
+            popular: "Beliebt (%count%+ Legungen)"
         remove: "Diesen Filter entfernen"
         predicted_max: "Bis %minutes% Min."
         gap:
@@ -3202,6 +3260,11 @@ puzzle_picker:
     presets:
         label: "Vorlagen:"
         beat_my_record: "Meinen Rekord schlagen"
+        surprise_me: "Überrasch mich"
+        something_new: "Etwas Neues"
+        quick_one: "Was Schnelles"
+        dust_off: "Regal entstauben"
+        rating_grind: "Rating sammeln"
     results:
         matching: "%shown% von %total% passenden Puzzles"
         pick_another: "Ein anderes"

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -3416,11 +3416,14 @@ puzzle_picker:
     title: "What should I solve next?"
     subtitle: "Tell me the mood, I'll pick from your shelf."
     menu_label: "What next?"
+    pick_from_collection: "Pick from this collection"
     filters:
         button: "Filters"
         title: "Filters"
         apply: "Pick a puzzle"
         reset: "Reset filters"
+        remembered: "Your last filters"
+        remembered_title: "These are the filters you used last time – applied automatically. Reset to start fresh."
         guest_note: "Sign in to pick from your own shelf and history."
         source:
             label: "Where to pick from"
@@ -3428,11 +3431,36 @@ puzzle_picker:
             not_mine: "Not in my collection"
             any: "Any puzzle"
             include_lent_out: "Include puzzles I have lent out"
+            collections_label: "Only these collections"
+            collections_note: "Nothing ticked = your whole shelf."
+            collections_locked: "Pick from specific collections – for members."
         solved:
             label: "My history"
             any: "Any"
             never: "Never solved"
             before: "Solved before"
+            between: "Solved between"
+            and: "and"
+            times: "times"
+        since:
+            label: "Not solved for more than"
+            unit: "Unit"
+            units:
+                d: "days"
+                w: "weeks"
+                m: "months"
+            require_solved: "Only puzzles I have solved before"
+            note: "Puzzles you have never solved are included unless you tick the box."
+        my_time:
+            label: "My time"
+            off: "– any –"
+            fastest: "fastest"
+            latest: "latest"
+            first: "first"
+            op_label: "Comparison"
+            lt: "is under"
+            gt: "is over"
+            note: "Solo times only – puzzles without a solo time never match."
         pieces:
             label: "Pieces"
             custom: "Custom range:"
@@ -3441,6 +3469,12 @@ puzzle_picker:
         brand:
             label: "Brand"
             placeholder: "Any brand"
+        community:
+            label: "Community results"
+            any: "Any"
+            few: "Few results (up to %count%) – be a pioneer"
+            rated: "Rated (%count%+ solves)"
+            popular: "Popular (%count%+ solves)"
         budget:
             label: "Time budget"
             i_have: "I have about"
@@ -3469,6 +3503,25 @@ puzzle_picker:
         solved:
             never: "Never solved"
             before: "Solved before"
+            exact: "Solved %count%×"
+            between: "Solved %min%–%max%×"
+            at_least: "Solved %min%+×"
+            at_most: "Solved up to %max%×"
+        since:
+            d: "Not solved in the last %count% day|Not solved in the last %count% days"
+            w: "Not solved in the last %count% week|Not solved in the last %count% weeks"
+            m: "Not solved in the last %count% month|Not solved in the last %count% months"
+        since_solved:
+            d: "Solved, but not in the last %count% day|Solved, but not in the last %count% days"
+            w: "Solved, but not in the last %count% week|Solved, but not in the last %count% weeks"
+            m: "Solved, but not in the last %count% month|Solved, but not in the last %count% months"
+        my_time:
+            fastest_lt: "Fastest under %minutes% min"
+            fastest_gt: "Fastest over %minutes% min"
+            latest_lt: "Latest under %minutes% min"
+            latest_gt: "Latest over %minutes% min"
+            first_lt: "First time under %minutes% min"
+            first_gt: "First time over %minutes% min"
         pieces:
             exact: "%count% pieces"
             between: "%min%–%max% pieces"
@@ -3476,6 +3529,11 @@ puzzle_picker:
             at_most: "up to %max% pieces"
         brand: "Brand"
         include_lent_out: "Incl. lent out"
+        collection: "Collection"
+        community:
+            few: "Few results (≤ %count%)"
+            rated: "Rated (%count%+ solves)"
+            popular: "Popular (%count%+ solves)"
         remove: "Remove this filter"
         predicted_max: "Up to %minutes% min"
         gap:
@@ -3489,6 +3547,11 @@ puzzle_picker:
     presets:
         label: "Presets:"
         beat_my_record: "Beat my record"
+        surprise_me: "Surprise me"
+        something_new: "Something new"
+        quick_one: "Quick one"
+        dust_off: "Dust off the shelf"
+        rating_grind: "Rating grind"
     results:
         matching: "%shown% of %total% matching puzzles"
         pick_another: "Pick another"

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -3129,11 +3129,14 @@ puzzle_picker:
     title: "¿Qué puzzle armar ahora?"
     subtitle: "Dime qué te apetece y elegiré de tu estantería."
     menu_label: "¿Y ahora qué?"
+    pick_from_collection: "Elegir de esta colección"
     filters:
         button: "Filtros"
         title: "Filtros"
         apply: "Elegir un puzzle"
         reset: "Quitar filtros"
+        remembered: "Tus últimos filtros"
+        remembered_title: "Son los filtros de la última vez, aplicados automáticamente. Quítalos para empezar de cero."
         guest_note: "Inicia sesión para elegir de tu propia estantería e historial."
         source:
             label: "De dónde elegir"
@@ -3141,11 +3144,36 @@ puzzle_picker:
             not_mine: "No está en mi colección"
             any: "Cualquier puzzle"
             include_lent_out: "Incluir puzzles que he prestado"
+            collections_label: "Solo estas colecciones"
+            collections_note: "Nada marcado = toda tu estantería."
+            collections_locked: "Elegir de colecciones concretas – para miembros."
         solved:
             label: "Mi historial"
             any: "Cualquiera"
             never: "Nunca armado"
             before: "Ya armado"
+            between: "Armado entre"
+            and: "y"
+            times: "veces"
+        since:
+            label: "Sin armar desde hace más de"
+            unit: "Unidad"
+            units:
+                d: "días"
+                w: "semanas"
+                m: "meses"
+            require_solved: "Solo puzzles que ya he armado"
+            note: "Los puzzles que nunca has armado se incluyen, salvo que marques la casilla."
+        my_time:
+            label: "Mi tiempo"
+            off: "– cualquiera –"
+            fastest: "más rápido"
+            latest: "último"
+            first: "primero"
+            op_label: "Comparación"
+            lt: "es menor de"
+            gt: "es mayor de"
+            note: "Solo tiempos en solitario – los puzzles sin tiempo en solitario nunca coinciden."
         pieces:
             label: "Piezas"
             custom: "Rango personalizado:"
@@ -3154,6 +3182,12 @@ puzzle_picker:
         brand:
             label: "Marca"
             placeholder: "Cualquier marca"
+        community:
+            label: "Resultados de la comunidad"
+            any: "Cualquiera"
+            few: "Pocos resultados (hasta %count%) – sé pionero"
+            rated: "Con valoración (%count%+ armados)"
+            popular: "Popular (%count%+ armados)"
         budget:
             label: "Tiempo disponible"
             i_have: "Tengo unos"
@@ -3182,6 +3216,25 @@ puzzle_picker:
         solved:
             never: "Nunca armado"
             before: "Ya armado"
+            exact: "Armado %count%×"
+            between: "Armado %min%–%max%×"
+            at_least: "Armado %min%+×"
+            at_most: "Armado hasta %max%×"
+        since:
+            d: "Sin armar en el último día|Sin armar en los últimos %count% días"
+            w: "Sin armar en la última semana|Sin armar en las últimas %count% semanas"
+            m: "Sin armar en el último mes|Sin armar en los últimos %count% meses"
+        since_solved:
+            d: "Ya armado, pero no en el último día|Ya armado, pero no en los últimos %count% días"
+            w: "Ya armado, pero no en la última semana|Ya armado, pero no en las últimas %count% semanas"
+            m: "Ya armado, pero no en el último mes|Ya armado, pero no en los últimos %count% meses"
+        my_time:
+            fastest_lt: "Más rápido menor de %minutes% min"
+            fastest_gt: "Más rápido mayor de %minutes% min"
+            latest_lt: "Último menor de %minutes% min"
+            latest_gt: "Último mayor de %minutes% min"
+            first_lt: "Primero menor de %minutes% min"
+            first_gt: "Primero mayor de %minutes% min"
         pieces:
             exact: "%count% piezas"
             between: "%min%–%max% piezas"
@@ -3189,6 +3242,11 @@ puzzle_picker:
             at_most: "hasta %max% piezas"
         brand: "Marca"
         include_lent_out: "Incl. prestados"
+        collection: "Colección"
+        community:
+            few: "Pocos resultados (≤ %count%)"
+            rated: "Con valoración (%count%+ armados)"
+            popular: "Popular (%count%+ armados)"
         remove: "Quitar este filtro"
         predicted_max: "Hasta %minutes% min"
         gap:
@@ -3202,6 +3260,11 @@ puzzle_picker:
     presets:
         label: "Atajos:"
         beat_my_record: "Batir mi récord"
+        surprise_me: "Sorpréndeme"
+        something_new: "Algo nuevo"
+        quick_one: "Uno rápido"
+        dust_off: "Quitar el polvo"
+        rating_grind: "Subir rating"
     results:
         matching: "%shown% de %total% puzzles que coinciden"
         pick_another: "Elegir otro"

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -3131,11 +3131,14 @@ puzzle_picker:
     title: "Quel puzzle faire ensuite ?"
     subtitle: "Dites-moi votre humeur, je choisis sur votre étagère."
     menu_label: "Et ensuite ?"
+    pick_from_collection: "Choisir dans cette collection"
     filters:
         button: "Filtres"
         title: "Filtres"
         apply: "Choisir un puzzle"
         reset: "Réinitialiser les filtres"
+        remembered: "Vos derniers filtres"
+        remembered_title: "Ce sont les filtres de la dernière fois, appliqués automatiquement. Réinitialisez pour repartir de zéro."
         guest_note: "Connectez-vous pour choisir parmi votre propre étagère et votre historique."
         source:
             label: "Où choisir"
@@ -3143,11 +3146,36 @@ puzzle_picker:
             not_mine: "Pas dans ma collection"
             any: "N'importe quel puzzle"
             include_lent_out: "Inclure les puzzles que j'ai prêtés"
+            collections_label: "Seulement ces collections"
+            collections_note: "Rien de coché = toute votre étagère."
+            collections_locked: "Choisir dans des collections précises – pour les membres."
         solved:
             label: "Mon historique"
             any: "Peu importe"
             never: "Jamais fait"
             before: "Déjà fait"
+            between: "Fait entre"
+            and: "et"
+            times: "fois"
+        since:
+            label: "Pas fait depuis plus de"
+            unit: "Unité"
+            units:
+                d: "jours"
+                w: "semaines"
+                m: "mois"
+            require_solved: "Seulement les puzzles déjà faits"
+            note: "Les puzzles jamais faits sont inclus, sauf si vous cochez la case."
+        my_time:
+            label: "Mon temps"
+            off: "– peu importe –"
+            fastest: "le meilleur"
+            latest: "le dernier"
+            first: "le premier"
+            op_label: "Comparaison"
+            lt: "est inférieur à"
+            gt: "est supérieur à"
+            note: "Temps en solo uniquement – un puzzle sans temps en solo ne correspond jamais."
         pieces:
             label: "Pièces"
             custom: "Plage personnalisée :"
@@ -3156,6 +3184,12 @@ puzzle_picker:
         brand:
             label: "Marque"
             placeholder: "Toutes les marques"
+        community:
+            label: "Résultats de la communauté"
+            any: "Peu importe"
+            few: "Peu de résultats (jusqu'à %count%) – soyez pionnier"
+            rated: "Coté (%count%+ réalisations)"
+            popular: "Populaire (%count%+ réalisations)"
         budget:
             label: "Temps disponible"
             i_have: "J'ai environ"
@@ -3184,6 +3218,25 @@ puzzle_picker:
         solved:
             never: "Jamais fait"
             before: "Déjà fait"
+            exact: "Fait %count%×"
+            between: "Fait %min%–%max%×"
+            at_least: "Fait %min%+×"
+            at_most: "Fait jusqu'à %max%×"
+        since:
+            d: "Pas fait depuis %count% jour|Pas fait depuis %count% jours"
+            w: "Pas fait depuis %count% semaine|Pas fait depuis %count% semaines"
+            m: "Pas fait depuis %count% mois|Pas fait depuis %count% mois"
+        since_solved:
+            d: "Déjà fait, mais pas depuis %count% jour|Déjà fait, mais pas depuis %count% jours"
+            w: "Déjà fait, mais pas depuis %count% semaine|Déjà fait, mais pas depuis %count% semaines"
+            m: "Déjà fait, mais pas depuis %count% mois|Déjà fait, mais pas depuis %count% mois"
+        my_time:
+            fastest_lt: "Meilleur temps sous %minutes% min"
+            fastest_gt: "Meilleur temps au-dessus de %minutes% min"
+            latest_lt: "Dernier temps sous %minutes% min"
+            latest_gt: "Dernier temps au-dessus de %minutes% min"
+            first_lt: "Premier temps sous %minutes% min"
+            first_gt: "Premier temps au-dessus de %minutes% min"
         pieces:
             exact: "%count% pièces"
             between: "%min%–%max% pièces"
@@ -3191,6 +3244,11 @@ puzzle_picker:
             at_most: "jusqu'à %max% pièces"
         brand: "Marque"
         include_lent_out: "Prêtés inclus"
+        collection: "Collection"
+        community:
+            few: "Peu de résultats (≤ %count%)"
+            rated: "Coté (%count%+ réalisations)"
+            popular: "Populaire (%count%+ réalisations)"
         remove: "Retirer ce filtre"
         predicted_max: "Jusqu'à %minutes% min"
         gap:
@@ -3204,6 +3262,11 @@ puzzle_picker:
     presets:
         label: "Raccourcis :"
         beat_my_record: "Battre mon record"
+        surprise_me: "Surprenez-moi"
+        something_new: "Du nouveau"
+        quick_one: "Un rapide"
+        dust_off: "Dépoussiérer l'étagère"
+        rating_grind: "Gagner du rating"
     results:
         matching: "%shown% sur %total% puzzles correspondants"
         pick_another: "En choisir un autre"

--- a/translations/messages.ja.yml
+++ b/translations/messages.ja.yml
@@ -3118,11 +3118,14 @@ puzzle_picker:
     title: "次はどのパズルを組む？"
     subtitle: "気分を教えてください。あなたの棚から選びます。"
     menu_label: "次は何を？"
+    pick_from_collection: "このコレクションから選ぶ"
     filters:
         button: "フィルター"
         title: "フィルター"
         apply: "パズルを選ぶ"
         reset: "フィルターをリセット"
+        remembered: "前回のフィルター"
+        remembered_title: "前回使ったフィルターを自動で適用しています。リセットすると最初からになります。"
         guest_note: "サインインすると、自分の棚と履歴から選べます。"
         source:
             label: "どこから選ぶか"
@@ -3130,11 +3133,36 @@ puzzle_picker:
             not_mine: "コレクションにないもの"
             any: "すべてのパズル"
             include_lent_out: "貸出中のパズルも含める"
+            collections_label: "このコレクションだけ"
+            collections_note: "何もチェックしなければ棚全体から選びます。"
+            collections_locked: "特定のコレクションから選ぶ – メンバー限定。"
         solved:
             label: "自分の履歴"
             any: "指定なし"
             never: "未完成"
             before: "完成済み"
+            between: "完成回数"
+            and: "〜"
+            times: "回"
+        since:
+            label: "組んでいない期間"
+            unit: "単位"
+            units:
+                d: "日以上"
+                w: "週間以上"
+                m: "か月以上"
+            require_solved: "完成済みのパズルだけ"
+            note: "チェックしない限り、まだ組んだことのないパズルも含まれます。"
+        my_time:
+            label: "自分の"
+            off: "– 指定なし –"
+            fastest: "最速タイム"
+            latest: "最新タイム"
+            first: "初回タイム"
+            op_label: "比較"
+            lt: "が次より短い"
+            gt: "が次より長い"
+            note: "ソロのタイムのみ – ソロタイムのないパズルは対象外です。"
         pieces:
             label: "ピース数"
             custom: "範囲を指定："
@@ -3143,6 +3171,12 @@ puzzle_picker:
         brand:
             label: "ブランド"
             placeholder: "すべてのブランド"
+        community:
+            label: "コミュニティの結果"
+            any: "指定なし"
+            few: "結果が少ない（%count%件以下）– 開拓者になろう"
+            rated: "レーティング対象（%count%件以上）"
+            popular: "人気（%count%件以上）"
         budget:
             label: "使える時間"
             i_have: "だいたい"
@@ -3171,6 +3205,25 @@ puzzle_picker:
         solved:
             never: "未完成"
             before: "完成済み"
+            exact: "完成%count%回"
+            between: "完成%min%〜%max%回"
+            at_least: "完成%min%回以上"
+            at_most: "完成%max%回以下"
+        since:
+            d: "直近%count%日は未完成"
+            w: "直近%count%週間は未完成"
+            m: "直近%count%か月は未完成"
+        since_solved:
+            d: "完成済みだが直近%count%日は未完成"
+            w: "完成済みだが直近%count%週間は未完成"
+            m: "完成済みだが直近%count%か月は未完成"
+        my_time:
+            fastest_lt: "最速%minutes%分未満"
+            fastest_gt: "最速%minutes%分超"
+            latest_lt: "最新%minutes%分未満"
+            latest_gt: "最新%minutes%分超"
+            first_lt: "初回%minutes%分未満"
+            first_gt: "初回%minutes%分超"
         pieces:
             exact: "%count%ピース"
             between: "%min%〜%max%ピース"
@@ -3178,6 +3231,11 @@ puzzle_picker:
             at_most: "%max%ピース以下"
         brand: "ブランド"
         include_lent_out: "貸出中を含む"
+        collection: "コレクション"
+        community:
+            few: "結果が少ない（%count%件以下）"
+            rated: "レーティング対象（%count%件以上）"
+            popular: "人気（%count%件以上）"
         remove: "このフィルターを外す"
         predicted_max: "%minutes%分以内"
         gap:
@@ -3191,6 +3249,11 @@ puzzle_picker:
     presets:
         label: "プリセット："
         beat_my_record: "自己ベスト更新"
+        surprise_me: "おまかせ"
+        something_new: "新しいもの"
+        quick_one: "サクッと1つ"
+        dust_off: "棚のほこりを払う"
+        rating_grind: "レーティング稼ぎ"
     results:
         matching: "該当パズル%total%件中%shown%件"
         pick_another: "別のパズルを選ぶ"


### PR DESCRIPTION
Stacked on #190 (base = `puzzle-picker/2-insights`).

## What ships
- **New free filters** (URL params, chips, null-tolerant SQL): solve-count range (`solved_min`/`solved_max`), "not solved for more than N days/weeks/months" (never-solved included by default, checkbox to require solved-before), my fastest/latest/first time under/over N minutes (solo times), community results (few ≤ 5 "be a pioneer" / rated ≥ 20 / popular ≥ 50)
- **Members**: "Only these collections" multi-select (system collection via the `__system_collection__` sentinel; `my_items` CTE gains `has_system` + non-null ids); **"Pick from this collection"** button on own collection detail pages
- **Remembered filters**: signed-in players' last filters are stored in the session and applied on a bare visit (URL stays canonical, no redirect); `?reset=1` clears; guests never get a session (pinned by test)
- **Presets** row: Surprise me · Something new · Quick one · Dust off the shelf · Rating grind (500 pcs, never solved, ≥ 20 solvers — see README §7) · Beat my record (🔒); active preset highlighted; all links `rel="nofollow"`
- Share button with the seeded URL of the current pick
- Six locales; tests: +query predicates, collections multi-select incl. system sentinel, criteria parsing/chips, session memory + reset, collection page button

## Checks
phpstan ✅ · cs ✅ · phpunit 1962 tests ✅ · schema:validate ✅ · cache:warmup ✅ · lint:twig/yaml ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGdSgARDzTuE99zDgd7jq5