### PR TITLE
API: GET /me exposes membership end and the three opt-out flags

### DIFF
--- a/docs/features/api/README.md
+++ b/docs/features/api/README.md
@@ -74,7 +74,7 @@ hand-typed `SOLVING_TIMES` variant silently matched nothing until 2026-08 (PR #1
 
 | Method | Endpoint | Required |
 |--------|----------|----------|
-| GET | `/api/v1/me` | PAT or `profile:read` (the `email` field is populated only for PAT or tokens granted `email:read`, otherwise `null`) |
+| GET | `/api/v1/me` | PAT or `profile:read` (the `email` field is populated only for PAT or tokens granted `email:read`, otherwise `null`). Also carries `has_active_membership`, `membership_ends_at` (ISO-8601, `null` without an active membership) and the owner's opt-out flags `time_predictions_opted_out`, `ranking_opted_out`, `streak_opted_out` |
 | GET | `/api/v1/me/results?type=solo\|duo\|team` | PAT or `results:read` |
 | GET | `/api/v1/me/puzzles/{puzzleId}/predicted-time` | PAT or `results:read` |
 | GET | `/api/v1/me/statistics` | PAT or `statistics:read` |
@@ -121,6 +121,8 @@ hand-typed `SOLVING_TIMES` variant silently matched nothing until 2026-08 (PR #1
 ### Members-Exclusive Data
 
 Puzzle difficulty and player skill tiers are included in responses only if the token owner has active membership. Non-members see `null` for these fields.
+
+An app tells the reasons for a `null` members-only block apart from `GET /api/v1/me` alone: `has_active_membership` (false ⇒ upgrade) and the opt-out flags `time_predictions_opted_out`, `ranking_opted_out`, `streak_opted_out` (true ⇒ the player switched that feature off on the website) — there is deliberately no per-endpoint `unavailable_reason` field.
 
 Puzzle Insights are gated **exactly as on the website** - the token owner (PAT, or the player behind an authorization-code token) must be a member; a `client_credentials` token has no player and therefore no membership. There is deliberately no `/api/v1/players/{id}/…` variant of members-only data: predictions are self-only on the website, and a single member's token must never become a proxy that serves a members-only feature to a third-party app's non-member users.
 

--- a/docs/features/api/v1-expansion-plan.md
+++ b/docs/features/api/v1-expansion-plan.md
@@ -208,7 +208,7 @@ Waves (dependencies): **wave 1** PR 0 ∥ PR 1 (independent) → **wave 2** PR 2
 ## 12. Progress
 
 - [x] #186 `GET /me/puzzles/{id}/predicted-time` (2026-08-18)
-- [ ] PR 0 `GET /me` flags
+- [x] PR 0 `GET /me` flags
 - [ ] PR 1 `GET /puzzles` + foundation (§1)
 - [ ] PR 2 `GET /puzzles/{id}`
 - [ ] PR 3 insights & solves on lists

--- a/src/Api/V1/CurrentUserResponse.php
+++ b/src/Api/V1/CurrentUserResponse.php
@@ -13,7 +13,14 @@ use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
     operations: [
         new Get(
             uriTemplate: '/v1/me',
-            openapi: new OpenApiOperation(tags: ['My Profile']),
+            openapi: new OpenApiOperation(
+                tags: ['My Profile'],
+                summary: 'Profile of the token owner',
+                description: 'has_active_membership and the three opt-out flags (time_predictions_opted_out, ranking_opted_out, streak_opted_out) '
+                    . 'tell an app why a members-only block elsewhere in the API is null: not a member, or the player opted out on the website. '
+                    . 'membership_ends_at is the ISO-8601 end of the current membership (for a Stripe subscription: the end of the paid billing period, '
+                    . 'which renews), null when the owner has no active membership.',
+            ),
             security: "is_granted('ROLE_PAT') or is_granted('ROLE_OAUTH2_PROFILE:READ')",
             provider: CurrentUserResponseProvider::class,
         ),
@@ -34,6 +41,10 @@ final class CurrentUserResponse
         public null|string $instagram,
         public bool $is_private,
         public bool $has_active_membership,
+        public null|string $membership_ends_at,
+        public bool $time_predictions_opted_out,
+        public bool $ranking_opted_out,
+        public bool $streak_opted_out,
     ) {
     }
 }

--- a/src/Api/V1/CurrentUserResponseProvider.php
+++ b/src/Api/V1/CurrentUserResponseProvider.php
@@ -47,6 +47,13 @@ final readonly class CurrentUserResponseProvider implements ProviderInterface
             instagram: $profile->instagram,
             is_private: $profile->isPrivate,
             has_active_membership: $profile->activeMembership,
+            // GetPlayerProfile coalesces a missing/expired membership to the 1970 epoch
+            // (GREATEST over COALESCEd columns), so the date is only meaningful - and
+            // only exposed - while the membership is active.
+            membership_ends_at: $profile->activeMembership ? $profile->membershipEndsAt?->format('c') : null,
+            time_predictions_opted_out: $profile->timePredictionsOptedOut,
+            ranking_opted_out: $profile->rankingOptedOut,
+            streak_opted_out: $profile->streakOptedOut,
         );
     }
 }

--- a/tests/Controller/Api/V1/CurrentUserEndpointTest.php
+++ b/tests/Controller/Api/V1/CurrentUserEndpointTest.php
@@ -4,11 +4,21 @@ declare(strict_types=1);
 
 namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
 
+use DateTimeImmutable;
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Doctrine\ORM\EntityManagerInterface;
+use SpeedPuzzling\Web\Entity\Membership;
+use SpeedPuzzling\Web\Entity\Player;
 use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
+use SpeedPuzzling\Web\Tests\PatTestHelper;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Profiler\Profile;
 
 final class CurrentUserEndpointTest extends WebTestCase
 {
@@ -196,5 +206,289 @@ final class CurrentUserEndpointTest extends WebTestCase
         $browser->request('GET', '/api/v1/me');
 
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * membership_ends_at + the three opt-out flags let an app tell a members-only
+     * null block apart ("upgrade" vs "you opted out"). PLAYER_WITH_STRIPE is a member
+     * (billing period ends 30 days from now), nothing opted out in the fixtures.
+     */
+    public function testMemberGetsMembershipEndAndDefaultFlagsViaOAuth2(): void
+    {
+        $browser = self::createClient();
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertTrue($response['has_active_membership']);
+        $this->assertIsString($response['membership_ends_at']);
+        $this->assertSame(
+            $response['membership_ends_at'],
+            (new DateTimeImmutable($response['membership_ends_at']))->format('c'),
+            'membership_ends_at must be ISO-8601 (DateTimeInterface::ATOM)',
+        );
+        $this->assertGreaterThan(new DateTimeImmutable(), new DateTimeImmutable($response['membership_ends_at']));
+        $this->assertFalse($response['time_predictions_opted_out']);
+        $this->assertFalse($response['ranking_opted_out']);
+        $this->assertFalse($response['streak_opted_out']);
+    }
+
+    public function testMemberGetsMembershipEndAndDefaultFlagsViaPersonalAccessToken(): void
+    {
+        $browser = self::createClient();
+
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_WITH_STRIPE));
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertSame(PlayerFixture::PLAYER_WITH_STRIPE, $response['id']);
+        $this->assertTrue($response['has_active_membership']);
+        $this->assertIsString($response['membership_ends_at']);
+        $this->assertGreaterThan(new DateTimeImmutable(), new DateTimeImmutable($response['membership_ends_at']));
+        $this->assertFalse($response['time_predictions_opted_out']);
+        $this->assertFalse($response['ranking_opted_out']);
+        $this->assertFalse($response['streak_opted_out']);
+    }
+
+    /**
+     * GetPlayerProfile coalesces a missing membership to the 1970 epoch - the API
+     * must still say null, not "1970-01-01T00:00:00+00:00".
+     */
+    public function testNonMemberHasNullMembershipEnd(): void
+    {
+        $browser = self::createClient();
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertFalse($response['has_active_membership']);
+        $this->assertArrayHasKey('membership_ends_at', $response);
+        $this->assertNull($response['membership_ends_at']);
+        $this->assertFalse($response['time_predictions_opted_out']);
+        $this->assertFalse($response['ranking_opted_out']);
+        $this->assertFalse($response['streak_opted_out']);
+    }
+
+    public function testNonMemberHasNullMembershipEndViaPersonalAccessToken(): void
+    {
+        $browser = self::createClient();
+
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_REGULAR));
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertFalse($response['has_active_membership']);
+        $this->assertNull($response['membership_ends_at']);
+    }
+
+    /**
+     * membership_ends_at is the end of the *current* membership, not a history: once the
+     * membership has run out the API says null, not the date it expired on.
+     */
+    public function testExpiredMembershipHasNullMembershipEnd(): void
+    {
+        $browser = self::createClient();
+        $this->expireMembership($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertFalse($response['has_active_membership']);
+        $this->assertNull($response['membership_ends_at']);
+    }
+
+    public function testOptOutFlagsReflectThePlayerSettingsViaOAuth2(): void
+    {
+        $browser = self::createClient();
+        $this->optOut($browser, PlayerFixture::PLAYER_WITH_STRIPE, timePredictions: true, ranking: true, streak: true);
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertTrue($response['has_active_membership']);
+        $this->assertTrue($response['time_predictions_opted_out']);
+        $this->assertTrue($response['ranking_opted_out']);
+        $this->assertTrue($response['streak_opted_out']);
+    }
+
+    public function testOptOutFlagsReflectThePlayerSettingsViaPersonalAccessToken(): void
+    {
+        $browser = self::createClient();
+        $this->optOut($browser, PlayerFixture::PLAYER_REGULAR, timePredictions: true, ranking: true, streak: true);
+
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_REGULAR));
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertFalse($response['has_active_membership']);
+        $this->assertTrue($response['time_predictions_opted_out']);
+        $this->assertTrue($response['ranking_opted_out']);
+        $this->assertTrue($response['streak_opted_out']);
+    }
+
+    /**
+     * Each flag is independent - one opt-out must not flip the others.
+     */
+    public function testSingleOptOutDoesNotAffectTheOtherFlags(): void
+    {
+        $browser = self::createClient();
+        $this->optOut($browser, PlayerFixture::PLAYER_WITH_STRIPE, timePredictions: false, ranking: true, streak: false);
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertFalse($response['time_predictions_opted_out']);
+        $this->assertTrue($response['ranking_opted_out']);
+        $this->assertFalse($response['streak_opted_out']);
+    }
+
+    /**
+     * The four new fields come from the PlayerProfile the provider already loads -
+     * the request must not issue a single extra query. Measured before the fields
+     * were added: OAuth2 = 3 queries (player, access token, profile), PAT = 2
+     * (token, profile). Only the request is counted - the token-creation queries
+     * are flushed from the Doctrine debug log right before it.
+     */
+    public function testRequestQueryBudgetIsUnchangedViaOAuth2(): void
+    {
+        $browser = self::createClient();
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $browser->enableProfiler();
+        $this->resetQueryLog($browser);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertLessThanOrEqual(3, $this->queryCount($browser));
+    }
+
+    public function testRequestQueryBudgetIsUnchangedViaPersonalAccessToken(): void
+    {
+        $browser = self::createClient();
+
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_WITH_STRIPE));
+        $browser->enableProfiler();
+        $this->resetQueryLog($browser);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertLessThanOrEqual(2, $this->queryCount($browser));
+    }
+
+    /**
+     * @param array<non-empty-string> $scopes
+     */
+    private function authenticateOAuth2(KernelBrowser $browser, string $playerId, array $scopes): void
+    {
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            $playerId,
+            $scopes,
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    private function optOut(KernelBrowser $browser, string $playerId, bool $timePredictions, bool $ranking, bool $streak): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $player = $entityManager->find(Player::class, $playerId);
+        $this->assertNotNull($player);
+
+        $player->changeTimePredictionsOptedOut($timePredictions);
+        $player->changeRankingOptedOut($ranking);
+        $player->changeStreakOptedOut($streak);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    /**
+     * Cancelled with a billing period that already ran out: ends_at in the past, no
+     * billing period, no grant - the same row an expired Stripe subscription leaves.
+     */
+    private function expireMembership(KernelBrowser $browser, string $playerId): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $membership = $entityManager->getRepository(Membership::class)->findOneBy(['player' => $playerId]);
+        $this->assertNotNull($membership);
+
+        $membership->cancel(new DateTimeImmutable('-1 day'));
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    /**
+     * The first request of a test reuses the kernel that the token helpers already
+     * booted, so the Doctrine data collector would also count the queries those
+     * helpers issued. Empty the debug log so the profile covers the request only.
+     */
+    private function resetQueryLog(KernelBrowser $browser): void
+    {
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var DebugDataHolder $debugDataHolder */
+        $debugDataHolder = $container->get('doctrine.debug_data_holder');
+        $debugDataHolder->reset();
+    }
+
+    private function queryCount(KernelBrowser $browser): int
+    {
+        $profile = $browser->getProfile();
+        $this->assertInstanceOf(Profile::class, $profile);
+
+        $collector = $profile->getCollector('db');
+        $this->assertInstanceOf(DoctrineDataCollector::class, $collector);
+
+        return $collector->getQueryCount();
+    }
+
+    private function entityManager(KernelBrowser $browser): EntityManagerInterface
+    {
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(KernelBrowser $browser): array
+    {
+        $content = $browser->getResponse()->getContent();
+        $this->assertIsString($content);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
     }
 }


### PR DESCRIPTION
PR 0 of `docs/features/api/v1-expansion-plan.md`.

`GET /api/v1/me` gains four trailing fields — `membership_ends_at` (ISO-8601, `null` without an active membership), `time_predictions_opted_out`, `ranking_opted_out`, `streak_opted_out` — so an app can tell *why* a members-only block elsewhere in the API is `null` (not a member vs. opted out) without a per-endpoint `unavailable_reason` field.

- Zero extra queries (values come from the `PlayerProfile` the provider already loads); request-only query budget asserted in tests (OAuth2 ≤ 3, PAT ≤ 2).
- Additive only — existing fields, order and values unchanged; existing `CurrentUserEndpointTest` assertions untouched, 9 new test methods (member/non-member/expired membership, each flag, PAT + auth-code).
- Note: `GetPlayerProfile` coalesces a missing membership to the 1970 epoch, so the date is only exposed while `has_active_membership` is true; for a Stripe subscription it is the end of the current billing period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uH2n4Y6gPLiYASEJwNr3H