### PR TITLE
Puzzle Picker (2/4): Insights layer for members — predictions on the card, gap / difficulty / time-budget filters

### DIFF
--- a/docs/features/puzzle-picker/implementation-plan.md
+++ b/docs/features/puzzle-picker/implementation-plan.md
@@ -114,22 +114,39 @@ myLatestSeconds, myLastSolvedAt (?DateTimeImmutable), inMyCollection, isBorrowed
 ## PR 2 — Insights layer for members: prediction on the card + insights filters
 
 Gated by `activeMembership && !timePredictionsOptedOut` (difficulty tier only by `activeMembership`).
+The controller computes `insightsAllowed` / `predictionsAllowed` once and hands them to
+`PuzzlePickerCriteria::fromRequest()`, which strips every non-eligible value — the gating lives in one place.
 
-- `src/Query/GetPlayerPredictions.php` (bulk): `forPuzzles(playerId, puzzleIds[])`,
-  `forAllSolvedPuzzles(playerId)`; extract the per-puzzle math out of `GetPlayerPrediction` into a shared
-  helper (one implementation, parity test); small per-request memo (`ResetInterface`).
-- Criteria: `difficultyTiers[]`, `gap` (`slower`|`faster`) + `gapMin` (minutes), `predictedMax`
-  (minutes; the "I have ~N minutes" control — community `average_time_solo` for non-members),
-  `order` (`random`|`gap_slower`|`gap_faster`); non-eligible → dropped server-side.
-- Query: conditional pre-LIMIT joins on `puzzle_difficulty` + `player_baseline`; personal predictions
-  injected via `unnest(:ids::uuid[], :predictions::int[])`; `predicted = COALESCE(personal, statistical)`.
-  Result gains `difficultyTier`, `difficultyConfidence`, `predictedSeconds`, `predictedLow/High`,
-  `predictionIsPersonalized`, `gapSeconds`.
-- Card: difficulty badge, prediction row (wording of `_difficulty_section.html.twig:65-98`); one locked
-  row for non-members. Filters modal: one "Insights (members)" group, locked for non-members; preset
-  "Beat my record" (🔒). Note the reduced pool ("puzzles with enough data").
-- Tests: bulk vs. single parity for every fixture pair; gap both directions; budget; order; non-member
-  criteria ignored even if present; opted-out player gets no prediction fields.
+- `src/Services/PuzzleIntelligence/TimePredictionCalculator.php`: the pure math (personal: ratio ×
+  Holt blend, 70 % floor, MAD range; statistical: baseline × difficulty, p25/p75 range) extracted out of
+  `GetPlayerPrediction`, which now only fetches rows and delegates. `src/Query/GetPlayerPredictions.php`
+  (bulk): `forPuzzles(playerId, puzzleIds[])`, `forAllSolvedPuzzles(playerId)` — attempts in one query,
+  the two ratio tables in one each, statistical inputs for the asked ids in one; per-request memo
+  (`ResetInterface`); `tests/Query/GetPlayerPredictionsTest.php` pins parity with `forPuzzle()` for
+  every fixture player × puzzle.
+- Criteria: `difficulty[]` (tiers 1–6), `gap` (`slower`|`faster`) + `gap_min` (minutes, default 1),
+  `predicted_max` (minutes; the "I have ~N minutes" control — my prediction for members with
+  predictions, community `average_time_solo` otherwise, `usesPersonalPrediction()`), `order`
+  (`random`|`gap_slower`|`gap_faster`); non-eligible → dropped server-side.
+- Query: only when an insights filter is active are `puzzle_difficulty` / `player_baseline` /
+  `puzzle_statistics` joined *before* the LIMIT; personal predictions injected via
+  `LEFT JOIN unnest(:ids::uuid[], :seconds::int[])`; `predicted = COALESCE(personal, round(baseline ×
+  difficulty))` and `gap = fastest − predicted` computed in `CROSS JOIN LATERAL` so they can be filtered
+  and ordered on; gap orders = `gap DESC/ASC NULLS LAST, md5(seed || id)`. Result gains
+  `difficultyTier`, `difficultyConfidence` (always hydrated post-LIMIT), `predictedSeconds`, `gapSeconds`
+  (only when computed pre-LIMIT). The card renders the full `TimePredictionResult` from
+  `GetPlayerPredictions::forPuzzles()` for the ≤ 6 picked puzzles (same numbers as the puzzle detail page).
+  Measured on a prod-like copy: "any puzzle" pool, 1.7k injected predictions, gap filter + gap order ≈ 27 ms.
+- Card: difficulty tier (icon + name) for members, prediction row (wording of
+  `_difficulty_section.html.twig:65-98`) + "could beat your record by N / N slower than your best / right at
+  your best"; one locked row for non-members; opt-out notice for opted-out members; guests nothing.
+  Filters modal: one "Insights (members)" group (tier pills + "only puzzles with enough data", compared to
+  my prediction + "by at least N min", pick order), locked for non-members, prediction controls disabled
+  for opted-out members; time budget in its own free group with the engine helper text; preset
+  "Beat my record" (link / muted / 🔒).
+- Tests: parity; gap both directions; gap orders (deterministic incl. seed tie-break, paging windows);
+  personal vs. community budget; tier filter; criteria stripping for non-member / opted-out / guest;
+  controller: member, non-member, guest, opted-out member markup.
 
 ## PR 3 — Precision filters, collection targeting, remembered filters, presets, share
 

--- a/src/Controller/PuzzlePickerController.php
+++ b/src/Controller/PuzzlePickerController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Controller;
 
 use SpeedPuzzling\Web\Query\GetManufacturers;
+use SpeedPuzzling\Web\Query\GetPlayerPredictions;
 use SpeedPuzzling\Web\Query\GetPuzzlePickerSuggestions;
+use SpeedPuzzling\Web\Results\PuzzlePickerSuggestion;
 use SpeedPuzzling\Web\Services\RetrieveLoggedUserProfile;
 use SpeedPuzzling\Web\Value\PuzzlePickerCriteria;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -21,12 +23,18 @@ use Symfony\Component\Routing\Attribute\Route;
  * with a live demo drawn from all approved puzzles. The seed is generated
  * server-side and never redirected into the URL, so the bare URL stays the
  * canonical one — it only travels in the "Pick another" links.
+ *
+ * Insights layer: members get difficulty tiers; members who have not opted out
+ * of time predictions additionally get the prediction row on the card and the
+ * gap / order / personal-budget filters. Non-eligible input is stripped by the
+ * criteria, so the gating lives in one place.
  */
 final class PuzzlePickerController extends AbstractController
 {
     public function __construct(
         readonly private RetrieveLoggedUserProfile $retrieveLoggedUserProfile,
         readonly private GetPuzzlePickerSuggestions $getPuzzlePickerSuggestions,
+        readonly private GetPlayerPredictions $getPlayerPredictions,
         readonly private GetManufacturers $getManufacturers,
     ) {
     }
@@ -46,8 +54,15 @@ final class PuzzlePickerController extends AbstractController
     public function __invoke(Request $request): Response
     {
         $profile = $this->retrieveLoggedUserProfile->getProfile();
+        $insightsAllowed = $profile !== null && $profile->activeMembership;
+        $predictionsAllowed = $profile !== null && $insightsAllowed && $profile->timePredictionsOptedOut === false;
 
-        $criteria = PuzzlePickerCriteria::fromRequest($request, isAuthenticated: $profile !== null);
+        $criteria = PuzzlePickerCriteria::fromRequest(
+            $request,
+            isAuthenticated: $profile !== null,
+            insightsAllowed: $insightsAllowed,
+            predictionsAllowed: $predictionsAllowed,
+        );
         $seed = $criteria->seed ?? self::generateSeed();
 
         $pick = $this->getPuzzlePickerSuggestions->pick(
@@ -56,11 +71,24 @@ final class PuzzlePickerController extends AbstractController
             PuzzlePickerCriteria::PICK_SIZE,
         );
 
+        // The card shows the full prediction (value, range, personalised or
+        // statistical) for the picked puzzles only - the exact same numbers the
+        // puzzle detail page shows, from the same calculator
+        $predictions = [];
+
+        if ($profile !== null && $predictionsAllowed && $pick->isEmpty() === false) {
+            $predictions = $this->getPlayerPredictions->forPuzzles(
+                $profile->playerId,
+                array_map(static fn (PuzzlePickerSuggestion $suggestion): string => $suggestion->puzzleId, $pick->suggestions),
+            );
+        }
+
         return $this->render($profile !== null ? 'puzzle_picker/index.html.twig' : 'puzzle_picker/landing.html.twig', [
             'criteria' => $criteria,
             'seed' => $seed,
             'next_seed' => self::generateSeed(),
             'pick' => $pick,
+            'predictions' => $predictions,
             'brand_names' => $this->getManufacturers->namesByIds($criteria->brandIds),
         ]);
     }

--- a/src/Query/GetPlayerPrediction.php
+++ b/src/Query/GetPlayerPrediction.php
@@ -4,16 +4,22 @@ declare(strict_types=1);
 
 namespace SpeedPuzzling\Web\Query;
 
+use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
+use Psr\Clock\ClockInterface;
 use SpeedPuzzling\Web\Results\TimePredictionResult;
+use SpeedPuzzling\Web\Services\PuzzleIntelligence\TimePredictionCalculator;
 
+/**
+ * Time prediction of one player on one puzzle. Fetches the inputs and hands the
+ * math to TimePredictionCalculator (shared with the bulk GetPlayerPredictions).
+ */
 readonly final class GetPlayerPrediction
 {
-    private const float DEFAULT_IMPROVEMENT_RATIO = 0.90;
-    private const int MAX_TRANSITION = 4;
-
     public function __construct(
         private Connection $database,
+        private ClockInterface $clock,
+        private TimePredictionCalculator $calculator,
     ) {
     }
 
@@ -63,14 +69,9 @@ SQL;
             return null;
         }
 
+        /** @var non-empty-list<int> $times */
         $times = array_map(static fn (array $row): int => (int) $row['seconds_to_solve'], $rows);
-        $bestTime = min($times);
-        $lastTime = $times[$count - 1];
-        $nextAttemptNumber = $count + 1;
-
-        // Determine gap since last solve
-        $lastSolvedAt = new \DateTimeImmutable($rows[$count - 1]['solved_at']);
-        $gapDays = (int) (new \DateTimeImmutable())->diff($lastSolvedAt)->days;
+        $lastSolvedAt = new DateTimeImmutable($rows[$count - 1]['solved_at']);
 
         // Get pieces count for global ratio lookup
         /** @var int|string|false $piecesCount */
@@ -85,125 +86,20 @@ SQL;
 
         $piecesCount = (int) $piecesCount;
 
-        // Get improvement ratio
-        $transition = min($count, self::MAX_TRANSITION);
-        $gapBucket = $this->classifyGap($gapDays);
-
-        $ratio = $this->getPlayerRatio($playerId, $transition);
-
-        if ($ratio !== null) {
-            $ratio = $this->applyGapCorrection($ratio, $piecesCount, $transition, $gapBucket);
-        } else {
-            $ratio = $this->getGlobalRatio($piecesCount, $transition, $gapBucket) ?? self::DEFAULT_IMPROVEMENT_RATIO;
-        }
-
-        $ratioPrediction = $lastTime * $ratio;
-
-        if ($count >= 6) {
-            // Pure Holt's damped trend
-            $predicted = $this->holtsDampedTrend($times);
-        } elseif ($count >= 2) {
-            // Blend ratio-based + Holt's
-            $holtsPrediction = $this->holtsDampedTrend($times);
-            $holtsWeight = min(1.0, ($count - 1) / 5);
-            $predicted = (int) round($holtsWeight * $holtsPrediction + (1.0 - $holtsWeight) * $ratioPrediction);
-        } else {
-            // N=1: pure ratio prediction
-            $predicted = (int) round($ratioPrediction);
-        }
-
-        // Safety floor: can't predict faster than 30% improvement over personal best
-        $predicted = max($predicted, (int) round($bestTime * 0.70));
-
-        // Range calculation
-        if ($count >= 2) {
-            // Use residual-based range from Holt's fitted values
-            $fittedValues = $this->holtsFittedValues($times);
-            $residuals = [];
-
-            for ($i = 0; $i < $count; $i++) {
-                $residuals[] = abs($times[$i] - $fittedValues[$i]);
-            }
-
-            $mad = array_sum($residuals) / count($residuals);
-            $spread = max($mad * 1.5, $predicted * 0.05);
-        } else {
-            // N=1: wider spread (15% or 2 minutes minimum)
-            $spread = max($predicted * 0.15, 120);
-        }
-
-        $rangeLow = (int) round($predicted - $spread);
-        $rangeHigh = (int) round($predicted + $spread);
-
-        // Safety: range low can't be below 70% of best time
-        $rangeLow = max($rangeLow, (int) round($bestTime * 0.70));
-        $rangeLow = max($rangeLow, 1);
-
-        return new TimePredictionResult(
-            predictedSeconds: $predicted,
-            rangeLowSeconds: $rangeLow,
-            rangeHighSeconds: $rangeHigh,
-            difficultyForPlayer: 0.0,
-            isPersonalized: true,
-            personalSolveCount: $count,
-            predictedAttemptNumber: $nextAttemptNumber,
-            lastTimeSeconds: $lastTime,
+        $transition = TimePredictionCalculator::transitionFor($count);
+        $gapBucket = TimePredictionCalculator::classifyGap(
+            TimePredictionCalculator::gapDays($this->clock->now(), $lastSolvedAt),
         );
-    }
 
-    /**
-     * Holt's damped trend exponential smoothing — returns predicted next value.
-     *
-     * @param list<int> $times chronologically ordered solve times
-     */
-    private function holtsDampedTrend(array $times): int
-    {
-        $fitted = $this->holtsFittedValues($times);
-        $count = count($times);
+        $playerRatio = $this->getPlayerRatio($playerId, $transition);
+        $globalRatioForGap = $this->getGlobalRatio($piecesCount, $transition, $gapBucket);
+        // The "all" bucket is only needed to gap-correct a player ratio
+        $globalRatioAll = $playerRatio !== null ? $this->getGlobalRatio($piecesCount, $transition, 'all') : null;
 
-        // Extract final level and trend from the last fitted step
-        $alpha = 0.5;
-        $beta = 0.4;
-        $phi = 0.8;
-
-        $level = (float) $times[0];
-        $trend = (float) ($times[1] - $times[0]);
-
-        for ($i = 1; $i < $count; $i++) {
-            $prevLevel = $level;
-            $level = $alpha * $times[$i] + (1.0 - $alpha) * ($level + $phi * $trend);
-            $trend = $beta * ($level - $prevLevel) + (1.0 - $beta) * $phi * $trend;
-        }
-
-        return (int) round($level + $phi * $trend);
-    }
-
-    /**
-     * Returns fitted values from Holt's damped trend for residual calculation.
-     *
-     * @param list<int> $times
-     * @return list<float>
-     */
-    private function holtsFittedValues(array $times): array
-    {
-        $alpha = 0.5;
-        $beta = 0.4;
-        $phi = 0.8;
-        $count = count($times);
-
-        $level = (float) $times[0];
-        $trend = (float) ($times[1] - $times[0]);
-
-        $fittedValues = [(float) $times[0]];
-
-        for ($i = 1; $i < $count; $i++) {
-            $fittedValues[] = $level + $phi * $trend;
-            $prevLevel = $level;
-            $level = $alpha * $times[$i] + (1.0 - $alpha) * ($level + $phi * $trend);
-            $trend = $beta * ($level - $prevLevel) + (1.0 - $beta) * $phi * $trend;
-        }
-
-        return $fittedValues;
+        return $this->calculator->personal(
+            $times,
+            TimePredictionCalculator::resolveRatio($playerRatio, $globalRatioForGap, $globalRatioAll),
+        );
     }
 
     private function getPlayerRatio(string $playerId, int $transition): null|float
@@ -226,39 +122,6 @@ SQL;
         );
 
         return $ratio !== false ? (float) $ratio : null;
-    }
-
-    /**
-     * Apply gap correction to a player-specific ratio using global gap data.
-     * gap_correction = global_ratio[transition][gap_bucket] / global_ratio[transition][all]
-     */
-    private function applyGapCorrection(float $playerRatio, int $piecesCount, int $transition, string $gapBucket): float
-    {
-        $gapSpecific = $this->getGlobalRatio($piecesCount, $transition, $gapBucket);
-        $gapAll = $this->getGlobalRatio($piecesCount, $transition, 'all');
-
-        if ($gapSpecific === null || $gapAll === null || $gapAll == 0.0) {
-            return $playerRatio;
-        }
-
-        return $playerRatio * ($gapSpecific / $gapAll);
-    }
-
-    private function classifyGap(int $gapDays): string
-    {
-        if ($gapDays < 30) {
-            return 'lt30d';
-        }
-
-        if ($gapDays < 90) {
-            return '1_3m';
-        }
-
-        if ($gapDays < 365) {
-            return '3_12m';
-        }
-
-        return 'gt12m';
     }
 
     private function statisticalPrediction(string $playerId, string $puzzleId): null|TimePredictionResult
@@ -288,26 +151,11 @@ SQL;
             return null;
         }
 
-        $baseline = (int) $row['baseline_seconds'];
-        $difficulty = (float) $row['difficulty_score'];
-        $predictedSeconds = (int) round($baseline * $difficulty);
-
-        // Use pre-computed IQR, with fallback for pre-migration state
-        $p25 = $row['indices_p25'] !== null ? (float) $row['indices_p25'] : $difficulty * 0.85;
-        $p75 = $row['indices_p75'] !== null ? (float) $row['indices_p75'] : $difficulty * 1.15;
-
-        $rangeLow = (int) round($baseline * $p25);
-        $rangeHigh = (int) round($baseline * $p75);
-
-        // Safety bounds
-        $rangeLow = (int) max($rangeLow, (int) round($predictedSeconds * 0.30), 1);
-        $rangeHigh = (int) min($rangeHigh, (int) round($predictedSeconds * 3.00));
-
-        return new TimePredictionResult(
-            predictedSeconds: $predictedSeconds,
-            rangeLowSeconds: $rangeLow,
-            rangeHighSeconds: $rangeHigh,
-            difficultyForPlayer: $difficulty,
+        return $this->calculator->statistical(
+            baselineSeconds: (int) $row['baseline_seconds'],
+            difficultyScore: (float) $row['difficulty_score'],
+            p25: $row['indices_p25'] !== null ? (float) $row['indices_p25'] : null,
+            p75: $row['indices_p75'] !== null ? (float) $row['indices_p75'] : null,
         );
     }
 }

--- a/src/Query/GetPlayerPredictions.php
+++ b/src/Query/GetPlayerPredictions.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Query;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Psr\Clock\ClockInterface;
+use SpeedPuzzling\Web\Results\TimePredictionResult;
+use SpeedPuzzling\Web\Services\PuzzleIntelligence\TimePredictionCalculator;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Time predictions of one player at list scale (puzzle picker cards and
+ * filters, collection pages). Same math as GetPlayerPrediction::forPuzzle() —
+ * both delegate to TimePredictionCalculator — but the inputs are loaded in bulk:
+ * the player's attempts on every puzzle in one query, the two ratio tables in
+ * one query each, and the statistical inputs (baseline × difficulty) for the
+ * asked puzzle ids in one more. The per-player part is memoised for the request
+ * (the picker query and the card rendering both need it), reset() clears it —
+ * FrankenPHP worker mode keeps the service instance alive between requests.
+ */
+final class GetPlayerPredictions implements ResetInterface
+{
+    /**
+     * Personal predictions per player: puzzle id → prediction, for every puzzle
+     * the player has at least one solo, valid, non-unboxed attempt on.
+     *
+     * @var array<string, array<string, TimePredictionResult>>
+     */
+    private array $personalByPlayer = [];
+
+    public function __construct(
+        private readonly Connection $database,
+        private readonly ClockInterface $clock,
+        private readonly TimePredictionCalculator $calculator,
+    ) {
+    }
+
+    public function reset(): void
+    {
+        $this->personalByPlayer = [];
+    }
+
+    /**
+     * Prediction for each of the given puzzles: personal where the player has
+     * solved the puzzle before, statistical where the player's baseline and the
+     * puzzle's difficulty exist, absent otherwise.
+     *
+     * @param list<string> $puzzleIds
+     *
+     * @return array<string, TimePredictionResult> keyed by puzzle id
+     */
+    public function forPuzzles(string $playerId, array $puzzleIds): array
+    {
+        if ($puzzleIds === []) {
+            return [];
+        }
+
+        $personal = $this->forAllSolvedPuzzles($playerId);
+        $predictions = [];
+        $missing = [];
+
+        foreach ($puzzleIds as $puzzleId) {
+            if (isset($personal[$puzzleId])) {
+                $predictions[$puzzleId] = $personal[$puzzleId];
+            } else {
+                $missing[] = $puzzleId;
+            }
+        }
+
+        if ($missing !== []) {
+            foreach ($this->statisticalPredictions($playerId, $missing) as $puzzleId => $prediction) {
+                $predictions[$puzzleId] = $prediction;
+            }
+        }
+
+        return $predictions;
+    }
+
+    /**
+     * Personal predictions for every puzzle the player has solo attempts on.
+     *
+     * @return array<string, TimePredictionResult> keyed by puzzle id
+     */
+    public function forAllSolvedPuzzles(string $playerId): array
+    {
+        if (isset($this->personalByPlayer[$playerId])) {
+            return $this->personalByPlayer[$playerId];
+        }
+
+        return $this->personalByPlayer[$playerId] = $this->personalPredictions($playerId);
+    }
+
+    /**
+     * @return array<string, TimePredictionResult>
+     */
+    private function personalPredictions(string $playerId): array
+    {
+        $query = <<<SQL
+SELECT
+    pst.puzzle_id,
+    p.pieces_count,
+    pst.seconds_to_solve,
+    COALESCE(pst.finished_at, pst.tracked_at) AS solved_at
+FROM puzzle_solving_time pst
+JOIN puzzle p ON p.id = pst.puzzle_id
+WHERE pst.player_id = :playerId
+    AND pst.puzzling_type = 'solo'
+    AND pst.suspicious = false
+    AND pst.seconds_to_solve IS NOT NULL
+    AND pst.unboxed = false
+ORDER BY pst.puzzle_id, COALESCE(pst.finished_at, pst.tracked_at) ASC, pst.tracked_at ASC
+SQL;
+
+        /** @var list<array{puzzle_id: string, pieces_count: int|string, seconds_to_solve: int|string, solved_at: string}> $rows */
+        $rows = $this->database->executeQuery($query, ['playerId' => $playerId])->fetchAllAssociative();
+
+        if ($rows === []) {
+            return [];
+        }
+
+        /** @var array<string, array{pieces_count: int, times: non-empty-list<int>, last_solved_at: string}> $attempts */
+        $attempts = [];
+
+        foreach ($rows as $row) {
+            $puzzleId = $row['puzzle_id'];
+
+            if (isset($attempts[$puzzleId])) {
+                $attempts[$puzzleId]['times'][] = (int) $row['seconds_to_solve'];
+                $attempts[$puzzleId]['last_solved_at'] = $row['solved_at'];
+            } else {
+                $attempts[$puzzleId] = [
+                    'pieces_count' => (int) $row['pieces_count'],
+                    'times' => [(int) $row['seconds_to_solve']],
+                    'last_solved_at' => $row['solved_at'],
+                ];
+            }
+        }
+
+        $playerRatios = $this->playerRatios($playerId);
+        $globalRatios = $this->globalRatios(array_values(array_unique(array_column($attempts, 'pieces_count'))));
+        $now = $this->clock->now();
+        $predictions = [];
+
+        foreach ($attempts as $puzzleId => $attempt) {
+            $transition = TimePredictionCalculator::transitionFor(count($attempt['times']));
+            $gapBucket = TimePredictionCalculator::classifyGap(
+                TimePredictionCalculator::gapDays($now, new DateTimeImmutable($attempt['last_solved_at'])),
+            );
+
+            $playerRatio = $playerRatios[$transition] ?? null;
+            $globalRatioForGap = $globalRatios[$attempt['pieces_count']][$transition][$gapBucket] ?? null;
+            $globalRatioAll = $globalRatios[$attempt['pieces_count']][$transition]['all'] ?? null;
+
+            $predictions[$puzzleId] = $this->calculator->personal(
+                $attempt['times'],
+                TimePredictionCalculator::resolveRatio($playerRatio, $globalRatioForGap, $globalRatioAll),
+            );
+        }
+
+        return $predictions;
+    }
+
+    /**
+     * @return array<int, float> transition → median ratio
+     */
+    private function playerRatios(string $playerId): array
+    {
+        /** @var list<array{from_attempt: int|string, median_ratio: float|string}> $rows */
+        $rows = $this->database->executeQuery(
+            'SELECT from_attempt, median_ratio FROM player_improvement_ratio WHERE player_id = :playerId',
+            ['playerId' => $playerId],
+        )->fetchAllAssociative();
+
+        $ratios = [];
+
+        foreach ($rows as $row) {
+            $ratios[(int) $row['from_attempt']] = (float) $row['median_ratio'];
+        }
+
+        return $ratios;
+    }
+
+    /**
+     * @param list<int> $piecesCounts
+     *
+     * @return array<int, array<int, array<string, float>>> pieces count → transition → gap bucket → median ratio
+     */
+    private function globalRatios(array $piecesCounts): array
+    {
+        if ($piecesCounts === []) {
+            return [];
+        }
+
+        /** @var list<array{pieces_count: int|string, from_attempt: int|string, gap_bucket: string, median_ratio: float|string}> $rows */
+        $rows = $this->database->executeQuery(
+            'SELECT pieces_count, from_attempt, gap_bucket, median_ratio FROM global_improvement_ratio WHERE pieces_count IN (:piecesCounts)',
+            ['piecesCounts' => $piecesCounts],
+            ['piecesCounts' => ArrayParameterType::INTEGER],
+        )->fetchAllAssociative();
+
+        $ratios = [];
+
+        foreach ($rows as $row) {
+            $ratios[(int) $row['pieces_count']][(int) $row['from_attempt']][$row['gap_bucket']] = (float) $row['median_ratio'];
+        }
+
+        return $ratios;
+    }
+
+    /**
+     * @param non-empty-list<string> $puzzleIds
+     *
+     * @return array<string, TimePredictionResult>
+     */
+    private function statisticalPredictions(string $playerId, array $puzzleIds): array
+    {
+        $query = <<<SQL
+SELECT
+    p.id AS puzzle_id,
+    pb.baseline_seconds,
+    pd.difficulty_score,
+    pd.indices_p25,
+    pd.indices_p75
+FROM puzzle p
+JOIN puzzle_difficulty pd ON pd.puzzle_id = p.id
+JOIN player_baseline pb ON pb.player_id = :playerId AND pb.pieces_count = p.pieces_count
+WHERE p.id IN (:puzzleIds)
+    AND pd.difficulty_score IS NOT NULL
+    AND pd.confidence != 'insufficient'
+SQL;
+
+        /** @var list<array{puzzle_id: string, baseline_seconds: int|string, difficulty_score: float|string, indices_p25: float|string|null, indices_p75: float|string|null}> $rows */
+        $rows = $this->database->executeQuery(
+            $query,
+            ['playerId' => $playerId, 'puzzleIds' => $puzzleIds],
+            ['puzzleIds' => ArrayParameterType::STRING],
+        )->fetchAllAssociative();
+
+        $predictions = [];
+
+        foreach ($rows as $row) {
+            $predictions[$row['puzzle_id']] = $this->calculator->statistical(
+                baselineSeconds: (int) $row['baseline_seconds'],
+                difficultyScore: (float) $row['difficulty_score'],
+                p25: $row['indices_p25'] !== null ? (float) $row['indices_p25'] : null,
+                p75: $row['indices_p75'] !== null ? (float) $row['indices_p75'] : null,
+            );
+        }
+
+        return $predictions;
+    }
+}

--- a/src/Query/GetPuzzlePickerSuggestions.php
+++ b/src/Query/GetPuzzlePickerSuggestions.php
@@ -9,7 +9,10 @@ use Doctrine\DBAL\Connection;
 use Psr\Clock\ClockInterface;
 use SpeedPuzzling\Web\Results\PuzzlePickerPick;
 use SpeedPuzzling\Web\Results\PuzzlePickerSuggestion;
+use SpeedPuzzling\Web\Results\TimePredictionResult;
 use SpeedPuzzling\Web\Value\PuzzlePickerCriteria;
+use SpeedPuzzling\Web\Value\PuzzlePickerGap;
+use SpeedPuzzling\Web\Value\PuzzlePickerOrder;
 
 /**
  * Read model of the puzzle picker ("What should I solve next?").
@@ -19,19 +22,27 @@ use SpeedPuzzling\Web\Value\PuzzlePickerCriteria;
  * lent/borrowed rows), aggregated at runtime in CTEs; the candidate set is
  * ordered by md5(seed || id) so the same seed always yields the same order
  * (offset paging never repeats or skips, links are reproducible) and only the
- * LIMIT rows are joined to manufacturer / statistics.
+ * LIMIT rows are joined to manufacturer / statistics / difficulty.
  *
  * Semantics (design doc §6.3): "solved" = any solving time of mine incl. duo /
  * team rows I own and team rows where I am a participant — the same meaning as
  * the "Unsolved puzzles" page; my fastest / first / latest use solo,
  * non-suspicious, timed solves; "when solved" = COALESCE(finished_at, tracked_at).
  * A null player (guest) leaves every personal CTE empty.
+ *
+ * Insights layer (members, design doc §6.4): only when an insights filter is
+ * active are puzzle_difficulty / player_baseline / puzzle_statistics joined
+ * *before* the LIMIT. My personal predictions (bulk GetPlayerPredictions, PHP)
+ * are handed to SQL as unnest(ids, seconds); the statistical fallback
+ * round(baseline × difficulty) is plain arithmetic, so one query still does the
+ * filtering, the gap ordering and the sampling.
  */
 readonly final class GetPuzzlePickerSuggestions
 {
     public function __construct(
         private Connection $database,
         private ClockInterface $clock,
+        private GetPlayerPredictions $getPlayerPredictions,
     ) {
     }
 
@@ -69,6 +80,77 @@ readonly final class GetPuzzlePickerSuggestions
             $brandCondition = 'AND p.manufacturer_id IN (:brandIds)';
             $params['brandIds'] = $criteria->brandIds;
             $types['brandIds'] = ArrayParameterType::STRING;
+        }
+
+        // --- Insights layer: joined and computed before the LIMIT only when asked for ---
+
+        $needsPredictions = $playerId !== null && $criteria->needsPredictions();
+        $needsDifficulty = $needsPredictions || $criteria->difficultyTiers !== [];
+        $needsCommunityAverage = $criteria->predictedMaxMinutes !== null && $criteria->usesPersonalPrediction() === false;
+
+        $insightsJoins = '';
+        $insightsConditions = '';
+        $predictedSelect = 'NULL::int AS predicted_seconds, NULL::int AS gap_seconds,';
+        $innerOrder = 'md5(:seed || p.id::text)';
+        $outerOrder = 'md5(:seed || picked.puzzle_id::text)';
+
+        if ($needsDifficulty) {
+            $insightsJoins .= "\n    LEFT JOIN puzzle_difficulty pd ON pd.puzzle_id = p.id";
+        }
+
+        if ($criteria->difficultyTiers !== []) {
+            $insightsConditions .= "\n        AND pd.confidence <> 'insufficient' AND pd.difficulty_tier IN (:difficultyTiers)";
+            $params['difficultyTiers'] = $criteria->difficultyTiers;
+            $types['difficultyTiers'] = ArrayParameterType::INTEGER;
+        }
+
+        if ($needsCommunityAverage) {
+            $insightsJoins .= "\n    LEFT JOIN puzzle_statistics ps ON ps.puzzle_id = p.id";
+            $insightsConditions .= "\n        AND ps.average_time_solo <= :predictedMaxSeconds";
+            $params['predictedMaxSeconds'] = $criteria->predictedMaxMinutes * 60;
+        }
+
+        if ($playerId !== null && $needsPredictions) {
+            [$predictionIds, $predictionSeconds] = self::predictionArrays($this->getPlayerPredictions->forAllSolvedPuzzles($playerId));
+
+            $insightsJoins .= <<<SQL
+
+    LEFT JOIN player_baseline pb ON pb.player_id = :playerId AND pb.pieces_count = p.pieces_count
+    LEFT JOIN unnest(:predictionIds::uuid[], :predictionSeconds::int[]) AS pp(puzzle_id, predicted) ON pp.puzzle_id = p.id
+    CROSS JOIN LATERAL (
+        SELECT COALESCE(
+            pp.predicted,
+            CASE WHEN pd.difficulty_score IS NOT NULL AND pd.confidence <> 'insufficient' THEN round(pb.baseline_seconds * pd.difficulty_score)::int END
+        ) AS predicted_seconds
+    ) pr
+    CROSS JOIN LATERAL (
+        SELECT CASE WHEN COALESCE(s.solve_count_solo, 0) > 0 THEN s.fastest_seconds - pr.predicted_seconds END AS gap_seconds
+    ) gp
+SQL;
+            $params['predictionIds'] = $predictionIds;
+            $params['predictionSeconds'] = $predictionSeconds;
+            $predictedSelect = 'pr.predicted_seconds, gp.gap_seconds,';
+
+            if ($criteria->predictedMaxMinutes !== null) {
+                $insightsConditions .= "\n        AND pr.predicted_seconds <= :predictedMaxSeconds";
+                $params['predictedMaxSeconds'] = $criteria->predictedMaxMinutes * 60;
+            }
+
+            if ($criteria->gap === PuzzlePickerGap::Slower) {
+                $insightsConditions .= "\n        AND gp.gap_seconds >= :gapMinSeconds";
+                $params['gapMinSeconds'] = $criteria->gapMinSeconds();
+            } elseif ($criteria->gap === PuzzlePickerGap::Faster) {
+                $insightsConditions .= "\n        AND gp.gap_seconds <= -1 * :gapMinSeconds";
+                $params['gapMinSeconds'] = $criteria->gapMinSeconds();
+            }
+
+            if ($criteria->order === PuzzlePickerOrder::GapSlower) {
+                $innerOrder = 'gp.gap_seconds DESC NULLS LAST, ' . $innerOrder;
+                $outerOrder = 'picked.gap_seconds DESC NULLS LAST, ' . $outerOrder;
+            } elseif ($criteria->order === PuzzlePickerOrder::GapFaster) {
+                $innerOrder = 'gp.gap_seconds ASC NULLS LAST, ' . $innerOrder;
+                $outerOrder = 'picked.gap_seconds ASC NULLS LAST, ' . $outerOrder;
+            }
         }
 
         $query = <<<SQL
@@ -131,13 +213,14 @@ picked AS (
         (mi.puzzle_id IS NOT NULL) AS in_my_collection,
         (b.puzzle_id IS NOT NULL) AS is_borrowed,
         (lo.puzzle_id IS NOT NULL) AS is_lent_out,
+        {$predictedSelect}
         count(*) OVER () AS total_matching
     FROM puzzle p
     LEFT JOIN my_solves s ON s.puzzle_id = p.id
     LEFT JOIN my_team_solves ts ON ts.puzzle_id = p.id
     LEFT JOIN my_items mi ON mi.puzzle_id = p.id
     LEFT JOIN lent_out lo ON lo.puzzle_id = p.id
-    LEFT JOIN borrowed b ON b.puzzle_id = p.id
+    LEFT JOIN borrowed b ON b.puzzle_id = p.id{$insightsJoins}
     WHERE p.approved = true
         AND (p.hide_until IS NULL OR p.hide_until < :now::timestamp)
         AND (
@@ -152,8 +235,8 @@ picked AS (
             OR (:solved = 'before' AND COALESCE(s.solve_count_any, 0) + COALESCE(ts.solve_count, 0) > 0)
         )
         {$piecesCondition}
-        {$brandCondition}
-    ORDER BY md5(:seed || p.id::text)
+        {$brandCondition}{$insightsConditions}
+    ORDER BY {$innerOrder}
     LIMIT :limit OFFSET :offset
 )
 SELECT
@@ -167,6 +250,8 @@ SELECT
     picked.in_my_collection,
     picked.is_borrowed,
     picked.is_lent_out,
+    picked.predicted_seconds,
+    picked.gap_seconds,
     picked.total_matching,
     p.name AS puzzle_name,
     p.alternative_name AS puzzle_alternative_name,
@@ -178,12 +263,15 @@ SELECT
     m.id AS manufacturer_id,
     m.name AS manufacturer_name,
     COALESCE(ps.solved_times_solo_count, 0) AS community_solved_count_solo,
-    ps.average_time_solo AS community_average_time_solo
+    ps.average_time_solo AS community_average_time_solo,
+    pd.difficulty_tier,
+    pd.confidence AS difficulty_confidence
 FROM picked
 JOIN puzzle p ON p.id = picked.puzzle_id
 LEFT JOIN manufacturer m ON m.id = p.manufacturer_id
 LEFT JOIN puzzle_statistics ps ON ps.puzzle_id = p.id
-ORDER BY md5(:seed || picked.puzzle_id::text)
+LEFT JOIN puzzle_difficulty pd ON pd.puzzle_id = p.id
+ORDER BY {$outerOrder}
 SQL;
 
         $rows = $this->database
@@ -217,6 +305,10 @@ SQL;
              *     in_my_collection: bool,
              *     is_borrowed: bool,
              *     is_lent_out: bool,
+             *     difficulty_tier: null|int|string,
+             *     difficulty_confidence: null|string,
+             *     predicted_seconds: null|int|string,
+             *     gap_seconds: null|int|string,
              *     total_matching: int|string,
              * } $row
              */
@@ -227,5 +319,29 @@ SQL;
         }
 
         return new PuzzlePickerPick($suggestions, $totalMatching);
+    }
+
+    /**
+     * Personal predictions as two parallel Postgres array literals for
+     * unnest(:ids::uuid[], :seconds::int[]) — empty arrays when there are none.
+     *
+     * @param array<string, TimePredictionResult> $predictions
+     *
+     * @return array{string, string}
+     */
+    private static function predictionArrays(array $predictions): array
+    {
+        $ids = [];
+        $seconds = [];
+
+        foreach ($predictions as $puzzleId => $prediction) {
+            $ids[] = $puzzleId;
+            $seconds[] = $prediction->predictedSeconds;
+        }
+
+        return [
+            '{' . implode(',', $ids) . '}',
+            '{' . implode(',', $seconds) . '}',
+        ];
     }
 }

--- a/src/Results/PuzzlePickerSuggestion.php
+++ b/src/Results/PuzzlePickerSuggestion.php
@@ -5,10 +5,18 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Results;
 
 use DateTimeImmutable;
+use SpeedPuzzling\Web\Value\DifficultyTier;
+use SpeedPuzzling\Web\Value\MetricConfidence;
 
 /**
  * One puzzle card of the picker: puzzle basics, community numbers and the
  * viewer's own history on it. The "my*" fields are zero/null for guests.
+ *
+ * Insights fields: difficultyTier / difficultyConfidence are always hydrated
+ * (cheap post-LIMIT join; the template decides who may see them);
+ * predictedSeconds / gapSeconds are only set when the query had to compute
+ * predictions before sampling (gap filter, gap order, personal time budget) —
+ * the card itself renders the full TimePredictionResult from GetPlayerPredictions.
  */
 readonly final class PuzzlePickerSuggestion
 {
@@ -34,7 +42,21 @@ readonly final class PuzzlePickerSuggestion
         public bool $inMyCollection,
         public bool $isBorrowed,
         public bool $isLentOut,
+        public null|DifficultyTier $difficultyTier = null,
+        public null|MetricConfidence $difficultyConfidence = null,
+        public null|int $predictedSeconds = null,
+        public null|int $gapSeconds = null,
     ) {
+    }
+
+    /**
+     * A difficulty worth showing: a tier backed by enough data.
+     */
+    public function hasDifficulty(): bool
+    {
+        return $this->difficultyTier !== null
+            && $this->difficultyConfidence !== null
+            && $this->difficultyConfidence !== MetricConfidence::Insufficient;
     }
 
     /**
@@ -60,10 +82,17 @@ readonly final class PuzzlePickerSuggestion
      *     in_my_collection: bool,
      *     is_borrowed: bool,
      *     is_lent_out: bool,
+     *     difficulty_tier?: null|int|string,
+     *     difficulty_confidence?: null|string,
+     *     predicted_seconds?: null|int|string,
+     *     gap_seconds?: null|int|string,
      * } $row
      */
     public static function fromDatabaseRow(array $row): self
     {
+        $difficultyTier = isset($row['difficulty_tier']) ? DifficultyTier::tryFrom((int) $row['difficulty_tier']) : null;
+        $difficultyConfidence = isset($row['difficulty_confidence']) ? MetricConfidence::tryFrom($row['difficulty_confidence']) : null;
+
         return new self(
             puzzleId: $row['puzzle_id'],
             puzzleName: $row['puzzle_name'],
@@ -86,6 +115,10 @@ readonly final class PuzzlePickerSuggestion
             inMyCollection: $row['in_my_collection'],
             isBorrowed: $row['is_borrowed'],
             isLentOut: $row['is_lent_out'],
+            difficultyTier: $difficultyTier,
+            difficultyConfidence: $difficultyConfidence,
+            predictedSeconds: isset($row['predicted_seconds']) ? (int) $row['predicted_seconds'] : null,
+            gapSeconds: isset($row['gap_seconds']) ? (int) $row['gap_seconds'] : null,
         );
     }
 }

--- a/src/Services/PuzzleIntelligence/TimePredictionCalculator.php
+++ b/src/Services/PuzzleIntelligence/TimePredictionCalculator.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Services\PuzzleIntelligence;
+
+use DateTimeImmutable;
+use SpeedPuzzling\Web\Results\TimePredictionResult;
+
+/**
+ * Pure time-prediction math shared by the single-puzzle GetPlayerPrediction and
+ * the bulk GetPlayerPredictions read models — one implementation, no database.
+ *
+ * Personal prediction (the player has solved the puzzle before): last time × an
+ * improvement ratio for the upcoming attempt number and the gap since the last
+ * solve, blended with Holt's damped trend once there are ≥ 2 attempts, floored
+ * at 70 % of the personal best. Statistical prediction (never solved): the
+ * player's baseline for the piece count × the puzzle's difficulty score with the
+ * puzzle's p25/p75 difficulty indices as the range.
+ */
+final readonly class TimePredictionCalculator
+{
+    public const float DEFAULT_IMPROVEMENT_RATIO = 0.90;
+
+    public const int MAX_TRANSITION = 4;
+
+    private const float HOLT_ALPHA = 0.5;
+    private const float HOLT_BETA = 0.4;
+    private const float HOLT_PHI = 0.8;
+
+    /**
+     * Ratio table transition ("from attempt N") the next attempt is predicted with.
+     */
+    public static function transitionFor(int $attemptCount): int
+    {
+        return min($attemptCount, self::MAX_TRANSITION);
+    }
+
+    /**
+     * Whole days between now and the last solve — the input of the gap bucket.
+     */
+    public static function gapDays(DateTimeImmutable $now, DateTimeImmutable $lastSolvedAt): int
+    {
+        return (int) $now->diff($lastSolvedAt)->days;
+    }
+
+    public static function classifyGap(int $gapDays): string
+    {
+        if ($gapDays < 30) {
+            return 'lt30d';
+        }
+
+        if ($gapDays < 90) {
+            return '1_3m';
+        }
+
+        if ($gapDays < 365) {
+            return '3_12m';
+        }
+
+        return 'gt12m';
+    }
+
+    /**
+     * Improvement ratio for the next attempt: the player's own ratio corrected by
+     * the global gap effect when both global values are known, otherwise the
+     * global ratio for the gap bucket, otherwise the default.
+     */
+    public static function resolveRatio(null|float $playerRatio, null|float $globalRatioForGap, null|float $globalRatioAll): float
+    {
+        if ($playerRatio !== null) {
+            if ($globalRatioForGap === null || $globalRatioAll === null || $globalRatioAll == 0.0) {
+                return $playerRatio;
+            }
+
+            return $playerRatio * ($globalRatioForGap / $globalRatioAll);
+        }
+
+        return $globalRatioForGap ?? self::DEFAULT_IMPROVEMENT_RATIO;
+    }
+
+    /**
+     * @param non-empty-list<int> $times chronologically ordered solve times of the player on the puzzle
+     */
+    public function personal(array $times, float $improvementRatio): TimePredictionResult
+    {
+        $count = count($times);
+        $bestTime = min($times);
+        $lastTime = $times[$count - 1];
+
+        $ratioPrediction = $lastTime * $improvementRatio;
+
+        if ($count >= 6) {
+            // Pure Holt's damped trend
+            $predicted = self::holtsDampedTrend($times);
+        } elseif ($count >= 2) {
+            // Blend ratio-based + Holt's
+            $holtsPrediction = self::holtsDampedTrend($times);
+            $holtsWeight = min(1.0, ($count - 1) / 5);
+            $predicted = (int) round($holtsWeight * $holtsPrediction + (1.0 - $holtsWeight) * $ratioPrediction);
+        } else {
+            // N=1: pure ratio prediction
+            $predicted = (int) round($ratioPrediction);
+        }
+
+        // Safety floor: can't predict faster than 30% improvement over personal best
+        $predicted = max($predicted, (int) round($bestTime * 0.70));
+
+        // Range calculation
+        if ($count >= 2) {
+            // Use residual-based range from Holt's fitted values
+            $fittedValues = self::holtsFittedValues($times);
+            $residuals = [];
+
+            for ($i = 0; $i < $count; $i++) {
+                $residuals[] = abs($times[$i] - $fittedValues[$i]);
+            }
+
+            $mad = array_sum($residuals) / count($residuals);
+            $spread = max($mad * 1.5, $predicted * 0.05);
+        } else {
+            // N=1: wider spread (15% or 2 minutes minimum)
+            $spread = max($predicted * 0.15, 120);
+        }
+
+        $rangeLow = (int) round($predicted - $spread);
+        $rangeHigh = (int) round($predicted + $spread);
+
+        // Safety: range low can't be below 70% of best time
+        $rangeLow = max($rangeLow, (int) round($bestTime * 0.70));
+        $rangeLow = max($rangeLow, 1);
+
+        return new TimePredictionResult(
+            predictedSeconds: $predicted,
+            rangeLowSeconds: $rangeLow,
+            rangeHighSeconds: $rangeHigh,
+            difficultyForPlayer: 0.0,
+            isPersonalized: true,
+            personalSolveCount: $count,
+            predictedAttemptNumber: $count + 1,
+            lastTimeSeconds: $lastTime,
+        );
+    }
+
+    public function statistical(int $baselineSeconds, float $difficultyScore, null|float $p25, null|float $p75): TimePredictionResult
+    {
+        $predictedSeconds = (int) round($baselineSeconds * $difficultyScore);
+
+        // Use pre-computed IQR, with fallback for pre-migration state
+        $p25 ??= $difficultyScore * 0.85;
+        $p75 ??= $difficultyScore * 1.15;
+
+        $rangeLow = (int) round($baselineSeconds * $p25);
+        $rangeHigh = (int) round($baselineSeconds * $p75);
+
+        // Safety bounds
+        $rangeLow = (int) max($rangeLow, (int) round($predictedSeconds * 0.30), 1);
+        $rangeHigh = (int) min($rangeHigh, (int) round($predictedSeconds * 3.00));
+
+        return new TimePredictionResult(
+            predictedSeconds: $predictedSeconds,
+            rangeLowSeconds: $rangeLow,
+            rangeHighSeconds: $rangeHigh,
+            difficultyForPlayer: $difficultyScore,
+        );
+    }
+
+    /**
+     * Holt's damped trend exponential smoothing — returns predicted next value.
+     *
+     * @param non-empty-list<int> $times chronologically ordered solve times
+     */
+    private static function holtsDampedTrend(array $times): int
+    {
+        $count = count($times);
+
+        $level = (float) $times[0];
+        $trend = (float) ($times[1] - $times[0]);
+
+        for ($i = 1; $i < $count; $i++) {
+            $prevLevel = $level;
+            $level = self::HOLT_ALPHA * $times[$i] + (1.0 - self::HOLT_ALPHA) * ($level + self::HOLT_PHI * $trend);
+            $trend = self::HOLT_BETA * ($level - $prevLevel) + (1.0 - self::HOLT_BETA) * self::HOLT_PHI * $trend;
+        }
+
+        return (int) round($level + self::HOLT_PHI * $trend);
+    }
+
+    /**
+     * Returns fitted values from Holt's damped trend for residual calculation.
+     *
+     * @param non-empty-list<int> $times
+     * @return list<float>
+     */
+    private static function holtsFittedValues(array $times): array
+    {
+        $count = count($times);
+
+        $level = (float) $times[0];
+        $trend = (float) ($times[1] - $times[0]);
+
+        $fittedValues = [(float) $times[0]];
+
+        for ($i = 1; $i < $count; $i++) {
+            $fittedValues[] = $level + self::HOLT_PHI * $trend;
+            $prevLevel = $level;
+            $level = self::HOLT_ALPHA * $times[$i] + (1.0 - self::HOLT_ALPHA) * ($level + self::HOLT_PHI * $trend);
+            $trend = self::HOLT_BETA * ($level - $prevLevel) + (1.0 - self::HOLT_BETA) * self::HOLT_PHI * $trend;
+        }
+
+        return $fittedValues;
+    }
+}

--- a/src/Value/PuzzlePickerActiveFilter.php
+++ b/src/Value/PuzzlePickerActiveFilter.php
@@ -12,11 +12,11 @@ final readonly class PuzzlePickerActiveFilter
 {
     /**
      * @param string $key Unique within one criteria, e.g. "source", "pieces:500", "brand:<uuid>"
-     * @param string $type One of "source", "solved", "pieces", "brand", "lent"
+     * @param string $type One of "source", "solved", "pieces", "brand", "lent", "predicted_max", "difficulty", "gap", "order"
      * @param string $translationKey Chip label; brand chips render the manufacturer name instead
      * @param array<string, int|string> $translationParameters
      * @param array<string, mixed> $queryParametersWithoutThis
-     * @param null|string $value Raw value for label lookups (manufacturer id for brand chips)
+     * @param null|string $value Raw value for label lookups (manufacturer id for brand chips, tier value for difficulty chips)
      */
     public function __construct(
         public string $key,

--- a/src/Value/PuzzlePickerCriteria.php
+++ b/src/Value/PuzzlePickerCriteria.php
@@ -12,13 +12,20 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * The URL *is* the state (bookmarkable, shareable, back button works), so the
  * input can carry anything a crafted link can: unknown enum values, garbage in
- * `pieces[]`, mangled UUIDs, personal filters from a guest. Everything is
- * normalized here so the query stays graceful and the guest branch can never be
- * talked into personal data by a URL.
+ * `pieces[]`, mangled UUIDs, personal filters from a guest, insights filters
+ * from a non-member. Everything is normalized here so the query stays graceful
+ * and neither the guest branch nor a non-member can be talked into personal or
+ * members-only data by a URL — the same server-side rule as PuzzleSearchCriteria.
  *
  * Grammar of `pieces[]` values: `N` (exact), `A-B` (between), `A-` (at least),
  * `-B` (at most). The filter form additionally posts `pieces_min` / `pieces_max`,
  * which are folded into the same list, so the canonical URL only ever uses `pieces[]`.
+ *
+ * Insights layer (members): `difficulty[]` (tiers 1–6), `gap` + `gap_min` (my
+ * fastest vs. my prediction, minutes), `order` (`gap_slower` / `gap_faster`) and
+ * `predicted_max` — the "I have about N minutes" budget, which is free for
+ * everyone but switches engine: my predicted time for members with predictions,
+ * the community solo average otherwise (see usesPersonalPrediction()).
  */
 final readonly class PuzzlePickerCriteria
 {
@@ -30,6 +37,14 @@ final readonly class PuzzlePickerCriteria
 
     public const int MAX_PIECES = 100000;
 
+    public const int MIN_GAP_MINUTES = 1;
+
+    public const int MAX_GAP_MINUTES = 600;
+
+    public const int MIN_PREDICTED_MINUTES = 5;
+
+    public const int MAX_PREDICTED_MINUTES = 1440;
+
     /** @var list<int|string> */
     public const array PIECES_CHIPS = [54, 100, 150, 200, 300, 500, 750, 1000, 1500, '2000-'];
 
@@ -38,6 +53,7 @@ final readonly class PuzzlePickerCriteria
     /**
      * @param list<array{null|int, null|int}> $pieces
      * @param list<string> $brandIds
+     * @param list<int> $difficultyTiers
      */
     private function __construct(
         public PuzzlePickerSource $source,
@@ -45,12 +61,23 @@ final readonly class PuzzlePickerCriteria
         public array $pieces,
         public array $brandIds,
         public bool $includeLentOut,
+        public array $difficultyTiers,
+        public null|PuzzlePickerGap $gap,
+        public null|int $gapMinMinutes,
+        public null|int $predictedMaxMinutes,
+        public PuzzlePickerOrder $order,
         public null|string $seed,
         public bool $isAuthenticated,
+        public bool $insightsAllowed,
+        public bool $predictionsAllowed,
     ) {
     }
 
-    public static function fromRequest(Request $request, bool $isAuthenticated): self
+    /**
+     * @param bool $insightsAllowed Active membership: difficulty tiers
+     * @param bool $predictionsAllowed Active membership without the time-predictions opt-out: gap filter, gap orders, personal time budget
+     */
+    public static function fromRequest(Request $request, bool $isAuthenticated, bool $insightsAllowed = false, bool $predictionsAllowed = false): self
     {
         $query = $request->query->all();
 
@@ -62,14 +89,22 @@ final readonly class PuzzlePickerCriteria
             piecesMax: is_string($query['pieces_max'] ?? null) ? $query['pieces_max'] : null,
             brandIds: self::listInput($query['brand'] ?? null),
             includeLentOut: ($query['lent'] ?? null) === '1',
+            difficultyTiers: self::listInput($query['difficulty'] ?? null),
+            gap: is_string($query['gap'] ?? null) ? $query['gap'] : null,
+            gapMinMinutes: is_string($query['gap_min'] ?? null) ? $query['gap_min'] : null,
+            predictedMaxMinutes: is_string($query['predicted_max'] ?? null) ? $query['predicted_max'] : null,
+            order: is_string($query['order'] ?? null) ? $query['order'] : null,
             seed: is_string($query['seed'] ?? null) ? $query['seed'] : null,
             isAuthenticated: $isAuthenticated,
+            insightsAllowed: $insightsAllowed,
+            predictionsAllowed: $predictionsAllowed,
         );
     }
 
     /**
      * @param array<mixed> $pieces
      * @param array<mixed> $brandIds
+     * @param array<mixed> $difficultyTiers
      */
     public static function fromUserInput(
         null|string $source,
@@ -81,10 +116,21 @@ final readonly class PuzzlePickerCriteria
         bool $includeLentOut,
         null|string $seed,
         bool $isAuthenticated,
+        array $difficultyTiers = [],
+        null|string $gap = null,
+        null|string $gapMinMinutes = null,
+        null|string $predictedMaxMinutes = null,
+        null|string $order = null,
+        bool $insightsAllowed = false,
+        bool $predictionsAllowed = false,
     ): self {
         $defaultSource = self::defaultSourceFor($isAuthenticated);
         $sourceValue = $source !== null ? PuzzlePickerSource::tryFrom($source) ?? $defaultSource : $defaultSource;
         $solvedValue = $solved !== null ? PuzzlePickerSolved::tryFrom($solved) ?? PuzzlePickerSolved::Any : PuzzlePickerSolved::Any;
+        $gapValue = $gap !== null ? PuzzlePickerGap::tryFrom($gap) : null;
+        $orderValue = $order !== null ? PuzzlePickerOrder::tryFrom($order) ?? PuzzlePickerOrder::Random : PuzzlePickerOrder::Random;
+        $gapMinValue = $gapValue !== null ? self::parseMinutes($gapMinMinutes, self::MIN_GAP_MINUTES, self::MAX_GAP_MINUTES) : null;
+        $predictedMaxValue = self::parseMinutes($predictedMaxMinutes, self::MIN_PREDICTED_MINUTES, self::MAX_PREDICTED_MINUTES);
 
         // Guests have no shelf and no history: personal filters are dropped
         // server-side, so a crafted URL cannot reach the personal branches.
@@ -92,6 +138,21 @@ final readonly class PuzzlePickerCriteria
             $sourceValue = PuzzlePickerSource::Any;
             $solvedValue = PuzzlePickerSolved::Any;
             $includeLentOut = false;
+            $insightsAllowed = false;
+        }
+
+        // Insights are members-only; predictions additionally respect the
+        // player's opt-out. Non-eligible values are dropped, not errored on.
+        // The time budget survives — it just runs on the community engine.
+        if ($insightsAllowed === false) {
+            $difficultyTiers = [];
+            $predictionsAllowed = false;
+        }
+
+        if ($predictionsAllowed === false) {
+            $gapValue = null;
+            $gapMinValue = null;
+            $orderValue = PuzzlePickerOrder::Random;
         }
 
         return new self(
@@ -100,8 +161,15 @@ final readonly class PuzzlePickerCriteria
             pieces: self::normalizePieces($pieces, $piecesMin, $piecesMax),
             brandIds: self::normalizeBrandIds($brandIds),
             includeLentOut: $includeLentOut,
+            difficultyTiers: self::normalizeDifficultyTiers($difficultyTiers),
+            gap: $gapValue,
+            gapMinMinutes: $gapMinValue,
+            predictedMaxMinutes: $predictedMaxValue,
+            order: $orderValue,
             seed: $seed !== null && preg_match(self::SEED_PATTERN, $seed) === 1 ? $seed : null,
             isAuthenticated: $isAuthenticated,
+            insightsAllowed: $insightsAllowed,
+            predictionsAllowed: $predictionsAllowed,
         );
     }
 
@@ -113,8 +181,15 @@ final readonly class PuzzlePickerCriteria
             pieces: $this->pieces,
             brandIds: $this->brandIds,
             includeLentOut: $this->includeLentOut,
+            difficultyTiers: $this->difficultyTiers,
+            gap: $this->gap,
+            gapMinMinutes: $this->gapMinMinutes,
+            predictedMaxMinutes: $this->predictedMaxMinutes,
+            order: $this->order,
             seed: $seed,
             isAuthenticated: $this->isAuthenticated,
+            insightsAllowed: $this->insightsAllowed,
+            predictionsAllowed: $this->predictionsAllowed,
         );
     }
 
@@ -124,7 +199,11 @@ final readonly class PuzzlePickerCriteria
             && $this->solved === PuzzlePickerSolved::Any
             && $this->pieces === []
             && $this->brandIds === []
-            && $this->includeLentOut === false;
+            && $this->includeLentOut === false
+            && $this->difficultyTiers === []
+            && $this->gap === null
+            && $this->predictedMaxMinutes === null
+            && $this->order === PuzzlePickerOrder::Random;
     }
 
     /**
@@ -136,7 +215,37 @@ final readonly class PuzzlePickerCriteria
     {
         return $this->source !== PuzzlePickerSource::Any
             || $this->solved !== PuzzlePickerSolved::Any
-            || $this->includeLentOut;
+            || $this->includeLentOut
+            || $this->gap !== null
+            || $this->order->isGapOrder();
+    }
+
+    /**
+     * Which engine the "I have about N minutes" budget runs on: my predicted
+     * time (members with predictions) or the community solo average.
+     */
+    public function usesPersonalPrediction(): bool
+    {
+        return $this->predictionsAllowed;
+    }
+
+    /**
+     * True when the query has to compute my predictions before sampling — the
+     * gap filter, a gap order, or a personal time budget.
+     */
+    public function needsPredictions(): bool
+    {
+        return $this->predictionsAllowed
+            && ($this->gap !== null || $this->order->isGapOrder() || $this->predictedMaxMinutes !== null);
+    }
+
+    /**
+     * Minimum gap in seconds the gap filter asks for: the "by at least N min"
+     * input, or one minute so a 0-second "gap" never counts.
+     */
+    public function gapMinSeconds(): int
+    {
+        return ($this->gapMinMinutes ?? self::MIN_GAP_MINUTES) * 60;
     }
 
     /**
@@ -167,6 +276,26 @@ final readonly class PuzzlePickerCriteria
 
         if ($this->includeLentOut) {
             $parameters['lent'] = '1';
+        }
+
+        if ($this->difficultyTiers !== []) {
+            $parameters['difficulty'] = array_map(strval(...), $this->difficultyTiers);
+        }
+
+        if ($this->gap !== null) {
+            $parameters['gap'] = $this->gap->value;
+
+            if ($this->gapMinMinutes !== null) {
+                $parameters['gap_min'] = (string) $this->gapMinMinutes;
+            }
+        }
+
+        if ($this->predictedMaxMinutes !== null) {
+            $parameters['predicted_max'] = (string) $this->predictedMaxMinutes;
+        }
+
+        if ($this->order !== PuzzlePickerOrder::Random) {
+            $parameters['order'] = $this->order->value;
         }
 
         $seed = $seedOverride ?? $this->seed;
@@ -248,6 +377,49 @@ final readonly class PuzzlePickerCriteria
             );
         }
 
+        if ($this->predictedMaxMinutes !== null) {
+            $filters[] = new PuzzlePickerActiveFilter(
+                key: 'predicted_max',
+                type: 'predicted_max',
+                translationKey: 'puzzle_picker.chips.predicted_max',
+                translationParameters: ['%minutes%' => $this->predictedMaxMinutes],
+                queryParametersWithoutThis: $this->with(clearPredictedMax: true)->toQueryParams(),
+            );
+        }
+
+        foreach ($this->difficultyTiers as $tier) {
+            $difficultyTier = DifficultyTier::from($tier);
+
+            $filters[] = new PuzzlePickerActiveFilter(
+                key: 'difficulty:' . $tier,
+                type: 'difficulty',
+                translationKey: 'puzzle_intelligence.difficulty.tiers.' . strtolower($difficultyTier->name),
+                translationParameters: [],
+                queryParametersWithoutThis: $this->with(difficultyTiers: array_values(array_diff($this->difficultyTiers, [$tier])))->toQueryParams(),
+                value: (string) $tier,
+            );
+        }
+
+        if ($this->gap !== null) {
+            $filters[] = new PuzzlePickerActiveFilter(
+                key: 'gap',
+                type: 'gap',
+                translationKey: 'puzzle_picker.chips.gap.' . $this->gap->value . ($this->gapMinMinutes !== null ? '_by' : ''),
+                translationParameters: ['%minutes%' => $this->gapMinMinutes ?? 0],
+                queryParametersWithoutThis: $this->with(clearGap: true)->toQueryParams(),
+            );
+        }
+
+        if ($this->order !== PuzzlePickerOrder::Random) {
+            $filters[] = new PuzzlePickerActiveFilter(
+                key: 'order',
+                type: 'order',
+                translationKey: 'puzzle_picker.chips.order.' . $this->order->value,
+                translationParameters: [],
+                queryParametersWithoutThis: $this->with(order: PuzzlePickerOrder::Random)->toQueryParams(),
+            );
+        }
+
         return $filters;
     }
 
@@ -305,8 +477,12 @@ final readonly class PuzzlePickerCriteria
     }
 
     /**
+     * Copy with some fields replaced. Nullable fields (gap, budget) cannot be
+     * "set to null" through a null argument, hence the explicit clear flags.
+     *
      * @param list<array{null|int, null|int}>|null $pieces
      * @param list<string>|null $brandIds
+     * @param list<int>|null $difficultyTiers
      */
     private function with(
         null|PuzzlePickerSource $source = null,
@@ -314,6 +490,10 @@ final readonly class PuzzlePickerCriteria
         null|array $pieces = null,
         null|array $brandIds = null,
         null|bool $includeLentOut = null,
+        null|array $difficultyTiers = null,
+        null|PuzzlePickerOrder $order = null,
+        bool $clearGap = false,
+        bool $clearPredictedMax = false,
     ): self {
         return new self(
             source: $source ?? $this->source,
@@ -321,8 +501,15 @@ final readonly class PuzzlePickerCriteria
             pieces: $pieces ?? $this->pieces,
             brandIds: $brandIds ?? $this->brandIds,
             includeLentOut: $includeLentOut ?? $this->includeLentOut,
+            difficultyTiers: $difficultyTiers ?? $this->difficultyTiers,
+            gap: $clearGap ? null : $this->gap,
+            gapMinMinutes: $clearGap ? null : $this->gapMinMinutes,
+            predictedMaxMinutes: $clearPredictedMax ? null : $this->predictedMaxMinutes,
+            order: $order ?? $this->order,
             seed: $this->seed,
             isAuthenticated: $this->isAuthenticated,
+            insightsAllowed: $this->insightsAllowed,
+            predictionsAllowed: $this->predictionsAllowed,
         );
     }
 
@@ -431,5 +618,42 @@ final readonly class PuzzlePickerCriteria
         }
 
         return array_slice($normalized, 0, self::MAX_BRANDS);
+    }
+
+    /**
+     * Difficulty tiers 1–6 (DifficultyTier values), deduplicated and sorted;
+     * anything else is dropped.
+     *
+     * @param array<mixed> $difficultyTiers
+     *
+     * @return list<int>
+     */
+    private static function normalizeDifficultyTiers(array $difficultyTiers): array
+    {
+        $tiers = [];
+
+        foreach ($difficultyTiers as $tier) {
+            if ((is_int($tier) || (is_string($tier) && preg_match('/^\d{1,2}$/', trim($tier)) === 1)) && DifficultyTier::tryFrom((int) $tier) !== null) {
+                $tiers[(int) $tier] = (int) $tier;
+            }
+        }
+
+        sort($tiers);
+
+        return $tiers;
+    }
+
+    /**
+     * Whole minutes within [min, max]; anything else (blank, text, out of range) is null.
+     */
+    private static function parseMinutes(null|string $value, int $min, int $max): null|int
+    {
+        if ($value === null || preg_match('/^\d{1,5}$/', trim($value)) !== 1) {
+            return null;
+        }
+
+        $minutes = (int) trim($value);
+
+        return $minutes >= $min && $minutes <= $max ? $minutes : null;
     }
 }

--- a/src/Value/PuzzlePickerGap.php
+++ b/src/Value/PuzzlePickerGap.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+/**
+ * "Compared to my prediction" filter of the puzzle picker (members with
+ * predictions): keep only puzzles where my fastest solo time is slower than my
+ * predicted time (room to improve — a PB chance) or faster than it (I outperform
+ * on this one). Needs at least one solo solve and a prediction on the puzzle.
+ */
+enum PuzzlePickerGap: string
+{
+    case Slower = 'slower';
+    case Faster = 'faster';
+}

--- a/src/Value/PuzzlePickerOrder.php
+++ b/src/Value/PuzzlePickerOrder.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+/**
+ * Pick order of the puzzle picker. Random is the seeded shuffle; the gap orders
+ * (members with predictions) put the puzzles with the largest gap between my
+ * fastest time and my prediction first — puzzles without a gap sort last — with
+ * the seed as the tie-breaker so the order stays reproducible.
+ */
+enum PuzzlePickerOrder: string
+{
+    case Random = 'random';
+    case GapSlower = 'gap_slower';
+    case GapFaster = 'gap_faster';
+
+    public function isGapOrder(): bool
+    {
+        return $this !== self::Random;
+    }
+}

--- a/templates/puzzle_picker/_card.html.twig
+++ b/templates/puzzle_picker/_card.html.twig
@@ -1,7 +1,10 @@
-{# One picker card: puzzle basics, my history on it, community numbers, CTAs.
-   Expects: suggestion (PuzzlePickerSuggestion), position (1-based, for eager image loading), criteria #}
+{# One picker card: puzzle basics, my history on it, community numbers, insights (members), CTAs.
+   Expects: suggestion (PuzzlePickerSuggestion), position (1-based, for eager image loading), criteria,
+   predictions (puzzle id => TimePredictionResult, only for members with predictions) #}
+{% from 'puzzle_intelligence/_macros.html.twig' import difficulty_icon %}
 {% set puzzle_full_name = (suggestion.manufacturerName is not null ? suggestion.manufacturerName ~ ' ' : '') ~ suggestion.puzzleName %}
 {% set is_authenticated = criteria.isAuthenticated %}
+{% set prediction = (predictions|default({}))[suggestion.puzzleId] ?? null %}
 <div class="card card-body shadow p-3 puzzle-picker-card">
     <div class="d-flex">
         <div class="flex-shrink-0 me-3" style="width: 90px;">
@@ -23,10 +26,20 @@
         <div class="flex-grow-1">
             <div class="fs-sm text-muted">{{ suggestion.manufacturerName ?? '–' }}</div>
             <a class="h5 d-block mb-1 low-line-height text-decoration-none" href="{{ path('puzzle_detail', {puzzleId: suggestion.puzzleId}) }}">{{ suggestion.puzzleName }}</a>
-            <div class="fs-sm">
-                <span class="fw-bold">{{ 'pieces_count'|trans({'%count%': suggestion.piecesCount})|raw }}</span>
-                {% if suggestion.puzzleIdentificationNumber is not null %}
-                    <span class="text-muted ms-1">{{ suggestion.puzzleIdentificationNumber }}</span>
+            <div class="fs-sm d-flex flex-wrap align-items-center gap-2">
+                <span>
+                    <span class="fw-bold">{{ 'pieces_count'|trans({'%count%': suggestion.piecesCount})|raw }}</span>
+                    {% if suggestion.puzzleIdentificationNumber is not null %}
+                        <span class="text-muted ms-1">{{ suggestion.puzzleIdentificationNumber }}</span>
+                    {% endif %}
+                </span>
+                {# Difficulty tier - members only; non-members get no lock here, the one lock on the card is the prediction row #}
+                {% if criteria.insightsAllowed and suggestion.hasDifficulty %}
+                    {% set tier_name = suggestion.difficultyTier.name|lower %}
+                    <span class="d-inline-flex align-items-center gap-1 puzzle-picker-difficulty" title="{{ 'puzzle_intelligence.difficulty.tier_label'|trans }}">
+                        {{ difficulty_icon(tier_name, 20) }}
+                        {{ ('puzzle_intelligence.difficulty.tiers.' ~ tier_name)|trans }}
+                    </span>
                 {% endif %}
             </div>
             {% if is_authenticated and (suggestion.inMyCollection or suggestion.isBorrowed or suggestion.isLentOut) %}
@@ -98,6 +111,53 @@
                 {{ 'puzzle_picker.card.community_none'|trans }}
             {% endif %}
         </div>
+
+        {# Prediction row - the Insights layer on the card. Guests: nothing. Non-members: one locked
+           row. Members who opted out: the opt-out notice. Eligible members: the same numbers as the
+           puzzle detail page (personalised or statistical), plus how it compares to my best. #}
+        {% if is_authenticated %}
+            {% if not criteria.insightsAllowed %}
+                <div class="mt-1 puzzle-picker-prediction-locked">
+                    <a href="#" class="text-muted text-decoration-none" data-bs-toggle="modal" data-bs-target="#membersExclusiveModal">
+                        <i class="ci-locked me-1"></i>{{ 'puzzle_picker.card.prediction_locked'|trans }}
+                    </a>
+                </div>
+            {% elseif not criteria.predictionsAllowed %}
+                <div class="mt-1 text-muted puzzle-picker-prediction-opted-out">
+                    <i class="bi bi-eye-slash me-1"></i>{{ 'puzzle_intelligence.prediction.time_predictions_opted_out'|trans }}
+                    <a href="{{ path('edit_profile') }}">{{ 'statistics.change_in_settings'|trans }}</a>
+                </div>
+            {% elseif prediction is not null %}
+                <div class="mt-1 puzzle-picker-prediction">
+                    <span class="text-muted"><i class="bi bi-clock-history me-1"></i>{{ 'puzzle_picker.card.prediction'|trans }}</span>
+                    <span class="fw-bold">~{{ prediction.predictedSeconds|compactTime }}</span>
+                    <span class="text-muted">({{ 'puzzle_intelligence.prediction.range'|trans({'%low%': prediction.rangeLowSeconds|compactTime, '%high%': prediction.rangeHighSeconds|compactTime}) }})</span>
+                </div>
+                <div class="text-muted small">
+                    {% if prediction.isPersonalized and prediction.predictedAttemptNumber is not null %}
+                        {{ 'puzzle_intelligence.prediction.personal_attempt_explanation'|trans({'%attempt%': prediction.predictedAttemptNumber, '%count%': prediction.personalSolveCount}) }}
+                    {% elseif prediction.isPersonalized %}
+                        {{ 'puzzle_intelligence.prediction.personal_explanation'|trans({'%count%': prediction.personalSolveCount}) }}
+                    {% else %}
+                        {{ 'puzzle_intelligence.prediction.explanation'|trans }}
+                    {% endif %}
+                </div>
+                {% if suggestion.myFastestSeconds is not null %}
+                    {% set delta_minutes = ((suggestion.myFastestSeconds - prediction.predictedSeconds) / 60)|round %}
+                    {% if delta_minutes > 0 %}
+                        <div class="text-success puzzle-picker-prediction-vs-best"><i class="bi bi-arrow-right-short"></i>{{ 'puzzle_picker.card.prediction_beats_record'|trans({'%delta%': (delta_minutes * 60)|compactTime}) }}</div>
+                    {% elseif delta_minutes < 0 %}
+                        <div class="text-muted puzzle-picker-prediction-vs-best"><i class="bi bi-arrow-right-short"></i>{{ 'puzzle_picker.card.prediction_slower_than_best'|trans({'%delta%': (delta_minutes|abs * 60)|compactTime}) }}</div>
+                    {% else %}
+                        <div class="text-muted puzzle-picker-prediction-vs-best"><i class="bi bi-arrow-right-short"></i>{{ 'puzzle_picker.card.prediction_at_best'|trans }}</div>
+                    {% endif %}
+                {% endif %}
+            {% else %}
+                <div class="mt-1 text-muted puzzle-picker-prediction-unavailable">
+                    <i class="bi bi-clock-history me-1"></i>{{ 'puzzle_picker.card.prediction_unavailable'|trans }}
+                </div>
+            {% endif %}
+        {% endif %}
     </div>
 
     <hr class="my-2">

--- a/templates/puzzle_picker/_filter_bar.html.twig
+++ b/templates/puzzle_picker/_filter_bar.html.twig
@@ -13,6 +13,8 @@
            title="{{ 'puzzle_picker.chips.remove'|trans }}">
             {% if filter.type == 'brand' %}
                 {{ brand_names[filter.value] ?? filter.translationKey|trans }}
+            {% elseif filter.type == 'difficulty' %}
+                {{ 'puzzle_intelligence.difficulty.tier_label'|trans }}: {{ filter.translationKey|trans }}
             {% else %}
                 {{ filter.translationKey|trans(filter.translationParameters) }}
             {% endif %}

--- a/templates/puzzle_picker/_filters_modal.html.twig
+++ b/templates/puzzle_picker/_filters_modal.html.twig
@@ -1,9 +1,21 @@
 {# Filter sheet: a plain GET form - Apply submits, the URL is the state (bookmarkable, back
    button works). Personal groups (shelf, history, lent-out) are disabled for guests with a
-   sign-in note; the server drops those values for guests anyway. Expects: criteria, brand_names #}
+   sign-in note; the "Insights (members)" group is one locked block for non-members and its
+   prediction controls are disabled for members who opted out of predictions. The server drops
+   every non-eligible value anyway. Expects: criteria, brand_names #}
 {% set is_guest = not criteria.isAuthenticated %}
+{% set is_member = criteria.insightsAllowed %}
+{% set predictions_on = criteria.predictionsAllowed %}
 {% set pieces_values = criteria.piecesValues %}
 {% set custom_range = criteria.customPiecesRange %}
+{% set difficulty_tiers = [
+    {value: 1, name: 'veryeasy', icon: 'diff-very-easy'},
+    {value: 2, name: 'easy', icon: 'diff-easy'},
+    {value: 3, name: 'average', icon: 'diff-average'},
+    {value: 4, name: 'challenging', icon: 'diff-challenging'},
+    {value: 5, name: 'hard', icon: 'diff-hard'},
+    {value: 6, name: 'veryhard', icon: 'diff-very-hard'},
+] %}
 <div class="modal fade" id="puzzlePickerFilters" tabindex="-1" aria-labelledby="puzzlePickerFiltersLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-sm-down">
         <div class="modal-content">
@@ -21,7 +33,7 @@
                         </div>
                     {% endif %}
 
-                    <fieldset class="mb-3 {{ is_guest ? 'opacity-50' }}" {{ is_guest ? 'disabled' }}>
+                    <fieldset class="mb-3 {{ is_guest ? 'opacity-50' }}" data-picker-group="personal" {{ is_guest ? 'disabled' }}>
                         <legend class="fs-sm fw-bold mb-1">{{ 'puzzle_picker.filters.source.label'|trans }}</legend>
                         <div class="d-flex flex-wrap align-items-center gap-1">
                             {% for option in ['mine', 'not_mine', 'any'] %}
@@ -37,7 +49,7 @@
                         </div>
                     </fieldset>
 
-                    <fieldset class="mb-3 {{ is_guest ? 'opacity-50' }}" {{ is_guest ? 'disabled' }}>
+                    <fieldset class="mb-3 {{ is_guest ? 'opacity-50' }}" data-picker-group="personal" {{ is_guest ? 'disabled' }}>
                         <legend class="fs-sm fw-bold mb-1">{{ 'puzzle_picker.filters.solved.label'|trans }}</legend>
                         <div class="d-flex flex-wrap align-items-center gap-1">
                             {% for option in ['any', 'never', 'before'] %}
@@ -70,7 +82,7 @@
                         </div>
                     </fieldset>
 
-                    <fieldset class="mb-1">
+                    <fieldset class="mb-3">
                         <legend class="fs-sm fw-bold mb-1">{{ 'puzzle_picker.filters.brand.label'|trans }}</legend>
                         {# Option list is NOT rendered here (hundreds of brands) - tomselect-sync fetches
                            it from the cached filter-options endpoint on first focus. Only the currently
@@ -90,6 +102,92 @@
                             {% endfor %}
                         </select>
                     </fieldset>
+
+                    {# Time budget - free for everyone, the engine differs: my prediction for members
+                       with predictions, the community solo average for everybody else #}
+                    <fieldset class="mb-3">
+                        <legend class="fs-sm fw-bold mb-1">{{ 'puzzle_picker.filters.budget.label'|trans }}</legend>
+                        <div class="d-flex align-items-center gap-2">
+                            <label class="fs-sm text-muted mb-0" for="picker-predicted-max">{{ 'puzzle_picker.filters.budget.i_have'|trans }}</label>
+                            <input type="number" class="form-control form-control-sm" style="max-width: 6rem;" id="picker-predicted-max" name="predicted_max" min="{{ constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCriteria::MIN_PREDICTED_MINUTES') }}" max="{{ constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCriteria::MAX_PREDICTED_MINUTES') }}" step="5" inputmode="numeric" placeholder="60" value="{{ criteria.predictedMaxMinutes ?? '' }}">
+                            <span class="fs-sm text-muted">{{ 'puzzle_picker.filters.budget.minutes'|trans }}</span>
+                        </div>
+                        <div class="form-text puzzle-picker-budget-engine">
+                            {% if criteria.usesPersonalPrediction %}
+                                <i class="bi bi-person-check me-1"></i>{{ 'puzzle_picker.filters.budget.engine_personal'|trans }}
+                            {% else %}
+                                <i class="bi bi-people me-1"></i>{{ 'puzzle_picker.filters.budget.engine_community'|trans }}
+                            {% endif %}
+                        </div>
+                    </fieldset>
+
+                    {# Insights (members): one group, one lock. Difficulty needs membership; the
+                       prediction controls additionally need the player not to have opted out. #}
+                    <div class="puzzle-picker-insights-filters {{ not is_member ? 'puzzle-picker-insights-locked' }}">
+                        <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+                            <span class="fs-sm fw-bold">
+                                {% if not is_member %}<i class="ci-locked me-1"></i>{% endif %}{{ 'puzzle_picker.filters.insights.label'|trans }}
+                            </span>
+                            {% if not is_member and not is_guest %}
+                                <button type="button" class="btn btn-outline-secondary btn-xs" data-bs-toggle="modal" data-bs-target="#membersExclusiveModal">
+                                    <i class="ci-locked me-1"></i>{{ 'membership.members_exclusive_short'|trans }}
+                                </button>
+                            {% endif %}
+                        </div>
+
+                        <fieldset class="mb-3 {{ not is_member ? 'opacity-50' }}" data-picker-group="insights" {{ not is_member ? 'disabled' }}>
+                            <legend class="fs-sm text-muted mb-1">{{ 'puzzle_intelligence.difficulty.tier_label'|trans }}</legend>
+                            <div class="d-flex flex-wrap align-items-center gap-1">
+                                {% for tier in difficulty_tiers %}
+                                    <div class="form-check form-option form-check-inline mb-0">
+                                        <input type="checkbox" class="form-check-input" name="difficulty[]" id="picker-difficulty-{{ tier.value }}" value="{{ tier.value }}" {{ tier.value in criteria.difficultyTiers ? 'checked' }}>
+                                        <label class="form-option-label d-inline-flex align-items-center gap-1" for="picker-difficulty-{{ tier.value }}">
+                                            <svg class="diff-icon" width="16" height="16" style="color: var(--{{ tier.icon }})"><use href="/difficulty-icons-sprite.svg#{{ tier.icon }}"/></svg>
+                                            {{ ('puzzle_intelligence.difficulty.tiers.' ~ tier.name)|trans }}
+                                        </label>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                            <div class="form-text">{{ 'puzzle_picker.filters.insights.difficulty_note'|trans }}</div>
+                        </fieldset>
+
+                        <fieldset class="mb-3 {{ not predictions_on ? 'opacity-50' }}" data-picker-group="predictions" {{ not predictions_on ? 'disabled' }}>
+                            <legend class="fs-sm text-muted mb-1">{{ 'puzzle_picker.filters.insights.gap.label'|trans }}</legend>
+                            <div class="d-flex flex-wrap align-items-center gap-1">
+                                {% for option in ['any', 'slower', 'faster'] %}
+                                    <div class="form-check form-option form-check-inline mb-0">
+                                        <input type="radio" class="form-check-input" name="gap" id="picker-gap-{{ option }}" value="{{ option == 'any' ? '' : option }}" {{ (option == 'any' ? criteria.gap is null : (criteria.gap is not null and criteria.gap.value == option)) ? 'checked' }}>
+                                        <label class="form-option-label" for="picker-gap-{{ option }}">{{ ('puzzle_picker.filters.insights.gap.' ~ option)|trans }}</label>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                            <div class="d-flex align-items-center gap-2 mt-2">
+                                <label class="fs-sm text-muted mb-0" for="picker-gap-min">{{ 'puzzle_picker.filters.insights.gap.by_at_least'|trans }}</label>
+                                <input type="number" class="form-control form-control-sm" style="max-width: 6rem;" id="picker-gap-min" name="gap_min" min="{{ constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCriteria::MIN_GAP_MINUTES') }}" max="{{ constant('SpeedPuzzling\\Web\\Value\\PuzzlePickerCriteria::MAX_GAP_MINUTES') }}" step="1" inputmode="numeric" placeholder="1" value="{{ criteria.gapMinMinutes ?? '' }}">
+                                <span class="fs-sm text-muted">{{ 'puzzle_picker.filters.budget.minutes'|trans }}</span>
+                            </div>
+                            <div class="form-text">{{ 'puzzle_picker.filters.insights.gap.note'|trans }}</div>
+                        </fieldset>
+
+                        <fieldset class="mb-1 {{ not predictions_on ? 'opacity-50' }}" data-picker-group="predictions" {{ not predictions_on ? 'disabled' }}>
+                            <legend class="fs-sm text-muted mb-1">{{ 'puzzle_picker.filters.insights.order.label'|trans }}</legend>
+                            <div class="d-flex flex-wrap align-items-center gap-1">
+                                {% for option in ['random', 'gap_slower', 'gap_faster'] %}
+                                    <div class="form-check form-option form-check-inline mb-0">
+                                        <input type="radio" class="form-check-input" name="order" id="picker-order-{{ option }}" value="{{ option }}" {{ criteria.order.value == option ? 'checked' }}>
+                                        <label class="form-option-label" for="picker-order-{{ option }}">{{ ('puzzle_picker.filters.insights.order.' ~ option)|trans }}</label>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        </fieldset>
+
+                        {% if is_member and not predictions_on %}
+                            <div class="form-text puzzle-picker-insights-opted-out">
+                                <i class="bi bi-eye-slash me-1"></i>{{ 'puzzle_intelligence.prediction.time_predictions_opted_out'|trans }}
+                                <a href="{{ path('edit_profile') }}">{{ 'statistics.change_in_settings'|trans }}</a>
+                            </div>
+                        {% endif %}
+                    </div>
                 </div>
 
                 <div class="modal-footer justify-content-between">

--- a/templates/puzzle_picker/_presets.html.twig
+++ b/templates/puzzle_picker/_presets.html.twig
@@ -1,0 +1,23 @@
+{# One-tap presets above the filter bar. Each preset only fills the filter form (query params) -
+   no backend concept. "Beat my record" needs predictions: members get the link, members who
+   opted out see it muted, non-members get the lock (-> members modal). Expects: criteria #}
+{% set beat_params = {solved: 'before', gap: 'slower', order: 'gap_slower'} %}
+{% set beat_active = criteria.solved.value == 'before' and criteria.gap is not null and criteria.gap.value == 'slower' and criteria.order.value == 'gap_slower' %}
+<div class="d-flex flex-wrap align-items-center gap-2 mb-2 puzzle-picker-presets">
+    <span class="fs-sm text-muted">{{ 'puzzle_picker.presets.label'|trans }}</span>
+    {% if criteria.predictionsAllowed %}
+        <a class="badge rounded-pill {{ beat_active ? 'bg-primary text-white' : 'bg-secondary text-dark' }} fw-normal text-decoration-none py-2 px-3 puzzle-picker-preset"
+           rel="nofollow"
+           href="{{ path('puzzle_picker', beat_params) }}">
+            <i class="bi bi-trophy me-1"></i>{{ 'puzzle_picker.presets.beat_my_record'|trans }}
+        </a>
+    {% elseif criteria.insightsAllowed %}
+        <span class="badge rounded-pill bg-secondary text-muted fw-normal py-2 px-3 puzzle-picker-preset" title="{{ 'puzzle_intelligence.prediction.time_predictions_opted_out'|trans }}">
+            <i class="bi bi-eye-slash me-1"></i>{{ 'puzzle_picker.presets.beat_my_record'|trans }}
+        </span>
+    {% else %}
+        <button type="button" class="badge rounded-pill bg-secondary text-muted fw-normal py-2 px-3 border-0 puzzle-picker-preset" data-bs-toggle="modal" data-bs-target="#membersExclusiveModal">
+            <i class="ci-locked me-1"></i>{{ 'puzzle_picker.presets.beat_my_record'|trans }}
+        </button>
+    {% endif %}
+</div>

--- a/templates/puzzle_picker/index.html.twig
+++ b/templates/puzzle_picker/index.html.twig
@@ -17,6 +17,8 @@
         <h1 class="mb-1">{{ 'puzzle_picker.title'|trans }}</h1>
         <p class="text-muted mb-3">{{ 'puzzle_picker.subtitle'|trans }}</p>
 
+        {{ include('puzzle_picker/_presets.html.twig') }}
+
         {{ include('puzzle_picker/_filter_bar.html.twig') }}
 
         {{ include('puzzle_picker/_results.html.twig') }}

--- a/tests/Controller/PuzzlePickerControllerTest.php
+++ b/tests/Controller/PuzzlePickerControllerTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace SpeedPuzzling\Web\Tests\Controller;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SpeedPuzzling\Web\Services\PuzzleIntelligence\PuzzleIntelligenceRecalculator;
 use SpeedPuzzling\Web\Tests\DataFixtures\ManufacturerFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\TestingLogin;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -46,7 +49,7 @@ final class PuzzlePickerControllerTest extends WebTestCase
         self::assertStringNotContainsString('puzzle-stopwatch/', $content);
         self::assertStringNotContainsString('/en/puzzle-add/', $content);
         self::assertGreaterThan(0, $crawler->filter('.puzzle-picker-card a[href="/login?return=/en/what-to-solve-next"]')->count(), 'Guest cards lead to sign-in');
-        self::assertCount(2, $crawler->filter('#puzzlePickerFilters fieldset[disabled]'), 'Shelf and history groups are disabled for guests');
+        self::assertCount(2, $crawler->filter('#puzzlePickerFilters fieldset[data-picker-group="personal"][disabled]'), 'Shelf and history groups are disabled for guests');
     }
 
     public function testEveryLocalePathIsServed(): void
@@ -146,7 +149,7 @@ final class PuzzlePickerControllerTest extends WebTestCase
         self::assertStringContainsString('source=any', (string) $chips->attr('href'));
 
         // Personal filter groups are enabled
-        self::assertCount(0, $crawler->filter('#puzzlePickerFilters fieldset[disabled]'));
+        self::assertCount(0, $crawler->filter('#puzzlePickerFilters fieldset[data-picker-group="personal"][disabled]'));
         self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="source"][value="mine"][checked]'));
     }
 
@@ -227,5 +230,214 @@ final class PuzzlePickerControllerTest extends WebTestCase
         self::assertStringContainsString('/en/what-to-solve-next</loc>', $content);
         self::assertStringContainsString('/co-skladat-dal</loc>', $content);
         self::assertStringContainsString('/de/welches-puzzle-als-naechstes</loc>', $content);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Insights layer: member / non-member / guest / opted-out member
+    // ---------------------------------------------------------------------------------------------
+
+    public function testMemberSeesDifficultyAndTheirPredictionOnTheCard(): void
+    {
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->recalculateIntelligence($browser);
+
+        // PLAYER_WITH_STRIPE's 500-piece shelf: 500_01, 500_02 (scored, solved by her -> personal
+        // predictions), 500_04, 500_05 (no difficulty -> no prediction possible)
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?pieces[]=500&seed=abcd1234');
+
+        $this->assertResponseIsSuccessful();
+        $content = (string) $browser->getResponse()->getContent();
+
+        self::assertCount(4, $crawler->filter('.puzzle-picker-card'));
+        self::assertCount(2, $crawler->filter('.puzzle-picker-card .puzzle-picker-difficulty'), 'Difficulty tier on the two scored puzzles');
+        self::assertStringContainsString('Average', $crawler->filter('.puzzle-picker-difficulty')->first()->text());
+        self::assertCount(2, $crawler->filter('.puzzle-picker-card .puzzle-picker-prediction'), 'Prediction row on the two puzzles with a prediction');
+        self::assertCount(2, $crawler->filter('.puzzle-picker-card .puzzle-picker-prediction-unavailable'));
+        self::assertCount(2, $crawler->filter('.puzzle-picker-card .puzzle-picker-prediction-vs-best'), 'Both predicted puzzles have a personal best to compare with');
+        self::assertCount(0, $crawler->filter('.puzzle-picker-prediction-locked'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-prediction-opted-out'));
+        self::assertStringContainsString('Your prediction:', $content);
+        self::assertStringContainsString('previous solve', $content, 'Personalised wording');
+        self::assertMatchesRegularExpression('/(slower than your best|could beat your record|right at your best)/', $content);
+
+        // Filters modal: insights group unlocked, prediction controls enabled, personal budget engine
+        self::assertCount(0, $crawler->filter('#puzzlePickerFilters fieldset[data-picker-group="insights"][disabled]'));
+        self::assertCount(0, $crawler->filter('#puzzlePickerFilters fieldset[data-picker-group="predictions"][disabled]'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-insights-filters [data-bs-target="#membersExclusiveModal"]'));
+        self::assertCount(6, $crawler->filter('#puzzlePickerFilters input[name="difficulty[]"]'));
+        self::assertCount(3, $crawler->filter('#puzzlePickerFilters input[name="gap"]'));
+        self::assertCount(3, $crawler->filter('#puzzlePickerFilters input[name="order"]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="predicted_max"]'));
+        self::assertStringContainsString('Based on your own predicted time', $crawler->filter('.puzzle-picker-budget-engine')->text());
+        self::assertStringContainsString('only puzzles with enough data', strtolower($content));
+
+        // "Beat my record" preset is a real link
+        $preset = $crawler->filter('a.puzzle-picker-preset');
+        self::assertCount(1, $preset);
+        self::assertStringContainsString('solved=before', (string) $preset->attr('href'));
+        self::assertStringContainsString('gap=slower', (string) $preset->attr('href'));
+        self::assertStringContainsString('order=gap_slower', (string) $preset->attr('href'));
+    }
+
+    public function testMemberInsightsFiltersAreAppliedAndShownAsChips(): void
+    {
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->recalculateIntelligence($browser);
+
+        // PLAYER_WITH_STRIPE has one attempt on each scored puzzle and beat every prediction -> "faster"
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?source=any&solved=before&gap=faster&gap_min=2&order=gap_faster&difficulty[]=3&predicted_max=90&seed=abcd1234');
+
+        $this->assertResponseIsSuccessful();
+
+        $labels = self::chipLabels($crawler);
+
+        self::assertContains('Solved before', $labels);
+        self::assertContains('Up to 90 min', $labels);
+        self::assertContains('Difficulty: Average', $labels);
+        self::assertContains('Faster than predicted by 2+ min', $labels);
+        self::assertContains('Order: largest gap (I\'m faster)', $labels);
+
+        // Every card that comes back is a scored puzzle she solved and is faster on than predicted
+        $cardCount = $crawler->filter('.puzzle-picker-card')->count();
+        self::assertGreaterThan(0, $cardCount);
+        self::assertCount($cardCount, $crawler->filter('.puzzle-picker-card .puzzle-picker-difficulty'));
+        self::assertCount($cardCount, $crawler->filter('.puzzle-picker-card .puzzle-picker-prediction'));
+        self::assertCount($cardCount, $crawler->filter('.puzzle-picker-card .puzzle-picker-prediction-vs-best:contains("slower than your best")'), 'Faster than predicted = the prediction is slower than my best');
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="gap"][value="faster"][checked]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="order"][value="gap_faster"][checked]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="difficulty[]"][value="3"][checked]'));
+        self::assertSame('2', $crawler->filter('#puzzlePickerFilters input[name="gap_min"]')->attr('value'));
+        self::assertSame('90', $crawler->filter('#puzzlePickerFilters input[name="predicted_max"]')->attr('value'));
+
+        // The preset chip is highlighted when its filters are active
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?solved=before&gap=slower&order=gap_slower');
+        $this->assertResponseIsSuccessful();
+        self::assertStringContainsString('bg-primary', (string) $crawler->filter('a.puzzle-picker-preset')->attr('class'));
+    }
+
+    public function testNonMemberGetsOneLockedPredictionRowPerCardAndALockedInsightsGroup(): void
+    {
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_REGULAR);
+        $this->recalculateIntelligence($browser);
+
+        // Insights params in the URL are ignored server-side: still the whole 7-puzzle shelf
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?gap=slower&order=gap_slower&difficulty[]=3&seed=abcd1234');
+
+        $this->assertResponseIsSuccessful();
+        $content = (string) $browser->getResponse()->getContent();
+
+        self::assertCount(6, $crawler->filter('.puzzle-picker-card'));
+        self::assertStringContainsString('of 7 matching puzzles', $content);
+        self::assertCount(1, $crawler->filter('.puzzle-picker-filter-bar a[title="Remove this filter"]'), 'Only the default shelf chip - no insights chips');
+
+        // Exactly one lock per card, no difficulty, no prediction numbers
+        self::assertCount(6, $crawler->filter('.puzzle-picker-card .puzzle-picker-prediction-locked [data-bs-target="#membersExclusiveModal"]'));
+        self::assertStringContainsString('Your time prediction – members only', $content);
+        self::assertCount(0, $crawler->filter('.puzzle-picker-difficulty'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-prediction'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-prediction-unavailable'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-prediction-opted-out'));
+        self::assertStringNotContainsString('Your prediction:', $content);
+
+        // Filters modal: the whole insights group is one locked block, budget on the community engine
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters .puzzle-picker-insights-locked'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters fieldset[data-picker-group="insights"][disabled]'));
+        self::assertCount(2, $crawler->filter('#puzzlePickerFilters fieldset[data-picker-group="predictions"][disabled]'));
+        self::assertCount(1, $crawler->filter('.puzzle-picker-insights-filters button[data-bs-target="#membersExclusiveModal"]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters input[name="predicted_max"]:not([disabled])'), 'The time budget stays free');
+        self::assertStringContainsString('community average', $crawler->filter('.puzzle-picker-budget-engine')->text());
+
+        // Preset chip is the lock -> members modal, not a link
+        self::assertCount(0, $crawler->filter('a.puzzle-picker-preset'));
+        self::assertCount(1, $crawler->filter('button.puzzle-picker-preset[data-bs-target="#membersExclusiveModal"]'));
+    }
+
+    public function testGuestSeesNeitherPredictionNorLockOnTheCards(): void
+    {
+        $browser = self::createClient();
+
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?gap=slower&difficulty[]=3&order=gap_slower&predicted_max=60');
+
+        $this->assertResponseIsSuccessful();
+        $content = (string) $browser->getResponse()->getContent();
+
+        self::assertGreaterThan(0, $crawler->filter('.puzzle-picker-card')->count());
+        self::assertCount(0, $crawler->filter('.puzzle-picker-prediction, .puzzle-picker-prediction-locked, .puzzle-picker-prediction-unavailable, .puzzle-picker-prediction-opted-out, .puzzle-picker-difficulty'));
+        self::assertStringNotContainsString('members only', $content);
+
+        // Insights group disabled, but no members-modal button for somebody who is not even signed in; no presets
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters fieldset[data-picker-group="insights"][disabled]'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-insights-filters [data-bs-target="#membersExclusiveModal"]'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-preset'));
+
+        // The community budget is the only insights-adjacent filter a guest keeps
+        $chips = $crawler->filter('.puzzle-picker-filter-bar a[title="Remove this filter"]');
+        self::assertCount(1, $chips);
+        self::assertStringContainsString('Up to 60 min', $chips->text());
+    }
+
+    public function testMemberWhoOptedOutOfPredictionsKeepsDifficultyButGetsNoPrediction(): void
+    {
+        $browser = self::createClient();
+        TestingLogin::asPlayer($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->recalculateIntelligence($browser);
+
+        // No fixture player has opted out - flip the flag inside the test transaction
+        $browser->getContainer()->get(Connection::class)->executeStatement(
+            'UPDATE player SET time_predictions_opted_out = true WHERE id = :id',
+            ['id' => PlayerFixture::PLAYER_WITH_STRIPE],
+        );
+
+        $crawler = $browser->request('GET', '/en/what-to-solve-next?pieces[]=500&gap=slower&order=gap_slower&difficulty[]=3&seed=abcd1234');
+
+        $this->assertResponseIsSuccessful();
+        $content = (string) $browser->getResponse()->getContent();
+
+        // Difficulty filter applied (2 scored 500-piece puzzles on her shelf), gap/order stripped
+        self::assertCount(2, $crawler->filter('.puzzle-picker-card'));
+        self::assertCount(2, $crawler->filter('.puzzle-picker-card .puzzle-picker-difficulty'));
+        self::assertEqualsCanonicalizing(['My collection', '500 pieces', 'Difficulty: Average'], self::chipLabels($crawler));
+
+        // Opt-out notice instead of the prediction, on every card
+        self::assertCount(2, $crawler->filter('.puzzle-picker-card .puzzle-picker-prediction-opted-out'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-prediction'));
+        self::assertCount(0, $crawler->filter('.puzzle-picker-prediction-locked'));
+        self::assertStringContainsString('You have opted out of time predictions', $content);
+        self::assertGreaterThan(0, $crawler->filter('.puzzle-picker-prediction-opted-out a[href*="edit-profile"], .puzzle-picker-prediction-opted-out a[href*="/en/"]')->count(), 'Link to the settings');
+
+        // Filters modal: difficulty on, prediction controls off with the notice, community budget engine
+        self::assertCount(0, $crawler->filter('#puzzlePickerFilters fieldset[data-picker-group="insights"][disabled]'));
+        self::assertCount(2, $crawler->filter('#puzzlePickerFilters fieldset[data-picker-group="predictions"][disabled]'));
+        self::assertCount(1, $crawler->filter('#puzzlePickerFilters .puzzle-picker-insights-opted-out'));
+        self::assertStringContainsString('community average', $crawler->filter('.puzzle-picker-budget-engine')->text());
+
+        // Preset chip is muted, neither a link nor the members lock
+        self::assertCount(0, $crawler->filter('a.puzzle-picker-preset'));
+        self::assertCount(0, $crawler->filter('button.puzzle-picker-preset'));
+        self::assertCount(1, $crawler->filter('span.puzzle-picker-preset'));
+    }
+
+    /**
+     * Visible labels of the active-filter chips (without the visually-hidden "remove" suffix).
+     *
+     * @return list<string>
+     */
+    private static function chipLabels(Crawler $crawler): array
+    {
+        return $crawler->filter('.puzzle-picker-filter-bar a[title="Remove this filter"]')->each(
+            static fn (Crawler $chip): string => trim(preg_replace('/\s*–\s*Remove this filter\s*$/u', '', $chip->text()) ?? ''),
+        );
+    }
+
+    /**
+     * Baselines / difficulties / ratios are computed by the 15-minute cron in production;
+     * tests build them on demand (rolled back with the test transaction).
+     */
+    private function recalculateIntelligence(KernelBrowser $browser): void
+    {
+        $browser->getContainer()->get(PuzzleIntelligenceRecalculator::class)->recalculate();
     }
 }

--- a/tests/Query/GetPlayerPredictionsTest.php
+++ b/tests/Query/GetPlayerPredictionsTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Query;
+
+use Doctrine\DBAL\Connection;
+use SpeedPuzzling\Web\Query\GetPlayerPrediction;
+use SpeedPuzzling\Web\Query\GetPlayerPredictions;
+use SpeedPuzzling\Web\Results\TimePredictionResult;
+use SpeedPuzzling\Web\Services\PuzzleIntelligence\PuzzleIntelligenceRecalculator;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleIntelligenceFixture;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The bulk read model must be indistinguishable from the single-puzzle one:
+ * both delegate to TimePredictionCalculator, this test pins that they also
+ * feed it the same inputs for every fixture player × puzzle pair.
+ */
+final class GetPlayerPredictionsTest extends KernelTestCase
+{
+    private const array PLAYERS = [
+        PlayerFixture::PLAYER_REGULAR,
+        PlayerFixture::PLAYER_PRIVATE,
+        PlayerFixture::PLAYER_ADMIN,
+        PlayerFixture::PLAYER_WITH_FAVORITES,
+        PlayerFixture::PLAYER_WITH_STRIPE,
+    ];
+
+    private GetPlayerPrediction $single;
+
+    private GetPlayerPredictions $bulk;
+
+    private Connection $database;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $container->get(PuzzleIntelligenceRecalculator::class)->recalculate();
+
+        $this->single = $container->get(GetPlayerPrediction::class);
+        $this->bulk = $container->get(GetPlayerPredictions::class);
+        $this->database = $container->get(Connection::class);
+    }
+
+    public function testBulkEqualsSingleForEveryFixturePlayerAndPuzzle(): void
+    {
+        $puzzleIds = $this->allPuzzleIds();
+        $personalPairs = 0;
+        $statisticalPairs = 0;
+        $absentPairs = 0;
+
+        foreach (self::PLAYERS as $playerId) {
+            $bulk = $this->bulk->forPuzzles($playerId, $puzzleIds);
+            $personal = $this->bulk->forAllSolvedPuzzles($playerId);
+
+            foreach ($puzzleIds as $puzzleId) {
+                $single = $this->single->forPuzzle($playerId, $puzzleId);
+
+                if ($single === null) {
+                    self::assertArrayNotHasKey($puzzleId, $bulk, "Bulk must have no prediction for {$playerId} × {$puzzleId}");
+                    $absentPairs++;
+
+                    continue;
+                }
+
+                self::assertArrayHasKey($puzzleId, $bulk, "Bulk is missing {$playerId} × {$puzzleId}");
+                self::assertEquals($single, $bulk[$puzzleId], "Bulk differs from single for {$playerId} × {$puzzleId}");
+
+                if ($single->isPersonalized) {
+                    $personalPairs++;
+                } else {
+                    $statisticalPairs++;
+                }
+            }
+
+            $personalFromBulk = array_filter($bulk, static fn (TimePredictionResult $prediction): bool => $prediction->isPersonalized);
+            ksort($personalFromBulk);
+            ksort($personal);
+
+            self::assertEquals($personalFromBulk, $personal, 'forAllSolvedPuzzles() is exactly the personal subset of forPuzzles()');
+        }
+
+        // Make sure the sweep exercised real cases, not an empty intersection
+        self::assertGreaterThanOrEqual(20, $personalPairs);
+        self::assertGreaterThan(0, $absentPairs);
+        // Every fixture player has solved every scored puzzle, so a statistical
+        // case never occurs naturally here - it is covered by the dedicated test
+        self::assertSame(0, $statisticalPairs);
+    }
+
+    public function testRegularPlayerOnPuzzle50002IsAPersonalPredictionFromThreeAttempts(): void
+    {
+        // PLAYER_REGULAR on PUZZLE_500_02: 2200 -> 1900 -> 1700 (chronological), 10 days since the last solve
+        $prediction = $this->bulk->forPuzzles(PlayerFixture::PLAYER_REGULAR, [PuzzleFixture::PUZZLE_500_02])[PuzzleFixture::PUZZLE_500_02];
+
+        self::assertTrue($prediction->isPersonalized);
+        self::assertSame(3, $prediction->personalSolveCount);
+        self::assertSame(4, $prediction->predictedAttemptNumber);
+        self::assertSame(1700, $prediction->lastTimeSeconds);
+        self::assertSame(0.0, $prediction->difficultyForPlayer);
+        // Improving player: predicted below the best time but never below the 70 % floor (1190)
+        self::assertLessThan(1700, $prediction->predictedSeconds);
+        self::assertGreaterThanOrEqual(1190, $prediction->predictedSeconds);
+        self::assertGreaterThanOrEqual($prediction->rangeLowSeconds, $prediction->predictedSeconds);
+        self::assertLessThanOrEqual($prediction->rangeHighSeconds, $prediction->predictedSeconds);
+
+        self::assertEquals($this->single->forPuzzle(PlayerFixture::PLAYER_REGULAR, PuzzleFixture::PUZZLE_500_02), $prediction);
+        self::assertEquals($prediction, $this->bulk->forAllSolvedPuzzles(PlayerFixture::PLAYER_REGULAR)[PuzzleFixture::PUZZLE_500_02]);
+    }
+
+    public function testStatisticalPredictionForAPuzzleThePlayerHasNeverSolved(): void
+    {
+        // Every fixture player has solved every puzzle with a difficulty score, so build the
+        // case: drop PLAYER_WITH_STRIPE's only attempt on INTEL_PUZZLE_A *after* the intelligence
+        // tables were computed (the test transaction rolls it back). Baseline (500 pcs) x
+        // difficulty score of the puzzle is what both read models must now return.
+        $this->database->executeStatement(
+            'DELETE FROM puzzle_solving_time WHERE player_id = :playerId AND puzzle_id = :puzzleId',
+            ['playerId' => PlayerFixture::PLAYER_WITH_STRIPE, 'puzzleId' => PuzzleIntelligenceFixture::INTEL_PUZZLE_A],
+        );
+
+        $baseline = $this->database->fetchOne(
+            'SELECT baseline_seconds FROM player_baseline WHERE player_id = :playerId AND pieces_count = 500',
+            ['playerId' => PlayerFixture::PLAYER_WITH_STRIPE],
+        );
+        $difficulty = $this->database->fetchOne(
+            'SELECT difficulty_score FROM puzzle_difficulty WHERE puzzle_id = :puzzleId',
+            ['puzzleId' => PuzzleIntelligenceFixture::INTEL_PUZZLE_A],
+        );
+        assert(is_int($baseline) || is_string($baseline));
+        assert(is_float($difficulty) || is_string($difficulty));
+
+        $prediction = $this->bulk->forPuzzles(PlayerFixture::PLAYER_WITH_STRIPE, [PuzzleIntelligenceFixture::INTEL_PUZZLE_A])[PuzzleIntelligenceFixture::INTEL_PUZZLE_A];
+
+        self::assertFalse($prediction->isPersonalized);
+        self::assertNull($prediction->personalSolveCount);
+        self::assertNull($prediction->lastTimeSeconds);
+        self::assertSame((int) round((int) $baseline * (float) $difficulty), $prediction->predictedSeconds);
+        self::assertSame((float) $difficulty, $prediction->difficultyForPlayer);
+        self::assertGreaterThan(0, $prediction->rangeLowSeconds);
+        self::assertGreaterThanOrEqual($prediction->rangeLowSeconds, $prediction->predictedSeconds);
+        self::assertLessThanOrEqual($prediction->rangeHighSeconds, $prediction->predictedSeconds);
+
+        self::assertEquals($this->single->forPuzzle(PlayerFixture::PLAYER_WITH_STRIPE, PuzzleIntelligenceFixture::INTEL_PUZZLE_A), $prediction);
+        self::assertArrayNotHasKey(PuzzleIntelligenceFixture::INTEL_PUZZLE_A, $this->bulk->forAllSolvedPuzzles(PlayerFixture::PLAYER_WITH_STRIPE), 'Statistical predictions are not part of the solved-puzzles set');
+    }
+
+    public function testNothingForPuzzlesWithoutDataOrPlayersWithoutBaseline(): void
+    {
+        // PUZZLE_9000: never solved by anyone, no difficulty -> absent
+        self::assertArrayNotHasKey(PuzzleFixture::PUZZLE_9000, $this->bulk->forPuzzles(PlayerFixture::PLAYER_REGULAR, [PuzzleFixture::PUZZLE_9000, PuzzleFixture::PUZZLE_500_01]));
+        self::assertSame([], $this->bulk->forPuzzles(PlayerFixture::PLAYER_REGULAR, []));
+        self::assertSame([], $this->bulk->forPuzzles('00000000-0000-0000-0000-000000000099', [PuzzleFixture::PUZZLE_500_01]));
+        self::assertSame([], $this->bulk->forAllSolvedPuzzles('00000000-0000-0000-0000-000000000099'));
+    }
+
+    public function testPersonalPredictionsAreMemoisedPerRequestAndResetClearsThem(): void
+    {
+        $before = $this->bulk->forAllSolvedPuzzles(PlayerFixture::PLAYER_REGULAR);
+        self::assertArrayHasKey(PuzzleFixture::PUZZLE_500_02, $before);
+
+        $this->database->executeStatement(
+            'DELETE FROM puzzle_solving_time WHERE player_id = :playerId AND puzzle_id = :puzzleId',
+            ['playerId' => PlayerFixture::PLAYER_REGULAR, 'puzzleId' => PuzzleFixture::PUZZLE_500_02],
+        );
+
+        self::assertArrayHasKey(PuzzleFixture::PUZZLE_500_02, $this->bulk->forAllSolvedPuzzles(PlayerFixture::PLAYER_REGULAR), 'Memoised within the request');
+        self::assertArrayHasKey(PuzzleFixture::PUZZLE_500_02, $this->bulk->forPuzzles(PlayerFixture::PLAYER_REGULAR, [PuzzleFixture::PUZZLE_500_02]));
+
+        $this->bulk->reset();
+
+        $after = $this->bulk->forAllSolvedPuzzles(PlayerFixture::PLAYER_REGULAR);
+        self::assertArrayNotHasKey(PuzzleFixture::PUZZLE_500_02, $after, 'reset() drops the memo');
+        self::assertArrayHasKey(PuzzleFixture::PUZZLE_500_01, $after);
+        // ... and the puzzle now falls back to the statistical prediction
+        self::assertFalse($this->bulk->forPuzzles(PlayerFixture::PLAYER_REGULAR, [PuzzleFixture::PUZZLE_500_02])[PuzzleFixture::PUZZLE_500_02]->isPersonalized);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allPuzzleIds(): array
+    {
+        /** @var list<string> $ids */
+        $ids = $this->database->fetchFirstColumn('SELECT id FROM puzzle ORDER BY id');
+
+        return $ids;
+    }
+}

--- a/tests/Query/GetPuzzlePickerSuggestionsTest.php
+++ b/tests/Query/GetPuzzlePickerSuggestionsTest.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Tests\Query;
 
 use Doctrine\DBAL\Connection;
+use SpeedPuzzling\Web\Query\GetPlayerPredictions;
 use SpeedPuzzling\Web\Query\GetPuzzlePickerSuggestions;
 use SpeedPuzzling\Web\Results\PuzzlePickerPick;
 use SpeedPuzzling\Web\Results\PuzzlePickerSuggestion;
+use SpeedPuzzling\Web\Services\PuzzleIntelligence\PuzzleIntelligenceRecalculator;
 use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionApiFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\ManufacturerFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleIntelligenceFixture;
+use SpeedPuzzling\Web\Value\DifficultyTier;
+use SpeedPuzzling\Web\Value\MetricConfidence;
 use SpeedPuzzling\Web\Value\PuzzlePickerCriteria;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,6 +25,10 @@ final class GetPuzzlePickerSuggestionsTest extends KernelTestCase
 {
     private GetPuzzlePickerSuggestions $getPuzzlePickerSuggestions;
 
+    private GetPlayerPredictions $getPlayerPredictions;
+
+    private PuzzleIntelligenceRecalculator $recalculator;
+
     private Connection $database;
 
     protected function setUp(): void
@@ -27,6 +36,8 @@ final class GetPuzzlePickerSuggestionsTest extends KernelTestCase
         self::bootKernel();
         $container = self::getContainer();
         $this->getPuzzlePickerSuggestions = $container->get(GetPuzzlePickerSuggestions::class);
+        $this->getPlayerPredictions = $container->get(GetPlayerPredictions::class);
+        $this->recalculator = $container->get(PuzzleIntelligenceRecalculator::class);
         $this->database = $container->get(Connection::class);
     }
 
@@ -418,14 +429,302 @@ final class GetPuzzlePickerSuggestionsTest extends KernelTestCase
         self::assertSame(0, $none->totalMatching);
     }
 
+
+    // ---------------------------------------------------------------------------------------------
+    // Insights layer (members): difficulty tiers, gap vs. my prediction, gap orders, time budget
+    // ---------------------------------------------------------------------------------------------
+
+    public function testDifficultyIsHydratedOnEveryCardButPredictionFieldsOnlyWhenComputedPreLimit(): void
+    {
+        $this->recalculator->recalculate();
+        $any = $this->pickAll(['source' => 'any'], PlayerFixture::PLAYER_PRIVATE);
+
+        // Scored puzzle: tier + confidence; unscored: tier null; no difficulty row at all: both null
+        $scored = self::byId($any, PuzzleFixture::PUZZLE_500_01);
+        self::assertSame(DifficultyTier::Average, $scored->difficultyTier);
+        self::assertSame(MetricConfidence::Low, $scored->difficultyConfidence);
+        self::assertTrue($scored->hasDifficulty());
+
+        $insufficient = self::byId($any, PuzzleFixture::PUZZLE_300);
+        self::assertNull($insufficient->difficultyTier);
+        self::assertSame(MetricConfidence::Insufficient, $insufficient->difficultyConfidence);
+        self::assertFalse($insufficient->hasDifficulty());
+
+        $noRow = self::byId($any, PuzzleFixture::PUZZLE_9000);
+        self::assertNull($noRow->difficultyTier);
+        self::assertNull($noRow->difficultyConfidence);
+        self::assertFalse($noRow->hasDifficulty());
+
+        // Without an insights filter nothing is computed before the LIMIT (PR 1 query shape)
+        foreach ($any->suggestions as $suggestion) {
+            self::assertNull($suggestion->predictedSeconds);
+            self::assertNull($suggestion->gapSeconds);
+        }
+    }
+
+    public function testDifficultyTierFilterKeepsOnlyScoredPuzzlesOfThoseTiers(): void
+    {
+        $this->recalculator->recalculate();
+        // The five puzzles with a difficulty score are all tier 3 (Average); PLAYER_PRIVATE has nothing lent out
+        $scored = [
+            PuzzleFixture::PUZZLE_500_01,
+            PuzzleFixture::PUZZLE_500_02,
+            PuzzleFixture::PUZZLE_500_03,
+            PuzzleIntelligenceFixture::INTEL_PUZZLE_A,
+            PuzzleIntelligenceFixture::INTEL_PUZZLE_B,
+        ];
+
+        $average = $this->pickAll(['source' => 'any', 'difficulty' => ['3']], PlayerFixture::PLAYER_PRIVATE, member: true);
+        self::assertEqualsCanonicalizing($scored, self::ids($average));
+        self::assertSame(5, $average->totalMatching);
+
+        foreach ($average->suggestions as $suggestion) {
+            self::assertSame(DifficultyTier::Average, $suggestion->difficultyTier);
+            self::assertTrue($suggestion->hasDifficulty());
+        }
+
+        self::assertTrue($this->pickAll(['source' => 'any', 'difficulty' => ['1']], PlayerFixture::PLAYER_PRIVATE, member: true)->isEmpty());
+        self::assertEqualsCanonicalizing($scored, self::ids($this->pickAll(['source' => 'any', 'difficulty' => ['1', '3', '6']], PlayerFixture::PLAYER_PRIVATE, member: true)));
+
+        // Combines with the free filters (all five scored puzzles are Ravensburger, 500 pieces, solved by PLAYER_PRIVATE)
+        self::assertEqualsCanonicalizing(
+            $scored,
+            self::ids($this->pickAll(['source' => 'any', 'difficulty' => ['3'], 'brand' => [ManufacturerFixture::MANUFACTURER_RAVENSBURGER], 'solved' => 'before', 'pieces' => ['500']], PlayerFixture::PLAYER_PRIVATE, member: true)),
+        );
+        self::assertTrue($this->pickAll(['source' => 'any', 'difficulty' => ['3'], 'brand' => [ManufacturerFixture::MANUFACTURER_TREFL]], PlayerFixture::PLAYER_PRIVATE, member: true)->isEmpty());
+        self::assertTrue($this->pickAll(['source' => 'any', 'difficulty' => ['3'], 'solved' => 'never'], PlayerFixture::PLAYER_PRIVATE, member: true)->isEmpty());
+
+        // Non-members: the tier filter is stripped by the criteria, the pool stays whole
+        $everything = $this->pickAll(['source' => 'any'], PlayerFixture::PLAYER_PRIVATE);
+        self::assertSame($everything->totalMatching, $this->pickAll(['source' => 'any', 'difficulty' => ['3']], PlayerFixture::PLAYER_PRIVATE)->totalMatching);
+    }
+
+    public function testGapSlowerAndFasterCompareMyFastestSoloTimeWithMyPrediction(): void
+    {
+        $this->recalculator->recalculate();
+        $playerId = PlayerFixture::PLAYER_REGULAR;
+        $predictions = $this->getPlayerPredictions->forAllSolvedPuzzles($playerId);
+        $all = $this->pickAll(['source' => 'any', 'lent' => '1'], $playerId, member: true);
+
+        $expectedSlower = [];
+        $expectedFaster = [];
+        $expectedGaps = [];
+
+        foreach ($all->suggestions as $suggestion) {
+            if ($suggestion->mySolveCountSolo === 0 || isset($predictions[$suggestion->puzzleId]) === false) {
+                continue;
+            }
+
+            $gap = (int) $suggestion->myFastestSeconds - $predictions[$suggestion->puzzleId]->predictedSeconds;
+            $expectedGaps[$suggestion->puzzleId] = $gap;
+
+            if ($gap >= 60) {
+                $expectedSlower[] = $suggestion->puzzleId;
+            }
+
+            if ($gap <= -60) {
+                $expectedFaster[] = $suggestion->puzzleId;
+            }
+        }
+
+        // PLAYER_REGULAR improves on PUZZLE_500_02 (2200 -> 1900 -> 1700): predicted below the best -> "slower"
+        self::assertGreaterThan(0, $expectedGaps[PuzzleFixture::PUZZLE_500_02]);
+        self::assertContains(PuzzleFixture::PUZZLE_500_02, $expectedSlower);
+        self::assertNotSame([], $expectedFaster, 'The fixture needs at least one puzzle where the player beat the prediction');
+
+        $slower = $this->pickAll(['source' => 'any', 'lent' => '1', 'gap' => 'slower'], $playerId, member: true);
+        self::assertEqualsCanonicalizing($expectedSlower, self::ids($slower));
+        self::assertSame(count($expectedSlower), $slower->totalMatching);
+
+        foreach ($slower->suggestions as $suggestion) {
+            self::assertSame($expectedGaps[$suggestion->puzzleId], $suggestion->gapSeconds);
+            self::assertSame($predictions[$suggestion->puzzleId]->predictedSeconds, $suggestion->predictedSeconds);
+            self::assertGreaterThanOrEqual(60, $suggestion->gapSeconds);
+        }
+
+        $faster = $this->pickAll(['source' => 'any', 'lent' => '1', 'gap' => 'faster'], $playerId, member: true);
+        self::assertEqualsCanonicalizing($expectedFaster, self::ids($faster));
+
+        foreach ($faster->suggestions as $suggestion) {
+            self::assertSame($expectedGaps[$suggestion->puzzleId], $suggestion->gapSeconds);
+            self::assertLessThanOrEqual(-60, $suggestion->gapSeconds);
+        }
+
+        self::assertSame([], array_intersect(self::ids($slower), self::ids($faster)));
+
+        // "by at least N min" tightens the threshold
+        self::assertNotSame([], $expectedGaps);
+        $gapMin = 1 + intdiv(max($expectedGaps), 60);
+        self::assertTrue($this->pickAll(['source' => 'any', 'lent' => '1', 'gap' => 'slower', 'gap_min' => (string) ($gapMin + 60)], $playerId, member: true)->isEmpty());
+        $tight = $this->pickAll(['source' => 'any', 'lent' => '1', 'gap' => 'slower', 'gap_min' => '2'], $playerId, member: true);
+        self::assertEqualsCanonicalizing(
+            array_keys(array_filter($expectedGaps, static fn (int $gap): bool => $gap >= 120)),
+            self::ids($tight),
+        );
+
+        // Puzzles without a solo time never match a gap filter, whatever the prediction
+        foreach ([...$slower->suggestions, ...$faster->suggestions] as $suggestion) {
+            self::assertGreaterThan(0, $suggestion->mySolveCountSolo);
+        }
+
+        // Non-members / opted-out: the gap filter is stripped, the pool stays whole
+        self::assertSame($all->totalMatching, $this->pickAll(['source' => 'any', 'lent' => '1', 'gap' => 'slower'], $playerId)->totalMatching);
+        self::assertSame($all->totalMatching, $this->pickAll(['source' => 'any', 'lent' => '1', 'gap' => 'slower'], $playerId, member: true, predictions: false)->totalMatching);
+    }
+
+    public function testGapOrdersAreDeterministicWithTheSeedAsTieBreaker(): void
+    {
+        $this->recalculator->recalculate();
+        $playerId = PlayerFixture::PLAYER_REGULAR;
+        $seed = 'abcd1234';
+        $predictions = $this->getPlayerPredictions->forAllSolvedPuzzles($playerId);
+        $all = $this->pickAll(['source' => 'any', 'lent' => '1'], $playerId, member: true);
+
+        $gaps = [];
+
+        foreach ($all->suggestions as $suggestion) {
+            $gaps[$suggestion->puzzleId] = $suggestion->mySolveCountSolo > 0 && isset($predictions[$suggestion->puzzleId])
+                ? (int) $suggestion->myFastestSeconds - $predictions[$suggestion->puzzleId]->predictedSeconds
+                : null;
+        }
+
+        $knownGaps = array_filter($gaps, static fn (null|int $gap): bool => $gap !== null);
+        self::assertNotSame([], $knownGaps);
+        self::assertGreaterThan(count($knownGaps), count($gaps), 'Some puzzles have no gap and must sort last');
+
+        $expectedSlowerFirst = array_keys($gaps);
+        usort($expectedSlowerFirst, static function (string $a, string $b) use ($gaps, $seed): int {
+            if ($gaps[$a] === null || $gaps[$b] === null) {
+                return ($gaps[$a] === null ? 1 : 0) <=> ($gaps[$b] === null ? 1 : 0) ?: strcmp(md5($seed . $a), md5($seed . $b));
+            }
+
+            return $gaps[$b] <=> $gaps[$a] ?: strcmp(md5($seed . $a), md5($seed . $b));
+        });
+
+        $slowerFirst = $this->getPuzzlePickerSuggestions->pick($this->memberCriteria(['source' => 'any', 'lent' => '1', 'order' => 'gap_slower', 'seed' => $seed]), $playerId, 1000);
+        self::assertSame($expectedSlowerFirst, self::ids($slowerFirst), 'gap DESC NULLS LAST, then the seeded shuffle');
+        self::assertSame($all->totalMatching, $slowerFirst->totalMatching, 'An order never filters');
+        self::assertSame($gaps[$expectedSlowerFirst[0]], $slowerFirst->suggestions[0]->gapSeconds);
+        self::assertSame(max($knownGaps), $slowerFirst->suggestions[0]->gapSeconds);
+        self::assertNull($slowerFirst->suggestions[count($gaps) - 1]->gapSeconds, 'Puzzles without a gap come last');
+
+        $expectedFasterFirst = array_keys($gaps);
+        usort($expectedFasterFirst, static function (string $a, string $b) use ($gaps, $seed): int {
+            if ($gaps[$a] === null || $gaps[$b] === null) {
+                return ($gaps[$a] === null ? 1 : 0) <=> ($gaps[$b] === null ? 1 : 0) ?: strcmp(md5($seed . $a), md5($seed . $b));
+            }
+
+            return $gaps[$a] <=> $gaps[$b] ?: strcmp(md5($seed . $a), md5($seed . $b));
+        });
+
+        $fasterFirst = $this->getPuzzlePickerSuggestions->pick($this->memberCriteria(['source' => 'any', 'lent' => '1', 'order' => 'gap_faster', 'seed' => $seed]), $playerId, 1000);
+        self::assertSame($expectedFasterFirst, self::ids($fasterFirst), 'gap ASC NULLS LAST, then the seeded shuffle');
+        self::assertSame(min($knownGaps), $fasterFirst->suggestions[0]->gapSeconds);
+
+        // Paging windows of the same order, and a re-run gives the same answer
+        $firstPage = $this->getPuzzlePickerSuggestions->pick($this->memberCriteria(['source' => 'any', 'lent' => '1', 'order' => 'gap_slower', 'seed' => $seed]), $playerId, 6);
+        $secondPage = $this->getPuzzlePickerSuggestions->pick($this->memberCriteria(['source' => 'any', 'lent' => '1', 'order' => 'gap_slower', 'seed' => $seed]), $playerId, 6, 6);
+        self::assertSame(array_slice($expectedSlowerFirst, 0, 12), [...self::ids($firstPage), ...self::ids($secondPage)]);
+
+        // Order + gap filter = "Beat my record": only slower puzzles, largest gap first
+        $beat = $this->getPuzzlePickerSuggestions->pick($this->memberCriteria(['source' => 'any', 'lent' => '1', 'solved' => 'before', 'gap' => 'slower', 'order' => 'gap_slower', 'seed' => $seed]), $playerId, 1000);
+        self::assertSame(
+            array_values(array_filter($expectedSlowerFirst, static fn (string $id): bool => $gaps[$id] !== null && $gaps[$id] >= 60)),
+            self::ids($beat),
+        );
+
+        // Not allowed -> plain seeded shuffle
+        $stripped = $this->getPuzzlePickerSuggestions->pick($this->criteria(['source' => 'any', 'lent' => '1', 'order' => 'gap_slower', 'seed' => $seed]), $playerId, 1000);
+        self::assertSame(self::ids($this->getPuzzlePickerSuggestions->pick($this->criteria(['source' => 'any', 'lent' => '1', 'seed' => $seed]), $playerId, 1000)), self::ids($stripped));
+    }
+
+    public function testTimeBudgetUsesMyPredictionForMembersAndTheCommunityAverageOtherwise(): void
+    {
+        $this->recalculator->recalculate();
+        $playerId = PlayerFixture::PLAYER_REGULAR;
+        $all = $this->pickAll(['source' => 'any', 'lent' => '1'], $playerId, member: true);
+        $predictions = $this->getPlayerPredictions->forPuzzles($playerId, self::ids($all));
+        $budgetMinutes = 32;
+
+        // Members with predictions: personal where solved, statistical where baseline x difficulty exist
+        $expectedPersonal = array_keys(array_filter(
+            $predictions,
+            static fn ($prediction): bool => $prediction->predictedSeconds <= $budgetMinutes * 60,
+        ));
+        self::assertNotSame([], $expectedPersonal);
+        self::assertGreaterThan(count($expectedPersonal), count($predictions), 'The budget must actually cut something');
+
+        $personal = $this->pickAll(['source' => 'any', 'lent' => '1', 'predicted_max' => (string) $budgetMinutes], $playerId, member: true);
+        self::assertEqualsCanonicalizing($expectedPersonal, self::ids($personal));
+
+        foreach ($personal->suggestions as $suggestion) {
+            self::assertSame($predictions[$suggestion->puzzleId]->predictedSeconds, $suggestion->predictedSeconds);
+            self::assertLessThanOrEqual($budgetMinutes * 60, $suggestion->predictedSeconds);
+        }
+
+        // Everybody else: community solo average
+        /** @var list<string> $expectedCommunity */
+        $expectedCommunity = $this->database->fetchFirstColumn(
+            'SELECT puzzle_id FROM puzzle_statistics WHERE average_time_solo <= :seconds',
+            ['seconds' => $budgetMinutes * 60],
+        );
+        $expectedCommunity = array_values(array_intersect($expectedCommunity, self::ids($all)));
+        self::assertNotSame([], $expectedCommunity);
+        self::assertNotEqualsCanonicalizing($expectedPersonal, $expectedCommunity, 'The two engines must give different answers for the test to mean anything');
+
+        $nonMember = $this->pickAll(['source' => 'any', 'lent' => '1', 'predicted_max' => (string) $budgetMinutes], $playerId);
+        self::assertEqualsCanonicalizing($expectedCommunity, self::ids($nonMember));
+
+        foreach ($nonMember->suggestions as $suggestion) {
+            self::assertNotNull($suggestion->communityAverageTimeSolo);
+            self::assertLessThanOrEqual($budgetMinutes * 60, $suggestion->communityAverageTimeSolo);
+            self::assertNull($suggestion->predictedSeconds, 'Community engine computes no prediction');
+        }
+
+        $optedOut = $this->pickAll(['source' => 'any', 'lent' => '1', 'predicted_max' => (string) $budgetMinutes], $playerId, member: true, predictions: false);
+        self::assertEqualsCanonicalizing($expectedCommunity, self::ids($optedOut));
+
+        $guest = $this->pickAll(['predicted_max' => (string) $budgetMinutes], null);
+        self::assertEqualsCanonicalizing(
+            $this->database->fetchFirstColumn('SELECT ps.puzzle_id FROM puzzle_statistics ps JOIN puzzle p ON p.id = ps.puzzle_id WHERE p.approved = true AND ps.average_time_solo <= :seconds', ['seconds' => $budgetMinutes * 60]),
+            self::ids($guest),
+        );
+    }
+
+    public function testInsightsFiltersAreIgnoredForGuests(): void
+    {
+        $this->recalculator->recalculate();
+        $guest = $this->pickAll(['gap' => 'slower', 'order' => 'gap_slower', 'difficulty' => ['3']], null, isAuthenticated: false);
+        $approvedCount = $this->database->fetchOne(
+            'SELECT count(*) FROM puzzle WHERE approved = true AND (hide_until IS NULL OR hide_until < now())',
+        );
+
+        self::assertSame($approvedCount, $guest->totalMatching);
+
+        foreach ($guest->suggestions as $suggestion) {
+            self::assertNull($suggestion->predictedSeconds);
+            self::assertNull($suggestion->gapSeconds);
+        }
+    }
+
     /**
      * @param array<string, mixed> $query
      */
-    private function criteria(array $query, bool $isAuthenticated = true): PuzzlePickerCriteria
+    private function criteria(array $query, bool $isAuthenticated = true, bool $member = false, bool $predictions = true): PuzzlePickerCriteria
     {
-        $criteria = PuzzlePickerCriteria::fromRequest(new Request($query), $isAuthenticated);
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request($query), $isAuthenticated, insightsAllowed: $member, predictionsAllowed: $member && $predictions);
 
         return $criteria->seed === null ? $criteria->withSeed('abcd1234') : $criteria;
+    }
+
+    /**
+     * A member who has not opted out of predictions.
+     *
+     * @param array<string, mixed> $query
+     */
+    private function memberCriteria(array $query): PuzzlePickerCriteria
+    {
+        return $this->criteria($query, member: true);
     }
 
     /**
@@ -433,9 +732,9 @@ final class GetPuzzlePickerSuggestionsTest extends KernelTestCase
      *
      * @param array<string, mixed> $query
      */
-    private function pickAll(array $query, null|string $playerId, null|bool $isAuthenticated = null): PuzzlePickerPick
+    private function pickAll(array $query, null|string $playerId, null|bool $isAuthenticated = null, bool $member = false, bool $predictions = true): PuzzlePickerPick
     {
-        return $this->getPuzzlePickerSuggestions->pick($this->criteria($query, $isAuthenticated ?? $playerId !== null), $playerId, 1000);
+        return $this->getPuzzlePickerSuggestions->pick($this->criteria($query, $isAuthenticated ?? $playerId !== null, $member, $predictions), $playerId, 1000);
     }
 
     /**

--- a/tests/Services/PuzzleIntelligence/TimePredictionCalculatorTest.php
+++ b/tests/Services/PuzzleIntelligence/TimePredictionCalculatorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Services\PuzzleIntelligence;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SpeedPuzzling\Web\Services\PuzzleIntelligence\TimePredictionCalculator;
+
+/**
+ * Pure math of the time predictions - the DB-backed parity is pinned by
+ * GetPlayerPredictionsTest, this pins the formulas themselves.
+ */
+final class TimePredictionCalculatorTest extends TestCase
+{
+    private TimePredictionCalculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new TimePredictionCalculator();
+    }
+
+    #[DataProvider('provideGapDays')]
+    public function testClassifyGap(int $days, string $bucket): void
+    {
+        self::assertSame($bucket, TimePredictionCalculator::classifyGap($days));
+    }
+
+    /**
+     * @return iterable<string, array{int, string}>
+     */
+    public static function provideGapDays(): iterable
+    {
+        yield 'today' => [0, 'lt30d'];
+        yield '29 days' => [29, 'lt30d'];
+        yield '30 days' => [30, '1_3m'];
+        yield '89 days' => [89, '1_3m'];
+        yield '90 days' => [90, '3_12m'];
+        yield '364 days' => [364, '3_12m'];
+        yield 'a year' => [365, 'gt12m'];
+        yield 'years' => [900, 'gt12m'];
+    }
+
+    public function testGapDaysAndTransition(): void
+    {
+        $now = new DateTimeImmutable('2026-08-19 10:00:00');
+
+        self::assertSame(0, TimePredictionCalculator::gapDays($now, new DateTimeImmutable('2026-08-19 08:00:00')));
+        self::assertSame(10, TimePredictionCalculator::gapDays($now, new DateTimeImmutable('2026-08-09 09:00:00')));
+        self::assertSame(45, TimePredictionCalculator::gapDays($now, new DateTimeImmutable('2026-07-05 10:00:00')));
+
+        self::assertSame(1, TimePredictionCalculator::transitionFor(1));
+        self::assertSame(3, TimePredictionCalculator::transitionFor(3));
+        self::assertSame(4, TimePredictionCalculator::transitionFor(4));
+        self::assertSame(4, TimePredictionCalculator::transitionFor(12), 'Transitions are capped');
+    }
+
+    public function testResolveRatio(): void
+    {
+        // Player ratio corrected by the global gap effect
+        self::assertEqualsWithDelta(0.95 * (1.10 / 1.00), TimePredictionCalculator::resolveRatio(0.95, 1.10, 1.00), 0.000001);
+        // Player ratio alone when the global values are incomplete or degenerate
+        self::assertSame(0.95, TimePredictionCalculator::resolveRatio(0.95, null, 1.00));
+        self::assertSame(0.95, TimePredictionCalculator::resolveRatio(0.95, 1.10, null));
+        self::assertSame(0.95, TimePredictionCalculator::resolveRatio(0.95, 1.10, 0.0));
+        // No player ratio: the global ratio for the gap bucket, else the default
+        self::assertSame(1.10, TimePredictionCalculator::resolveRatio(null, 1.10, 1.00));
+        self::assertSame(1.10, TimePredictionCalculator::resolveRatio(null, 1.10, null));
+        self::assertSame(TimePredictionCalculator::DEFAULT_IMPROVEMENT_RATIO, TimePredictionCalculator::resolveRatio(null, null, 1.00));
+    }
+
+    public function testSingleAttemptIsAPureRatioPredictionWithAWideRange(): void
+    {
+        $result = $this->calculator->personal([2000], 0.9);
+
+        self::assertTrue($result->isPersonalized);
+        self::assertSame(1800, $result->predictedSeconds);
+        self::assertSame(1, $result->personalSolveCount);
+        self::assertSame(2, $result->predictedAttemptNumber);
+        self::assertSame(2000, $result->lastTimeSeconds);
+        self::assertSame(0.0, $result->difficultyForPlayer);
+        // Spread = max(15 %, 2 min) = 270 s
+        self::assertSame(1530, $result->rangeLowSeconds);
+        self::assertSame(2070, $result->rangeHighSeconds);
+
+        // Short times: the 2-minute minimum spread and the 70 % floor on the low end
+        $short = $this->calculator->personal([300], 0.9);
+        self::assertSame(270, $short->predictedSeconds);
+        self::assertSame(210, $short->rangeLowSeconds, 'Never below 70 % of the best time');
+        self::assertSame(390, $short->rangeHighSeconds);
+    }
+
+    public function testImprovingPlayerIsBlendedWithHoltsTrendAndFlooredAtSeventyPercentOfTheBest(): void
+    {
+        // 2200 -> 1900 -> 1700 with the default ratio: ratio part 1530, Holt part 1548, weight 0.4
+        $result = $this->calculator->personal([2200, 1900, 1700], 0.9);
+
+        self::assertSame(1537, $result->predictedSeconds);
+        self::assertSame(3, $result->personalSolveCount);
+        self::assertSame(4, $result->predictedAttemptNumber);
+        self::assertSame(1700, $result->lastTimeSeconds);
+        self::assertGreaterThanOrEqual($result->rangeLowSeconds, $result->predictedSeconds);
+        self::assertLessThanOrEqual($result->rangeHighSeconds, $result->predictedSeconds);
+        self::assertGreaterThanOrEqual(1190, $result->rangeLowSeconds);
+
+        // A ridiculous ratio cannot push the prediction under 70 % of the personal best
+        $floored = $this->calculator->personal([1000, 1000], 0.1);
+        self::assertSame(700, $floored->predictedSeconds);
+        self::assertSame(700, $floored->rangeLowSeconds);
+
+        // Six or more attempts: pure Holt's damped trend, no ratio involved
+        $times = [3000, 2900, 2800, 2750, 2700, 2650];
+        self::assertEquals($this->calculator->personal($times, 0.5), $this->calculator->personal($times, 1.5));
+    }
+
+    public function testStatisticalPredictionUsesBaselineTimesDifficultyWithTheIqrRange(): void
+    {
+        $result = $this->calculator->statistical(2000, 1.1, 0.95, 1.30);
+
+        self::assertFalse($result->isPersonalized);
+        self::assertSame(2200, $result->predictedSeconds);
+        self::assertSame(1900, $result->rangeLowSeconds);
+        self::assertSame(2600, $result->rangeHighSeconds);
+        self::assertSame(1.1, $result->difficultyForPlayer);
+        self::assertNull($result->personalSolveCount);
+        self::assertNull($result->lastTimeSeconds);
+
+        // Missing indices fall back to ±15 % of the difficulty
+        $fallback = $this->calculator->statistical(2000, 1.0, null, null);
+        self::assertSame(2000, $fallback->predictedSeconds);
+        self::assertSame(1700, $fallback->rangeLowSeconds);
+        self::assertSame(2300, $fallback->rangeHighSeconds);
+
+        // Safety bounds: 30 %..300 % of the prediction
+        $wild = $this->calculator->statistical(1000, 1.0, 0.01, 9.0);
+        self::assertSame(300, $wild->rangeLowSeconds);
+        self::assertSame(3000, $wild->rangeHighSeconds);
+    }
+}

--- a/tests/Value/PuzzlePickerCriteriaTest.php
+++ b/tests/Value/PuzzlePickerCriteriaTest.php
@@ -7,6 +7,8 @@ namespace SpeedPuzzling\Web\Tests\Value;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SpeedPuzzling\Web\Value\PuzzlePickerCriteria;
+use SpeedPuzzling\Web\Value\PuzzlePickerGap;
+use SpeedPuzzling\Web\Value\PuzzlePickerOrder;
 use SpeedPuzzling\Web\Value\PuzzlePickerSolved;
 use SpeedPuzzling\Web\Value\PuzzlePickerSource;
 use Symfony\Component\HttpFoundation\Request;
@@ -351,5 +353,216 @@ final class PuzzlePickerCriteriaTest extends TestCase
 
             self::assertSame([(string) $chip], $criteria->piecesValues(), "Chip {$chip} must round-trip through the grammar");
         }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Insights layer: difficulty tiers, gap, order, time budget - and who may use what
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function insightsQuery(): array
+    {
+        return [
+            'difficulty' => ['3', '1', '3', '9', 'x', ''],
+            'gap' => 'slower',
+            'gap_min' => '5',
+            'predicted_max' => '60',
+            'order' => 'gap_slower',
+        ];
+    }
+
+    public function testMemberWithPredictionsGetsEveryInsightsFilter(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request(self::insightsQuery()), isAuthenticated: true, insightsAllowed: true, predictionsAllowed: true);
+
+        self::assertSame([1, 3], $criteria->difficultyTiers, 'Deduplicated, sorted, invalid tiers dropped');
+        self::assertSame(PuzzlePickerGap::Slower, $criteria->gap);
+        self::assertSame(5, $criteria->gapMinMinutes);
+        self::assertSame(300, $criteria->gapMinSeconds());
+        self::assertSame(60, $criteria->predictedMaxMinutes);
+        self::assertSame(PuzzlePickerOrder::GapSlower, $criteria->order);
+        self::assertTrue($criteria->insightsAllowed);
+        self::assertTrue($criteria->predictionsAllowed);
+        self::assertTrue($criteria->usesPersonalPrediction());
+        self::assertTrue($criteria->needsPredictions());
+        self::assertTrue($criteria->hasPersonalFilters());
+        self::assertFalse($criteria->isDefault());
+
+        self::assertSame(
+            ['difficulty' => ['1', '3'], 'gap' => 'slower', 'gap_min' => '5', 'predicted_max' => '60', 'order' => 'gap_slower'],
+            $criteria->toQueryParams(),
+        );
+        self::assertEquals($criteria, PuzzlePickerCriteria::fromRequest(new Request($criteria->toQueryParams()), true, true, true), 'Round trip');
+    }
+
+    public function testNonMemberKeepsOnlyTheCommunityTimeBudget(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request(['source' => 'any'] + self::insightsQuery()), isAuthenticated: true);
+
+        self::assertSame([], $criteria->difficultyTiers);
+        self::assertNull($criteria->gap);
+        self::assertNull($criteria->gapMinMinutes);
+        self::assertSame(PuzzlePickerOrder::Random, $criteria->order);
+        self::assertSame(60, $criteria->predictedMaxMinutes, 'The time budget is free - it just runs on the community engine');
+        self::assertFalse($criteria->insightsAllowed);
+        self::assertFalse($criteria->predictionsAllowed);
+        self::assertFalse($criteria->usesPersonalPrediction());
+        self::assertFalse($criteria->needsPredictions());
+        self::assertFalse($criteria->hasPersonalFilters());
+        self::assertSame(['source' => 'any', 'predicted_max' => '60'], $criteria->toQueryParams());
+        self::assertSame(['predicted_max'], array_map(static fn ($filter) => $filter->key, $criteria->activeFilters()));
+
+        // predictionsAllowed without insightsAllowed is not a thing
+        $inconsistent = PuzzlePickerCriteria::fromRequest(new Request(self::insightsQuery()), isAuthenticated: true, insightsAllowed: false, predictionsAllowed: true);
+        self::assertFalse($inconsistent->predictionsAllowed);
+        self::assertNull($inconsistent->gap);
+    }
+
+    public function testMemberWhoOptedOutOfPredictionsKeepsDifficultyButNoPredictionFilters(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request(self::insightsQuery()), isAuthenticated: true, insightsAllowed: true, predictionsAllowed: false);
+
+        self::assertSame([1, 3], $criteria->difficultyTiers);
+        self::assertNull($criteria->gap);
+        self::assertNull($criteria->gapMinMinutes);
+        self::assertSame(PuzzlePickerOrder::Random, $criteria->order);
+        self::assertSame(60, $criteria->predictedMaxMinutes);
+        self::assertTrue($criteria->insightsAllowed);
+        self::assertFalse($criteria->predictionsAllowed);
+        self::assertFalse($criteria->usesPersonalPrediction(), 'Community engine for the budget');
+        self::assertFalse($criteria->needsPredictions());
+        self::assertSame(['difficulty' => ['1', '3'], 'predicted_max' => '60'], $criteria->toQueryParams());
+    }
+
+    public function testGuestKeepsOnlyTheCommunityTimeBudgetWhateverTheFlagsSay(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request(self::insightsQuery()), isAuthenticated: false, insightsAllowed: true, predictionsAllowed: true);
+
+        self::assertSame([], $criteria->difficultyTiers);
+        self::assertNull($criteria->gap);
+        self::assertSame(PuzzlePickerOrder::Random, $criteria->order);
+        self::assertSame(60, $criteria->predictedMaxMinutes);
+        self::assertFalse($criteria->insightsAllowed);
+        self::assertFalse($criteria->predictionsAllowed);
+        self::assertSame(['predicted_max' => '60'], $criteria->toQueryParams());
+    }
+
+    public function testNeedsPredictionsOnlyForGapOrderOrPersonalBudget(): void
+    {
+        $member = static fn (array $query): PuzzlePickerCriteria => PuzzlePickerCriteria::fromRequest(new Request($query), true, true, true);
+
+        self::assertFalse($member([])->needsPredictions());
+        self::assertFalse($member(['difficulty' => ['3']])->needsPredictions(), 'Difficulty needs no prediction');
+        self::assertTrue($member(['gap' => 'faster'])->needsPredictions());
+        self::assertTrue($member(['order' => 'gap_faster'])->needsPredictions());
+        self::assertTrue($member(['predicted_max' => '45'])->needsPredictions());
+        self::assertTrue($member([])->isDefault());
+        self::assertFalse($member(['order' => 'gap_faster'])->isDefault());
+        self::assertFalse($member(['predicted_max' => '45'])->isDefault());
+        self::assertFalse($member(['difficulty' => ['3']])->isDefault());
+        self::assertTrue($member(['order' => 'random'])->isDefault(), 'Random is the default order');
+        self::assertSame([], $member(['order' => 'random'])->toQueryParams());
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     */
+    #[DataProvider('provideInvalidInsightsInput')]
+    public function testInvalidInsightsInputIsDropped(array $query): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request($query), isAuthenticated: true, insightsAllowed: true, predictionsAllowed: true);
+
+        self::assertSame([], $criteria->difficultyTiers);
+        self::assertNull($criteria->gap);
+        self::assertNull($criteria->gapMinMinutes);
+        self::assertNull($criteria->predictedMaxMinutes);
+        self::assertSame(PuzzlePickerOrder::Random, $criteria->order);
+        self::assertTrue($criteria->isDefault());
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function provideInvalidInsightsInput(): iterable
+    {
+        yield 'unknown enum values' => [['gap' => 'same', 'order' => 'newest']];
+        yield 'nested structures' => [['gap' => ['slower'], 'order' => ['gap_slower'], 'difficulty' => [['3']], 'gap_min' => ['5'], 'predicted_max' => ['60']]];
+        yield 'tiers out of range' => [['difficulty' => ['0', '7', '-1', '3.5', 'hard']]];
+        yield 'gap_min without gap' => [['gap_min' => '5']];
+        yield 'gap_min zero' => [['gap_min' => '0']];
+        yield 'gap_min too big' => [['gap_min' => '601']];
+        yield 'predicted_max out of range' => [['predicted_max' => '4']];
+        yield 'predicted_max too big' => [['predicted_max' => '1441']];
+        yield 'predicted_max not a number' => [['predicted_max' => 'hour']];
+        yield 'blank inputs from the form' => [['gap' => '', 'gap_min' => '', 'predicted_max' => '', 'order' => '']];
+    }
+
+    public function testGapMinIsOptionalAndDefaultsToOneMinute(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request(['gap' => 'faster']), true, true, true);
+
+        self::assertSame(PuzzlePickerGap::Faster, $criteria->gap);
+        self::assertNull($criteria->gapMinMinutes);
+        self::assertSame(60, $criteria->gapMinSeconds());
+        self::assertSame(['gap' => 'faster'], $criteria->toQueryParams());
+
+        // Out-of-range gap_min is dropped, the gap itself survives
+        $criteria = PuzzlePickerCriteria::fromRequest(new Request(['gap' => 'faster', 'gap_min' => '999']), true, true, true);
+        self::assertSame(PuzzlePickerGap::Faster, $criteria->gap);
+        self::assertNull($criteria->gapMinMinutes);
+    }
+
+    public function testInsightsChipsRemoveThemselves(): void
+    {
+        $criteria = PuzzlePickerCriteria::fromRequest(
+            new Request(['source' => 'any', 'difficulty' => ['2', '4'], 'gap' => 'slower', 'gap_min' => '3', 'predicted_max' => '90', 'order' => 'gap_slower', 'seed' => 'abcd1234']),
+            isAuthenticated: true,
+            insightsAllowed: true,
+            predictionsAllowed: true,
+        );
+
+        $byKey = [];
+
+        foreach ($criteria->activeFilters() as $filter) {
+            $byKey[$filter->key] = $filter;
+        }
+
+        self::assertSame(['predicted_max', 'difficulty:2', 'difficulty:4', 'gap', 'order'], array_keys($byKey));
+
+        self::assertSame('puzzle_picker.chips.predicted_max', $byKey['predicted_max']->translationKey);
+        self::assertSame(['%minutes%' => 90], $byKey['predicted_max']->translationParameters);
+        self::assertSame(
+            ['source' => 'any', 'difficulty' => ['2', '4'], 'gap' => 'slower', 'gap_min' => '3', 'order' => 'gap_slower', 'seed' => 'abcd1234'],
+            $byKey['predicted_max']->queryParametersWithoutThis,
+        );
+
+        self::assertSame('difficulty', $byKey['difficulty:2']->type);
+        self::assertSame('puzzle_intelligence.difficulty.tiers.easy', $byKey['difficulty:2']->translationKey);
+        self::assertSame('2', $byKey['difficulty:2']->value);
+        self::assertSame(['4'], $byKey['difficulty:2']->queryParametersWithoutThis['difficulty']);
+        self::assertSame('puzzle_intelligence.difficulty.tiers.challenging', $byKey['difficulty:4']->translationKey);
+        $onlyFour = PuzzlePickerCriteria::fromRequest(new Request($byKey['difficulty:2']->queryParametersWithoutThis), true, true, true);
+        self::assertSame([4], $onlyFour->difficultyTiers);
+        self::assertArrayNotHasKey('difficulty', $onlyFour->activeFilters()[1]->queryParametersWithoutThis, 'Removing the last tier drops the parameter');
+
+        self::assertSame('puzzle_picker.chips.gap.slower_by', $byKey['gap']->translationKey);
+        self::assertSame(['%minutes%' => 3], $byKey['gap']->translationParameters);
+        self::assertSame(
+            ['source' => 'any', 'difficulty' => ['2', '4'], 'predicted_max' => '90', 'order' => 'gap_slower', 'seed' => 'abcd1234'],
+            $byKey['gap']->queryParametersWithoutThis,
+            'Removing the gap chip drops gap_min with it',
+        );
+
+        self::assertSame('puzzle_picker.chips.order.gap_slower', $byKey['order']->translationKey);
+        self::assertSame(
+            ['source' => 'any', 'difficulty' => ['2', '4'], 'gap' => 'slower', 'gap_min' => '3', 'predicted_max' => '90', 'seed' => 'abcd1234'],
+            $byKey['order']->queryParametersWithoutThis,
+        );
+
+        // Gap chip without a minimum
+        $plain = PuzzlePickerCriteria::fromRequest(new Request(['gap' => 'faster']), true, true, true)->activeFilters();
+        self::assertSame('puzzle_picker.chips.gap.faster', $plain[1]->translationKey);
     }
 }

--- a/translations/messages.cs.yml
+++ b/translations/messages.cs.yml
@@ -3152,6 +3152,27 @@ puzzle_picker:
         brand:
             label: "Značka"
             placeholder: "Jakákoli značka"
+        budget:
+            label: "Kolik mám času"
+            i_have: "Mám zhruba"
+            minutes: "minut"
+            engine_personal: "Podle vašeho předpokládaného času na každé puzzle."
+            engine_community: "Podle průměrného sólo času komunity."
+        insights:
+            label: "Statistiky (pro členy)"
+            difficulty_note: "Obtížnost mají jen puzzle s dostatkem dat – tento filtr výběr hodně zúží."
+            gap:
+                label: "V porovnání s mojí predikcí"
+                any: "Bez omezení"
+                slower: "Jsem pomalejší, než se čekalo"
+                faster: "Jsem rychlejší, než se čekalo"
+                by_at_least: "alespoň o"
+                note: "Porovnává váš nejrychlejší sólo čas s predikcí – jen puzzle, která už máte poskládaná."
+            order:
+                label: "Pořadí výběru"
+                random: "Náhodně"
+                gap_slower: "Největší rozdíl první – jsem pomalejší"
+                gap_faster: "Největší rozdíl první – jsem rychlejší"
     chips:
         source:
             mine: "Moje kolekce"
@@ -3167,6 +3188,18 @@ puzzle_picker:
         brand: "Značka"
         include_lent_out: "Vč. půjčených"
         remove: "Odebrat tento filtr"
+        predicted_max: "Do %minutes% min"
+        gap:
+            slower: "Pomalejší než predikce"
+            slower_by: "Pomalejší než predikce o %minutes%+ min"
+            faster: "Rychlejší než predikce"
+            faster_by: "Rychlejší než predikce o %minutes%+ min"
+        order:
+            gap_slower: "Pořadí: největší rozdíl (jsem pomalejší)"
+            gap_faster: "Pořadí: největší rozdíl (jsem rychlejší)"
+    presets:
+        label: "Předvolby:"
+        beat_my_record: "Překonat svůj rekord"
     results:
         matching: "%shown% z %total% odpovídajících puzzlí"
         pick_another: "Vybrat jiné"
@@ -3184,6 +3217,12 @@ puzzle_picker:
         sign_in_for_times: "Po přihlášení tu uvidíte své vlastní časy."
         sign_in_to_solve: "Přihlásit se a skládat"
         detail: "Detail puzzle"
+        prediction: "Vaše predikce:"
+        prediction_locked: "Predikce vašeho času – jen pro členy"
+        prediction_unavailable: "Predikce zatím není – pro tento počet dílků je málo dat."
+        prediction_beats_record: "můžete překonat svůj rekord o %delta%"
+        prediction_slower_than_best: "o %delta% pomaleji než váš nejlepší čas"
+        prediction_at_best: "přesně na úrovni vašeho nejlepšího času"
     empty:
         collection_title: "Vaše kolekce je prázdná"
         collection_text: "Přidejte puzzle, které máte doma, a příště z nich výběr vybere."
@@ -3221,7 +3260,7 @@ puzzle_picker:
             lent: "Puzzle, která jste někomu půjčili, se vynechají; vypůjčená se počítají"
             times: "Váš nejrychlejší, poslední a první čas na každé kartě"
         members_title: "Pro členy"
-        members_text: "Členové mají navíc přehledy – obtížnost puzzlí, předpověď času skládání a úrovně dovednosti – na stránkách puzzlí a brzy i přímo na kartě výběru."
+        members_text: "Členové mají statistiky přímo na kartě i ve filtrech: predikci vašeho času u každého puzzle, stupeň obtížnosti, filtry jako „jsem pomalejší, než se čekalo“ a předvolbu „Překonat svůj rekord“ – a k tomu obtížnost a predikce na stránkách puzzlí."
         members_cta: "O členství"
         bottom_title: "Přestaňte přebírat poličku – ať rozhodne kolo"
         bottom_text: "Vytvořte si účet zdarma, přidejte puzzle, které máte doma, a nechte výběr rozhodnout za vás."

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -3154,6 +3154,27 @@ puzzle_picker:
         brand:
             label: "Marke"
             placeholder: "Beliebige Marke"
+        budget:
+            label: "Zeitbudget"
+            i_have: "Ich habe etwa"
+            minutes: "Minuten"
+            engine_personal: "Basierend auf Ihrer eigenen vorhergesagten Zeit für jedes Puzzle."
+            engine_community: "Basierend auf der durchschnittlichen Solo-Zeit der Community."
+        insights:
+            label: "Einblicke (Mitglieder)"
+            difficulty_note: "Nur Puzzles mit genügend Daten haben eine Schwierigkeitsstufe – dieser Filter verkleinert die Auswahl stark."
+            gap:
+                label: "Im Vergleich zu meiner Vorhersage"
+                any: "Egal"
+                slower: "Ich bin langsamer als vorhergesagt"
+                faster: "Ich bin schneller als vorhergesagt"
+                by_at_least: "um mindestens"
+                note: "Vergleicht Ihre schnellste Solo-Zeit mit Ihrer vorhergesagten Zeit – nur Puzzles, die Sie schon gelegt haben."
+            order:
+                label: "Reihenfolge"
+                random: "Zufällig"
+                gap_slower: "Größter Abstand zuerst – ich bin langsamer"
+                gap_faster: "Größter Abstand zuerst – ich bin schneller"
     chips:
         source:
             mine: "Meine Sammlung"
@@ -3169,6 +3190,18 @@ puzzle_picker:
         brand: "Marke"
         include_lent_out: "Inkl. verliehen"
         remove: "Diesen Filter entfernen"
+        predicted_max: "Bis %minutes% Min."
+        gap:
+            slower: "Langsamer als vorhergesagt"
+            slower_by: "Langsamer als vorhergesagt um %minutes%+ Min."
+            faster: "Schneller als vorhergesagt"
+            faster_by: "Schneller als vorhergesagt um %minutes%+ Min."
+        order:
+            gap_slower: "Reihenfolge: größter Abstand (ich bin langsamer)"
+            gap_faster: "Reihenfolge: größter Abstand (ich bin schneller)"
+    presets:
+        label: "Vorlagen:"
+        beat_my_record: "Meinen Rekord schlagen"
     results:
         matching: "%shown% von %total% passenden Puzzles"
         pick_another: "Ein anderes"
@@ -3186,6 +3219,12 @@ puzzle_picker:
         sign_in_for_times: "Nach der Anmeldung sehen Sie hier Ihre eigenen Zeiten."
         sign_in_to_solve: "Anmelden und lospuzzeln"
         detail: "Puzzle-Details"
+        prediction: "Ihre Vorhersage:"
+        prediction_locked: "Ihre Zeitvorhersage – nur für Mitglieder"
+        prediction_unavailable: "Noch keine Zeitvorhersage – zu wenig Daten für diese Teilezahl."
+        prediction_beats_record: "könnte Ihren Rekord um %delta% schlagen"
+        prediction_slower_than_best: "%delta% langsamer als Ihre Bestzeit"
+        prediction_at_best: "genau auf Ihrer Bestzeit"
     empty:
         collection_title: "Ihre Sammlung ist leer"
         collection_text: "Fügen Sie die Puzzles hinzu, die Sie besitzen – beim nächsten Mal wählt die Auswahl daraus."
@@ -3223,7 +3262,7 @@ puzzle_picker:
             lent: "Verliehene Puzzles bleiben außen vor, geliehene zählen mit"
             times: "Ihre schnellste, letzte und erste Zeit auf jeder Karte"
         members_title: "Für Mitglieder"
-        members_text: "Mitglieder schalten die Insights frei – Puzzle-Schwierigkeit, vorhergesagte Legezeiten und Könnensstufen – auf den Puzzleseiten und bald direkt auf der Auswahlkarte."
+        members_text: "Mitglieder erhalten die Einblicke direkt auf der Karte und in den Filtern: Ihre vorhergesagte Zeit für jedes Puzzle, die Schwierigkeitsstufe, Filter wie „ich bin langsamer als vorhergesagt“ und die Vorlage „Meinen Rekord schlagen“ – dazu Schwierigkeit und Vorhersagen auf den Puzzle-Seiten."
         members_cta: "Über die Mitgliedschaft"
         bottom_title: "Schluss mit Regal-Scannen – lassen Sie das Rad entscheiden"
         bottom_text: "Erstellen Sie ein kostenloses Konto, fügen Sie Ihre Puzzles hinzu und überlassen Sie der Auswahl die Wahl."

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -3441,6 +3441,27 @@ puzzle_picker:
         brand:
             label: "Brand"
             placeholder: "Any brand"
+        budget:
+            label: "Time budget"
+            i_have: "I have about"
+            minutes: "minutes"
+            engine_personal: "Based on your own predicted time for each puzzle."
+            engine_community: "Based on the community average solo time."
+        insights:
+            label: "Insights (members)"
+            difficulty_note: "Only puzzles with enough data have a difficulty tier – this filter shrinks the pool a lot."
+            gap:
+                label: "Compared to my prediction"
+                any: "Any"
+                slower: "I'm slower than predicted"
+                faster: "I'm faster than predicted"
+                by_at_least: "by at least"
+                note: "Compares your fastest solo time with your predicted time – only puzzles you have solved before."
+            order:
+                label: "Pick order"
+                random: "Random"
+                gap_slower: "Largest gap first – I'm slower"
+                gap_faster: "Largest gap first – I'm faster"
     chips:
         source:
             mine: "My collection"
@@ -3456,6 +3477,18 @@ puzzle_picker:
         brand: "Brand"
         include_lent_out: "Incl. lent out"
         remove: "Remove this filter"
+        predicted_max: "Up to %minutes% min"
+        gap:
+            slower: "Slower than predicted"
+            slower_by: "Slower than predicted by %minutes%+ min"
+            faster: "Faster than predicted"
+            faster_by: "Faster than predicted by %minutes%+ min"
+        order:
+            gap_slower: "Order: largest gap (I'm slower)"
+            gap_faster: "Order: largest gap (I'm faster)"
+    presets:
+        label: "Presets:"
+        beat_my_record: "Beat my record"
     results:
         matching: "%shown% of %total% matching puzzles"
         pick_another: "Pick another"
@@ -3473,6 +3506,12 @@ puzzle_picker:
         sign_in_for_times: "Sign in and your own times will show up here."
         sign_in_to_solve: "Sign in to start solving"
         detail: "Puzzle detail"
+        prediction: "Your prediction:"
+        prediction_locked: "Your time prediction – members only"
+        prediction_unavailable: "No time prediction yet – not enough data for this piece count."
+        prediction_beats_record: "could beat your record by %delta%"
+        prediction_slower_than_best: "%delta% slower than your best"
+        prediction_at_best: "right at your best"
     empty:
         collection_title: "Your collection is empty"
         collection_text: "Add the puzzles you own and the picker will choose from them next time."
@@ -3510,7 +3549,7 @@ puzzle_picker:
             lent: "Puzzles you have lent out are left out; borrowed ones are included"
             times: "Your fastest, latest and first time on every card"
         members_title: "For members"
-        members_text: "Members unlock the Insights family – puzzle difficulty, predicted solving times and skill tiers – on puzzle pages, and soon right on the picker card."
+        members_text: "Members unlock the Insights family right on the card and in the filters: your predicted time for every puzzle, the difficulty tier, filters like “I'm slower than predicted” and the “Beat my record” preset – plus difficulty and predictions on puzzle pages."
         members_cta: "About membership"
         bottom_title: "Stop scanning your shelf – let the wheel decide"
         bottom_text: "Create a free account, add the puzzles you own and let the picker do the choosing."

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -3154,6 +3154,27 @@ puzzle_picker:
         brand:
             label: "Marca"
             placeholder: "Cualquier marca"
+        budget:
+            label: "Tiempo disponible"
+            i_have: "Tengo unos"
+            minutes: "minutos"
+            engine_personal: "Según tu propio tiempo previsto para cada puzzle."
+            engine_community: "Según el tiempo medio en solitario de la comunidad."
+        insights:
+            label: "Información (miembros)"
+            difficulty_note: "Solo los puzzles con datos suficientes tienen nivel de dificultad – este filtro reduce mucho la selección."
+            gap:
+                label: "Comparado con mi predicción"
+                any: "Cualquiera"
+                slower: "Soy más lento de lo previsto"
+                faster: "Soy más rápido de lo previsto"
+                by_at_least: "al menos"
+                note: "Compara tu mejor tiempo en solitario con tu tiempo previsto – solo puzzles que ya has armado."
+            order:
+                label: "Orden de selección"
+                random: "Aleatorio"
+                gap_slower: "Mayor diferencia primero – soy más lento"
+                gap_faster: "Mayor diferencia primero – soy más rápido"
     chips:
         source:
             mine: "Mi colección"
@@ -3169,6 +3190,18 @@ puzzle_picker:
         brand: "Marca"
         include_lent_out: "Incl. prestados"
         remove: "Quitar este filtro"
+        predicted_max: "Hasta %minutes% min"
+        gap:
+            slower: "Más lento de lo previsto"
+            slower_by: "Más lento de lo previsto en %minutes%+ min"
+            faster: "Más rápido de lo previsto"
+            faster_by: "Más rápido de lo previsto en %minutes%+ min"
+        order:
+            gap_slower: "Orden: mayor diferencia (soy más lento)"
+            gap_faster: "Orden: mayor diferencia (soy más rápido)"
+    presets:
+        label: "Atajos:"
+        beat_my_record: "Batir mi récord"
     results:
         matching: "%shown% de %total% puzzles que coinciden"
         pick_another: "Elegir otro"
@@ -3186,6 +3219,12 @@ puzzle_picker:
         sign_in_for_times: "Inicia sesión y aquí verás tus propios tiempos."
         sign_in_to_solve: "Inicia sesión para empezar a armar"
         detail: "Detalle del puzzle"
+        prediction: "Tu predicción:"
+        prediction_locked: "Tu predicción de tiempo – solo para miembros"
+        prediction_unavailable: "Aún no hay predicción – faltan datos para este número de piezas."
+        prediction_beats_record: "podrías batir tu récord por %delta%"
+        prediction_slower_than_best: "%delta% más lento que tu mejor tiempo"
+        prediction_at_best: "justo en tu mejor tiempo"
     empty:
         collection_title: "Tu colección está vacía"
         collection_text: "Añade los puzzles que tienes y la próxima vez el selector elegirá entre ellos."
@@ -3223,7 +3262,7 @@ puzzle_picker:
             lent: "Los puzzles que has prestado se excluyen; los que te han prestado se incluyen"
             times: "Tu tiempo más rápido, el último y el primero en cada tarjeta"
         members_title: "Para miembros"
-        members_text: "Los miembros desbloquean los Insights – dificultad de los puzzles, tiempos previstos y niveles de habilidad – en las páginas de puzzles, y pronto también en la tarjeta del selector."
+        members_text: "Los miembros tienen la información directamente en la tarjeta y en los filtros: tu tiempo previsto para cada puzzle, el nivel de dificultad, filtros como «soy más lento de lo previsto» y el atajo «Batir mi récord» – además de la dificultad y las predicciones en las páginas de los puzzles."
         members_cta: "Sobre la membresía"
         bottom_title: "Deja de repasar la estantería – que decida la ruleta"
         bottom_text: "Crea una cuenta gratis, añade los puzzles que tienes y deja que el selector elija por ti."

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -3156,6 +3156,27 @@ puzzle_picker:
         brand:
             label: "Marque"
             placeholder: "Toutes les marques"
+        budget:
+            label: "Temps disponible"
+            i_have: "J'ai environ"
+            minutes: "minutes"
+            engine_personal: "D'après votre propre temps prédit pour chaque puzzle."
+            engine_community: "D'après le temps moyen en solo de la communauté."
+        insights:
+            label: "Statistiques (membres)"
+            difficulty_note: "Seuls les puzzles avec assez de données ont un niveau de difficulté – ce filtre réduit beaucoup la sélection."
+            gap:
+                label: "Par rapport à ma prédiction"
+                any: "Peu importe"
+                slower: "Je suis plus lent que prévu"
+                faster: "Je suis plus rapide que prévu"
+                by_at_least: "d'au moins"
+                note: "Compare votre meilleur temps en solo à votre temps prédit – uniquement les puzzles déjà faits."
+            order:
+                label: "Ordre de tirage"
+                random: "Aléatoire"
+                gap_slower: "Plus grand écart d'abord – je suis plus lent"
+                gap_faster: "Plus grand écart d'abord – je suis plus rapide"
     chips:
         source:
             mine: "Ma collection"
@@ -3171,6 +3192,18 @@ puzzle_picker:
         brand: "Marque"
         include_lent_out: "Prêtés inclus"
         remove: "Retirer ce filtre"
+        predicted_max: "Jusqu'à %minutes% min"
+        gap:
+            slower: "Plus lent que prévu"
+            slower_by: "Plus lent que prévu d'au moins %minutes% min"
+            faster: "Plus rapide que prévu"
+            faster_by: "Plus rapide que prévu d'au moins %minutes% min"
+        order:
+            gap_slower: "Ordre : plus grand écart (je suis plus lent)"
+            gap_faster: "Ordre : plus grand écart (je suis plus rapide)"
+    presets:
+        label: "Raccourcis :"
+        beat_my_record: "Battre mon record"
     results:
         matching: "%shown% sur %total% puzzles correspondants"
         pick_another: "En choisir un autre"
@@ -3188,6 +3221,12 @@ puzzle_picker:
         sign_in_for_times: "Connectez-vous et vos propres temps apparaîtront ici."
         sign_in_to_solve: "Se connecter pour commencer"
         detail: "Détail du puzzle"
+        prediction: "Votre prédiction :"
+        prediction_locked: "Votre prédiction de temps – réservée aux membres"
+        prediction_unavailable: "Pas encore de prédiction – pas assez de données pour ce nombre de pièces."
+        prediction_beats_record: "vous pourriez battre votre record de %delta%"
+        prediction_slower_than_best: "%delta% plus lent que votre meilleur temps"
+        prediction_at_best: "pile sur votre meilleur temps"
     empty:
         collection_title: "Votre collection est vide"
         collection_text: "Ajoutez les puzzles que vous possédez et le sélecteur choisira parmi eux la prochaine fois."
@@ -3225,7 +3264,7 @@ puzzle_picker:
             lent: "Les puzzles que vous avez prêtés sont exclus ; ceux qu'on vous a prêtés sont inclus"
             times: "Votre temps le plus rapide, le dernier et le premier sur chaque carte"
         members_title: "Pour les membres"
-        members_text: "Les membres débloquent les Insights – difficulté des puzzles, temps prévus et niveaux de compétence – sur les pages des puzzles, et bientôt directement sur la carte du sélecteur."
+        members_text: "Les membres retrouvent les statistiques directement sur la carte et dans les filtres : votre temps prédit pour chaque puzzle, le niveau de difficulté, des filtres comme « je suis plus lent que prévu » et le raccourci « Battre mon record » – en plus de la difficulté et des prédictions sur les pages des puzzles."
         members_cta: "À propos de l'adhésion"
         bottom_title: "Arrêtez de scruter l'étagère – laissez la roue décider"
         bottom_text: "Créez un compte gratuit, ajoutez les puzzles que vous possédez et laissez le sélecteur choisir pour vous."

--- a/translations/messages.ja.yml
+++ b/translations/messages.ja.yml
@@ -3143,6 +3143,27 @@ puzzle_picker:
         brand:
             label: "ブランド"
             placeholder: "すべてのブランド"
+        budget:
+            label: "使える時間"
+            i_have: "だいたい"
+            minutes: "分ある"
+            engine_personal: "各パズルのあなたの予測タイムに基づきます。"
+            engine_community: "コミュニティのソロ平均タイムに基づきます。"
+        insights:
+            label: "インサイト（メンバー）"
+            difficulty_note: "難易度があるのは十分なデータのあるパズルだけです – このフィルターで候補はかなり絞られます。"
+            gap:
+                label: "自分の予測との比較"
+                any: "指定なし"
+                slower: "予測より遅い"
+                faster: "予測より速い"
+                by_at_least: "少なくとも"
+                note: "あなたのソロ最速タイムと予測タイムを比較します – 完成済みのパズルのみ。"
+            order:
+                label: "選ぶ順番"
+                random: "ランダム"
+                gap_slower: "差が大きい順 – 自分が遅い"
+                gap_faster: "差が大きい順 – 自分が速い"
     chips:
         source:
             mine: "自分のコレクション"
@@ -3158,6 +3179,18 @@ puzzle_picker:
         brand: "ブランド"
         include_lent_out: "貸出中を含む"
         remove: "このフィルターを外す"
+        predicted_max: "%minutes%分以内"
+        gap:
+            slower: "予測より遅い"
+            slower_by: "予測より%minutes%分以上遅い"
+            faster: "予測より速い"
+            faster_by: "予測より%minutes%分以上速い"
+        order:
+            gap_slower: "順番：差が大きい順（自分が遅い）"
+            gap_faster: "順番：差が大きい順（自分が速い）"
+    presets:
+        label: "プリセット："
+        beat_my_record: "自己ベスト更新"
     results:
         matching: "該当パズル%total%件中%shown%件"
         pick_another: "別のパズルを選ぶ"
@@ -3175,6 +3208,12 @@ puzzle_picker:
         sign_in_for_times: "サインインすると、ここに自分のタイムが表示されます。"
         sign_in_to_solve: "サインインして始める"
         detail: "パズルの詳細"
+        prediction: "あなたの予測："
+        prediction_locked: "あなたのタイム予測 – メンバー限定"
+        prediction_unavailable: "まだ予測がありません – このピース数のデータが不足しています。"
+        prediction_beats_record: "自己ベストを%delta%更新できるかも"
+        prediction_slower_than_best: "自己ベストより%delta%遅い"
+        prediction_at_best: "ちょうど自己ベスト並み"
     empty:
         collection_title: "コレクションが空です"
         collection_text: "持っているパズルを追加すると、次回からその中から選びます。"
@@ -3212,7 +3251,7 @@ puzzle_picker:
             lent: "貸出中のパズルは除外、借りているパズルは含まれます"
             times: "各カードにあなたの最速・最新・初回タイムを表示"
         members_title: "メンバー向け"
-        members_text: "メンバーはインサイト – パズルの難易度、予測タイム、スキルティア – をパズルページで利用でき、まもなくピッカーのカードにも表示されます。"
+        members_text: "メンバーはカード上とフィルターでインサイトを直接使えます：各パズルのあなたの予測タイム、難易度、「予測より遅い」などのフィルター、「自己ベスト更新」プリセット – さらにパズルページでの難易度と予測も。"
         members_cta: "メンバーシップについて"
         bottom_title: "棚を眺めるのはもう終わり – ルーレットに決めてもらいましょう"
         bottom_text: "無料アカウントを作成し、持っているパズルを追加して、ピッカーに選んでもらいましょう。"


### PR DESCRIPTION
Supersedes #190 (auto-closed when the PR 1 branch was deleted). Rebased onto main after #189.

## What ships
- **Shared prediction math**: `TimePredictionCalculator` (pure PHP) now backs `GetPlayerPrediction::forPuzzle()` (behaviour unchanged, existing tests untouched) and the new **bulk `GetPlayerPredictions`** (`forPuzzles`, `forAllSolvedPuzzles`; ≤ 4 queries for a whole player, per-request memo) — the building block for predictions at list scale (picker, collections in PR 4). Parity test: bulk == single for every fixture player × puzzle.
- **Members-only filters** (stripped server-side for non-members / prediction-opted-out players): difficulty tier, "Compared to my prediction: I'm slower / faster (by ≥ N min)", pick order "largest gap first" (both directions), and "I have about N minutes" (personal prediction for eligible members, community average for everyone else — same control, better engine).
- **Query**: insights joins happen before the LIMIT only when an insights filter is active; personal predictions are injected via `unnest(:ids, :seconds)`, statistical = `round(baseline × difficulty)` inline; gap = my fastest − predicted (~27 ms on prod-like data for the heaviest player).
- **Card**: difficulty badge; prediction row with the exact numbers of the puzzle detail page (personalised or statistical + range + attempt explanation) and "could beat your record by N / N slower than your best"; ONE locked row for non-members (opens the members modal); opt-out notice for opted-out members; nothing for guests.
- Preset "Beat my record" (🔒 for non-members). Six locales. Tests: +6 query, +9 criteria, +5 controller, calculator unit tests, parity sweep.

## Checks
phpstan ✅ · cs ✅ · phpunit 1921 tests ✅ · schema:validate ✅ · cache:warmup ✅ · lint:twig/yaml ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGdSgARDzTuE99zDgd7jq5