### PR TITLE
API: GET /puzzles — catalog search & barcode lookup, validated params, insights per card, shared API foundation

### DIFF
--- a/config/packages/rate_limiter.php
+++ b/config/packages/rate_limiter.php
@@ -86,6 +86,16 @@ return App::config([
                 'limit' => 20,
                 'interval' => '1 hour',
             ],
+            // Public API catalog search (GET /api/v1/puzzles) - the only unbounded
+            // read in V1, so scraping is kept to a walk. Keyed by the token owner
+            // (player behind a PAT / auth-code token, client id for client_credentials);
+            // rejection is a 429 with Retry-After. Documented on /for-developers and
+            // in docs/features/api/README.md - keep the three in sync.
+            'api_puzzle_search' => [
+                'policy' => 'sliding_window',
+                'limit' => 60,
+                'interval' => '1 minute',
+            ],
         ],
     ],
 ]);

--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -230,6 +230,13 @@ return App::config([
                 'path' => '^/api/v1/competitions',
                 'roles' => [AuthenticatedVoter::IS_AUTHENTICATED_FULLY],
             ],
+            // The puzzle catalog is public data, but never an anonymous API: any
+            // valid token (PAT, auth-code, client_credentials) - members-only parts
+            // of the response are gated per token owner inside the providers.
+            [
+                'path' => '^/api/v1/puzzles',
+                'roles' => [AuthenticatedVoter::IS_AUTHENTICATED_FULLY],
+            ],
             // Admin access, not merely "signed in": every controller under
             // src/Controller/Admin also carries #[IsGranted(ADMIN_ACCESS)], but a
             // firewall-level rule is what covers the one somebody forgets to

--- a/docs/features/api/README.md
+++ b/docs/features/api/README.md
@@ -112,6 +112,59 @@ hand-typed `SOLVING_TIMES` variant silently matched nothing until 2026-08 (PR #1
   - `hideMode = ImageOnly` → the puzzle is returned but `image` is `null` (name, pieces count, manufacturer remain visible).
   - After reveal, everything is visible. This behavior is covered by dedicated tests in `CompetitionDetailEndpointTest`.
 
+### Puzzle Endpoints (any authenticated token)
+
+| Method | Endpoint | Auth |
+|--------|----------|------|
+| GET | `/api/v1/puzzles?query=…&ean=…&manufacturer=…&pieces_min=…&pieces_max=…&sort=…&difficulty=…&page=…&limit=…` | Any valid PAT or OAuth2 token (no specific scope); `sort=easiest\|hardest` and `difficulty=` are members-only |
+
+### Puzzles
+
+`GET /api/v1/puzzles` is the catalog: the same search as the website's `/puzzle` page (`SearchPuzzle::byUserInput`, brand / sort / difficulty normalised through `PuzzleSearchCriteria` so the two can never drift on what is members-only), plus the barcode lookup of the web scanner (`SearchPuzzle::allByEan`). Provider: `PuzzleSearchResponseProvider`; the query parameters are declared once on `PuzzleListResponse` (API Platform `QueryParameter`) - the declaration validates the input and renders the Swagger documentation.
+
+| Parameter | Type / constraints | Meaning |
+|-----------|-------------------|---------|
+| `query` | string, trimmed, 2-100 characters | name / alternative name (accent-insensitive), identification number, EAN substring - the same matching as the web search box |
+| `ean` | `^\d{8,14}$` | exact barcode lookup, leading / trailing zeros tolerated. **Mutually exclusive** with `query`, `manufacturer`, `pieces_min`, `pieces_max`, `sort`, `difficulty` (422 "ean cannot be combined with …"). `page` / `limit` still apply |
+| `manufacturer` | UUID | brand filter; an unknown id yields an empty result, not 404 |
+| `pieces_min`, `pieces_max` | int 1-50000, `pieces_min ≤ pieces_max` (422 otherwise) | inclusive piece-count range; exact count = both equal (`PiecesRange`) |
+| `sort` | `most-solved` (default) `least-solved` `a-z` `z-a` `easiest` `hardest` | `easiest` / `hardest` are **members-only → 403** `sort=easiest requires an active membership` (the website silently falls back, the API is explicit) |
+| `difficulty` | comma list of `very_easy` `easy` `average` `challenging` `hard` `very_hard` | tier filter, **members-only → 403**; each token must be valid (422) |
+| `page` | int 1-500, default 1 | |
+| `limit` | int 1-100, default 20 | |
+
+No filter at all lists the whole catalog (most solved first) - the catalog is public, scraping is bounded by the caps (≤ 100 items per page, ≤ 500 pages) and the rate limit. Invalid input is a `422 application/problem+json` with `violations[].propertyPath`, never a 500.
+
+**Rate limit:** 60 requests per minute per token owner (`api_puzzle_search` sliding window in `config/packages/rate_limiter.php`; key = player id for PAT / authorization-code tokens, client id for `client_credentials`). Over the limit → `429` with `Retry-After` (seconds). A 422 never consumes the budget (validation runs first).
+
+**Response** `{ count, total, page, limit, has_more, puzzles: [ … ] }` - `count` is this page, `total` the whole result. Each card:
+
+```json
+{ "id": "018d0003-0000-0000-0000-000000000002", "name": "Puzzle 2", "alternative_name": null,
+  "manufacturer": { "id": "018d0002-0000-0000-0000-000000000001", "name": "Ravensburger" },
+  "pieces_count": 500, "image": "puzzles/…/box.jpg", "ean": "4005556123456", "identification_number": null,
+  "is_available": true, "is_approved": true,
+  "statistics": { "solved_times": 41,
+                  "solo": { "count": 30, "fastest_seconds": 1500, "average_seconds": 2160, "slowest_seconds": 3900 },
+                  "duo":  { "count": 8,  "fastest_seconds": 1180, "average_seconds": 1320, "slowest_seconds": 1700 },
+                  "team": { "count": 3,  "fastest_seconds": null, "average_seconds": null, "slowest_seconds": null } },
+  "difficulty": { "score": 1.18, "level": "challenging", "confidence": "medium", "sample_size": 14 },
+  "prediction": { "predicted_seconds": 1890, "range_low_seconds": 1607, "range_high_seconds": 2174,
+                  "is_personalized": true, "personal_solve_count": 3, "predicted_attempt_number": 4, "last_time_seconds": 2100 },
+  "solves": { "solo": { "count": 3, "best_time_seconds": 1700, "last_time_seconds": 1700, "first_solved_at": "2026-07-30T10:12:45+00:00", "last_solved_at": "2026-08-09T14:30:00+00:00" },
+              "duo":  { "count": 0, "best_time_seconds": null, "last_time_seconds": null, "first_solved_at": null, "last_solved_at": null },
+              "team": { "count": 0, "best_time_seconds": null, "last_time_seconds": null, "first_solved_at": null, "last_solved_at": null } } }
+```
+
+- `statistics` is public, from the precomputed `puzzle_statistics` row (`GetPuzzleStatistics::forPuzzleList`), **always split by discipline** - solo, duo and team are different disciplines and are never merged; a puzzle nobody has solved has zeros and nulls.
+- The three insight objects are **always present** and `null` means exactly "not available to this token" (never an error, so one client code path works for every kind of token). When present, the object is complete and carries `null` *inside* for "not enough data":
+  - `difficulty` - token owner is a member (`ApiTokenOwner::isMember()`); a member looking at a puzzle without a difficulty row gets `{ score: null, level: null, confidence: "insufficient", sample_size: 0 }`
+  - `prediction` - member **and** not opted out of time predictions **and** the token may read results (PAT or `results:read`); all fields `null` + `is_personalized: false` when there is nothing to predict from
+  - `solves` - the token owner's **own** history (the same row set as `/me/results?type=`, unboxed and suspicious-flagged times included), for a token with a player behind it **and** PAT / `results:read`; always split by discipline like `/me/statistics`
+  - a `client_credentials` token has no player ⇒ all three are `null`
+- `hide_until` (secret competition puzzles) ⇒ never returned - not in the listing, not by `query`, not by `ean`; `hide_image_until` ⇒ `image: null` until the embargo ends.
+- **Fixed query cost** (asserted by `PuzzleSearchEndpointTest::testQueryBudgets`): the card builder (`PuzzleResponseFactory`) collects the puzzle ids once and makes one batch call per object - `GetPuzzleStatistics::forPuzzleList`, `GetPuzzleDifficulty::forPuzzleList`, `GetPlayerPredictions::forPuzzles` (itself ≤ 4 queries), `GetPlayerPuzzleSolves::forPuzzles` - each only when the token is entitled; a page of 100 costs the same as a page of 5. Measured: authentication 1 query (PAT) / 3 (OAuth2: access token, player, consent usage) + count + search + statistics + owner profile + solves + [member: difficulty + predictions] - `client_credentials` 3-4, non-member 6 (PAT) / 8 (OAuth2), member 10-11 (PAT) / 12-13 (OAuth2).
+
 ### Collection Membership Gating
 
 - **System collection** (`id=default`): All users can list/add/remove items
@@ -125,6 +178,8 @@ Puzzle difficulty and player skill tiers are included in responses only if the t
 An app tells the reasons for a `null` members-only block apart from `GET /api/v1/me` alone: `has_active_membership` (false ⇒ upgrade) and the opt-out flags `time_predictions_opted_out`, `ranking_opted_out`, `streak_opted_out` (true ⇒ the player switched that feature off on the website) — there is deliberately no per-endpoint `unavailable_reason` field.
 
 Puzzle Insights are gated **exactly as on the website** - the token owner (PAT, or the player behind an authorization-code token) must be a member; a `client_credentials` token has no player and therefore no membership. There is deliberately no `/api/v1/players/{id}/…` variant of members-only data: predictions are self-only on the website, and a single member's token must never become a proxy that serves a members-only feature to a third-party app's non-member users.
+
+One service decides this for every provider: `ApiTokenOwner` (`src/Services/Api/`) - `profile()` (the player behind the token, `null` for a machine token, memoised per request), `isMember()`, `canReadResults()` (PAT or `results:read`), `canReadStatistics()`. Providers never `assert($user instanceof ApiUser)` outside `/me/*`; they ask `ApiTokenOwner` and return `null` objects for what the token is not entitled to. Members-only blocks are **nullable objects**: `null` ⇔ "not available to this token" (not a member / machine token / missing scope / opted out); when available, the object is always present and carries `null` inside for "not enough data" (the `GET /me` flags above tell the reasons apart). Design and progress: `docs/features/api/v1-expansion-plan.md`.
 
 ### GET `/api/v1/me/puzzles/{puzzleId}/predicted-time`
 
@@ -230,12 +285,15 @@ Access control:
 - `^/api/v1/players/.*/statistics` → `ROLE_OAUTH2_STATISTICS:READ`
 - `^/api/v1/players/.*/collections` → `ROLE_OAUTH2_COLLECTIONS:READ`
 - `^/api/v1/competitions` → `IS_AUTHENTICATED_FULLY` (PAT or any OAuth2 token, no specific scope)
+- `^/api/v1/puzzles` → `IS_AUTHENTICATED_FULLY` (PAT or any OAuth2 token, no specific scope; members-only parts of the response are gated per token owner inside the providers)
 
 ## Fair Use Policy
 
 Full policy page at `/en/fair-use-policy` with 10 sections: welcome, rate limits, permitted use, data ownership, API keys, monitoring, attribution, community, policy updates, and contact.
 
 **Acceptance flow:** Users must read the full policy and click "I Accept the API Usage Policy" at the bottom. Acceptance is stored as `fairUsePolicyAcceptedAt` on the `Player` entity. Until accepted, PAT generation and OAuth2 client request forms are locked with a CTA to read and accept the policy.
+
+**Enforced limits:** `GET /api/v1/puzzles` - 60 requests per minute per token owner (`429` + `Retry-After`, see Puzzles above). Other endpoints are not rate-limited beyond the policy (yet).
 
 - Controller: `FairUsePolicyController` (GET), `AcceptFairUsePolicyController` (POST)
 - Message: `AcceptFairUsePolicy` → `AcceptFairUsePolicyHandler`
@@ -294,6 +352,12 @@ Stub endpoints for in-app purchase verification (not implemented).
 | `src/Entity/OAuth2/OAuth2ClientRequest.php` | Client registration request entity |
 | `src/Entity/OAuth2/OAuth2UserConsent.php` | Consent entity with `lastUsedAt` |
 | `src/Api/V1/` | All API Platform resources, providers, and processors |
+| `src/Api/V1/PuzzleListResponse.php` | `GET /api/v1/puzzles` resource: the single declaration of its query parameters (validation + OpenAPI) |
+| `src/Api/V1/PuzzleResponse.php` | The puzzle card (+ `PuzzleStatisticsResponse`, `PuzzleDifficultyResponse`, `TimePredictionResponse`, `PlayerSolvesResponse`) |
+| `src/Services/Api/ApiTokenOwner.php` | The single membership / scope gate behind every provider |
+| `src/Services/Api/PuzzleResponseFactory.php` | Builds puzzle cards for the calling token at a fixed query cost (one batch call per object) |
+| `src/Query/GetPuzzleStatistics.php`, `GetPlayerPuzzleSolves.php` | Batch queries behind the cards' `statistics` and `solves` objects |
+| `tests/QueryCountAssertions.php`, `tests/OpenApiAssertions.php` | Test traits: query budgets via the profiler, parameter documentation via `/api/docs.jsonopenapi` |
 | `src/Controller/FairUsePolicyController.php` | Fair use policy page |
 | `src/Controller/AcceptFairUsePolicyController.php` | Accept FUP action |
 | `src/Controller/CreatePersonalAccessTokenController.php` | PAT generation |

--- a/docs/features/api/v1-expansion-plan.md
+++ b/docs/features/api/v1-expansion-plan.md
@@ -228,7 +228,7 @@ Waves (dependencies): **wave 1** PR 0 ∥ PR 1 (independent) → **wave 2** PR 2
 
 - [x] #186 `GET /me/puzzles/{id}/predicted-time` (2026-08-18)
 - [x] PR 0 `GET /me` flags
-- [ ] PR 1 `GET /puzzles` + foundation (§1)
+- [x] PR 1 `GET /puzzles` + foundation (§1) (2026-08-19; `statistics` shipped split by discipline - `{ solved_times, solo, duo, team }` from `puzzle_statistics` via `GetPuzzleStatistics::forPuzzleList`, as §1.2/§13 now say; measured budgets: OAuth2 auth costs 3 queries, not 2, so auth-code tokens sit one above the §4 ceilings - cc 3-4, non-member 6 PAT / 8 OAuth2, member 10-11 PAT / 12-13 OAuth2)
 - [ ] PR 2 `GET /puzzles/{id}`
 - [ ] PR 3 insights & solves on lists
 - [ ] PR 4 `prediction` on `POST /me/solving-times`

--- a/src/Api/V1/PlayerSolvesResponse.php
+++ b/src/Api/V1/PlayerSolvesResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use SpeedPuzzling\Web\Results\PlayerPuzzleSolves;
+
+/**
+ * The token owner's own history on a puzzle, always split by discipline -
+ * solo, duo and team are different disciplines and are never merged (the same
+ * split as /me/statistics). Not members-only; an endpoint returns null for this
+ * object only when the token has no player behind it or no results:read / PAT.
+ */
+final class PlayerSolvesResponse
+{
+    public function __construct(
+        public SolvesGroupResponse $solo,
+        public SolvesGroupResponse $duo,
+        public SolvesGroupResponse $team,
+    ) {
+    }
+
+    public static function fromResult(PlayerPuzzleSolves $solves): self
+    {
+        return new self(
+            solo: SolvesGroupResponse::fromResult($solves->solo),
+            duo: SolvesGroupResponse::fromResult($solves->duo),
+            team: SolvesGroupResponse::fromResult($solves->team),
+        );
+    }
+}

--- a/src/Api/V1/PuzzleDifficultyResponse.php
+++ b/src/Api/V1/PuzzleDifficultyResponse.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use SpeedPuzzling\Web\Results\PuzzleDifficultyResult;
+use SpeedPuzzling\Web\Value\MetricConfidence;
+
+/**
+ * Puzzle difficulty (Puzzle Insights) - members-only, exactly as on the website.
+ * An endpoint returns null for this object when the token owner is not a member
+ * (or the token is a machine token); when it is present, the object is always
+ * complete and carries null *inside* for "not enough data yet".
+ */
+final class PuzzleDifficultyResponse
+{
+    public function __construct(
+        public null|float $score,
+        public null|string $level,
+        public string $confidence,
+        public int $sample_size,
+    ) {
+    }
+
+    public static function fromResult(PuzzleDifficultyResult $difficulty): self
+    {
+        return new self(
+            score: $difficulty->difficultyScore,
+            level: $difficulty->difficultyTier?->toApiValue(),
+            confidence: $difficulty->confidence->value,
+            sample_size: $difficulty->sampleSize,
+        );
+    }
+
+    /**
+     * A member looking at a puzzle that has no difficulty row yet (the
+     * recalculation is batch): "insufficient data", not "members only".
+     */
+    public static function insufficient(): self
+    {
+        return new self(
+            score: null,
+            level: null,
+            confidence: MetricConfidence::Insufficient->value,
+            sample_size: 0,
+        );
+    }
+}

--- a/src/Api/V1/PuzzleListResponse.php
+++ b/src/Api/V1/PuzzleListResponse.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
+use ApiPlatform\OpenApi\Model\Response as OpenApiResponse;
+use SpeedPuzzling\Web\Value\DifficultyTier;
+use SpeedPuzzling\Web\Value\PuzzleSearchCriteria;
+use Symfony\Component\Validator\Constraints\All;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Type;
+
+/**
+ * GET /api/v1/puzzles - the puzzle catalog: search, filters, barcode lookup.
+ *
+ * Every query parameter is declared once, here: the declaration validates the
+ * input (invalid => 422 application/problem+json with violations) and renders
+ * the Swagger documentation. Cross-parameter rules (ean exclusivity,
+ * pieces_min <= pieces_max) and the members-only values (sort=easiest|hardest,
+ * difficulty=) are enforced in PuzzleSearchResponseProvider.
+ */
+#[ApiResource(
+    shortName: 'PuzzleList',
+    operations: [
+        new Get(
+            uriTemplate: '/v1/puzzles',
+            openapi: new OpenApiOperation(
+                tags: ['Puzzles'],
+                summary: 'Search the puzzle catalog or look a puzzle up by barcode',
+                description: 'Returns puzzle cards - the same catalog as the website\'s puzzle search. '
+                    . 'Without any filter the whole catalog is listed (most solved first); "query" searches names, '
+                    . 'alternative names, identification numbers and barcodes accent-insensitively; "ean" is an exact '
+                    . 'barcode lookup (leading/trailing zeros tolerated) and cannot be combined with the other filters. '
+                    . 'Secret competition puzzles are never returned and an embargoed image is null until its release. '
+                    . 'Every card carries three insight objects that are always present and null when the token is not '
+                    . 'entitled to them: "difficulty" (token owner must be a member), "prediction" (member who has not '
+                    . 'opted out of time predictions, with a PAT or results:read) and "solves" (the token owner\'s own '
+                    . 'history, PAT or results:read). A client_credentials token has no player behind it, so it gets null '
+                    . 'for all three. sort=easiest|hardest and the difficulty filter are members-only (403 otherwise). '
+                    . 'Pagination is capped at 100 items per page and 500 pages; the endpoint is rate-limited to 60 '
+                    . 'requests per minute per token owner (429 with Retry-After).',
+                responses: [
+                    '401' => new OpenApiResponse(description: 'Missing, invalid or expired token.'),
+                    '403' => new OpenApiResponse(description: 'sort=easiest|hardest or the difficulty filter without an active membership.'),
+                    '422' => new OpenApiResponse(description: 'Invalid or contradicting query parameters (application/problem+json with "violations").'),
+                    '429' => new OpenApiResponse(description: 'Rate limit exceeded - 60 requests per minute per token owner. "Retry-After" says in how many seconds the next request is accepted.'),
+                ],
+            ),
+            security: "is_granted('IS_AUTHENTICATED_FULLY')",
+            provider: PuzzleSearchResponseProvider::class,
+            parameters: [
+                'query' => new QueryParameter(
+                    key: 'query',
+                    schema: ['type' => 'string', 'minLength' => 2, 'maxLength' => 100],
+                    description: 'Free-text search (2-100 characters): puzzle name and alternative name (accent-insensitive), identification number, barcode substring - the same matching as the website search box. Surrounding whitespace is ignored.',
+                    constraints: [new Length(min: 2, max: 100)],
+                    castToNativeType: true,
+                    castFn: [QueryParameterCaster::class, 'trim'],
+                ),
+                'ean' => new QueryParameter(
+                    key: 'ean',
+                    schema: ['type' => 'string', 'pattern' => '^\d{8,14}$'],
+                    description: 'Exact barcode (EAN/UPC, 8-14 digits) lookup; leading and trailing zeros are tolerated. Mutually exclusive with query, manufacturer, pieces_min, pieces_max, sort and difficulty (422 when combined).',
+                    constraints: [new Regex(pattern: '/^\d{8,14}$/', message: 'ean must be 8 to 14 digits.')],
+                ),
+                'manufacturer' => new QueryParameter(
+                    key: 'manufacturer',
+                    schema: ['type' => 'string', 'format' => 'uuid'],
+                    description: 'Brand (manufacturer) id. An unknown id yields an empty result, not 404.',
+                    constraints: [new Regex(pattern: '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', message: 'manufacturer must be a UUID.')],
+                ),
+                'pieces_min' => new QueryParameter(
+                    key: 'pieces_min',
+                    schema: ['type' => 'integer', 'minimum' => 1, 'maximum' => 50000],
+                    description: 'Lowest piece count to include (inclusive). Use pieces_min = pieces_max for an exact count.',
+                    constraints: [new Type(type: 'integer'), new Range(min: 1, max: 50000)],
+                    castToNativeType: true,
+                ),
+                'pieces_max' => new QueryParameter(
+                    key: 'pieces_max',
+                    schema: ['type' => 'integer', 'minimum' => 1, 'maximum' => 50000],
+                    description: 'Highest piece count to include (inclusive); must not be below pieces_min (422 otherwise).',
+                    constraints: [new Type(type: 'integer'), new Range(min: 1, max: 50000)],
+                    castToNativeType: true,
+                ),
+                'sort' => new QueryParameter(
+                    key: 'sort',
+                    schema: ['type' => 'string', 'enum' => PuzzleSearchCriteria::VALID_SORTS, 'default' => 'most-solved'],
+                    description: 'Sort order. easiest and hardest (by difficulty score) are members-only: 403 for a non-member or a client_credentials token.',
+                    constraints: [new Choice(choices: PuzzleSearchCriteria::VALID_SORTS)],
+                ),
+                'difficulty' => new QueryParameter(
+                    key: 'difficulty',
+                    schema: ['type' => 'array', 'items' => ['type' => 'string', 'enum' => DifficultyTier::API_VALUES]],
+                    openApi: new OpenApiParameter(name: 'difficulty', in: 'query', style: 'form', explode: false),
+                    description: 'Comma-separated difficulty tiers to include, e.g. "hard,very_hard" (very_easy, easy, average, challenging, hard, very_hard). Members-only: 403 for a non-member or a client_credentials token.',
+                    constraints: [new All(constraints: [new Choice(choices: DifficultyTier::API_VALUES)])],
+                    castToNativeType: true,
+                    castFn: [QueryParameterCaster::class, 'commaSeparatedList'],
+                ),
+                'page' => new QueryParameter(
+                    key: 'page',
+                    schema: ['type' => 'integer', 'minimum' => 1, 'maximum' => 500, 'default' => 1],
+                    description: 'Page number, 1-based, at most 500.',
+                    constraints: [new Type(type: 'integer'), new Range(min: 1, max: 500)],
+                    castToNativeType: true,
+                ),
+                'limit' => new QueryParameter(
+                    key: 'limit',
+                    schema: ['type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'default' => 20],
+                    description: 'Items per page, at most 100.',
+                    constraints: [new Type(type: 'integer'), new Range(min: 1, max: 100)],
+                    castToNativeType: true,
+                ),
+            ],
+        ),
+    ],
+)]
+final class PuzzleListResponse
+{
+    /**
+     * @param list<PuzzleResponse> $puzzles
+     */
+    public function __construct(
+        /** Number of puzzles on this page */
+        public int $count,
+        /** Number of puzzles matching the filters altogether */
+        public int $total,
+        public int $page,
+        public int $limit,
+        public bool $has_more,
+        /** @var list<PuzzleResponse> */
+        public array $puzzles,
+    ) {
+    }
+}

--- a/src/Api/V1/PuzzleListResponse.php
+++ b/src/Api/V1/PuzzleListResponse.php
@@ -61,7 +61,7 @@ use Symfony\Component\Validator\Constraints\Type;
                 'query' => new QueryParameter(
                     key: 'query',
                     schema: ['type' => 'string', 'minLength' => 2, 'maxLength' => 100],
-                    description: 'Free-text search (2-100 characters): puzzle name and alternative name (accent-insensitive), identification number, barcode substring - the same matching as the website search box. Surrounding whitespace is ignored.',
+                    description: 'Free-text search (2-100 characters): puzzle name and alternative name (accent-insensitive), identification number, barcode substring - the same matching as the website search box. Surrounding whitespace is ignored; an empty value is the same as omitting the parameter.',
                     constraints: [new Length(min: 2, max: 100)],
                     castToNativeType: true,
                     castFn: [QueryParameterCaster::class, 'trim'],

--- a/src/Api/V1/PuzzleManufacturerResponse.php
+++ b/src/Api/V1/PuzzleManufacturerResponse.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+final class PuzzleManufacturerResponse
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Api/V1/PuzzleResponse.php
+++ b/src/Api/V1/PuzzleResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+/**
+ * The puzzle card: catalog list item and the base of the puzzle detail.
+ *
+ * The three trailing insight objects are always present in the JSON: null
+ * means "not available to this token" (difficulty: not a member / machine
+ * token; prediction: not a member, opted out, machine token or no results:read;
+ * solves: machine token or no results:read), never an error - one client code
+ * path works for every kind of token. See docs/features/api/README.md, Puzzles.
+ */
+final class PuzzleResponse
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public null|string $alternative_name,
+        public PuzzleManufacturerResponse $manufacturer,
+        public int $pieces_count,
+        public null|string $image,
+        public null|string $ean,
+        public null|string $identification_number,
+        public bool $is_available,
+        public bool $is_approved,
+        public PuzzleStatisticsResponse $statistics,
+        public null|PuzzleDifficultyResponse $difficulty,
+        public null|TimePredictionResponse $prediction,
+        public null|PlayerSolvesResponse $solves,
+    ) {
+    }
+}

--- a/src/Api/V1/PuzzleSearchResponseProvider.php
+++ b/src/Api/V1/PuzzleSearchResponseProvider.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ParameterNotFound;
+use ApiPlatform\State\ProviderInterface;
+use ApiPlatform\Validator\Exception\ValidationException;
+use SpeedPuzzling\Web\Query\SearchPuzzle;
+use SpeedPuzzling\Web\Services\Api\ApiTokenOwner;
+use SpeedPuzzling\Web\Services\Api\PuzzleResponseFactory;
+use SpeedPuzzling\Web\Value\DifficultyTier;
+use SpeedPuzzling\Web\Value\PiecesRange;
+use SpeedPuzzling\Web\Value\PuzzleSearchCriteria;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * GET /api/v1/puzzles - search / barcode lookup over the same catalog query the
+ * website uses (SearchPuzzle), with puzzle cards built for the calling token.
+ *
+ * The parameters are validated and documented by the declaration on
+ * PuzzleListResponse; this provider only reads the validated values, enforces
+ * the cross-parameter rules (422), the members-only values (403 - the website
+ * silently falls back, the API is explicit), the per-owner rate limit (429),
+ * runs the search and builds the response.
+ *
+ * @implements ProviderInterface<PuzzleListResponse>
+ */
+final readonly class PuzzleSearchResponseProvider implements ProviderInterface
+{
+    /** @var list<string> */
+    private const array EAN_EXCLUSIVE_WITH = ['query', 'manufacturer', 'pieces_min', 'pieces_max', 'sort', 'difficulty'];
+
+    public function __construct(
+        private Security $security,
+        private ApiTokenOwner $tokenOwner,
+        private SearchPuzzle $searchPuzzle,
+        private PuzzleResponseFactory $puzzleResponseFactory,
+        private RateLimiterFactoryInterface $apiPuzzleSearchLimiter,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): PuzzleListResponse
+    {
+        $this->consumeRateLimit();
+
+        /** @var null|Request $request */
+        $request = $context['request'] ?? null;
+
+        $page = $this->intValue($operation, 'page', 1);
+        $limit = $this->intValue($operation, 'limit', 20);
+
+        $ean = $this->stringValue($operation, 'ean');
+
+        if ($ean !== null) {
+            return $this->byEan($ean, $page, $limit, $request);
+        }
+
+        $search = $this->stringValue($operation, 'query');
+        $manufacturer = $this->stringValue($operation, 'manufacturer');
+        $piecesMin = $this->intValue($operation, 'pieces_min', null);
+        $piecesMax = $this->intValue($operation, 'pieces_max', null);
+        $sort = $this->stringValue($operation, 'sort') ?? 'most-solved';
+        $difficultyTokens = $this->listValue($operation, 'difficulty');
+
+        if ($piecesMin !== null && $piecesMax !== null && $piecesMin > $piecesMax) {
+            throw self::violation('pieces_min', $piecesMin, 'pieces_min must not be above pieces_max.');
+        }
+
+        $difficultyTiers = [];
+
+        foreach ($difficultyTokens as $token) {
+            // The Choice constraint already rejected unknown tokens; this is the mapping only
+            $tier = DifficultyTier::fromApiValue($token);
+
+            if ($tier !== null) {
+                $difficultyTiers[] = $tier->value;
+            }
+        }
+
+        // The same normalisation as the website's /puzzle search: what is
+        // members-only is decided in one place. The website silently falls back
+        // for a non-member; the API turns that downgrade into a 403 instead.
+        $criteria = PuzzleSearchCriteria::fromUserInput(
+            brandId: $manufacturer,
+            search: $search,
+            pieces: null,
+            tagId: null,
+            difficultyTiers: $difficultyTiers,
+            sortBy: $sort,
+            isMember: $this->tokenOwner->isMember(),
+        );
+
+        if ($criteria->sortBy !== $sort) {
+            throw new AccessDeniedHttpException(sprintf('sort=%s requires an active membership.', $sort));
+        }
+
+        if ($difficultyTiers !== [] && $criteria->difficultyTiers === []) {
+            throw new AccessDeniedHttpException('The difficulty filter requires an active membership.');
+        }
+
+        $pieces = PiecesRange::between($piecesMin, $piecesMax);
+
+        $total = $this->searchPuzzle->countByUserInput(
+            $criteria->brandId,
+            $criteria->search,
+            $pieces,
+            $criteria->tagId,
+            $criteria->difficultyTiers,
+        );
+
+        $overviews = $this->searchPuzzle->byUserInput(
+            $criteria->brandId,
+            $criteria->search,
+            $pieces,
+            $criteria->tagId,
+            $criteria->sortBy,
+            offset: ($page - 1) * $limit,
+            limit: $limit,
+            difficultyTiers: $criteria->difficultyTiers,
+        );
+
+        $puzzles = $this->puzzleResponseFactory->cards($overviews);
+
+        return new PuzzleListResponse(
+            count: count($puzzles),
+            total: $total,
+            page: $page,
+            limit: $limit,
+            has_more: $page * $limit < $total,
+            puzzles: $puzzles,
+        );
+    }
+
+    /**
+     * Barcode lookup: exact match with zero tolerance, no count query (the
+     * handful of matches is paginated in memory, the response shape stays the same).
+     */
+    private function byEan(string $ean, int $page, int $limit, null|Request $request): PuzzleListResponse
+    {
+        foreach (self::EAN_EXCLUSIVE_WITH as $key) {
+            if ($request?->query->has($key) === true) {
+                throw self::violation('ean', $ean, sprintf('ean cannot be combined with %s.', $key));
+            }
+        }
+
+        $overviews = $this->searchPuzzle->allByEan($ean);
+        $total = count($overviews);
+
+        $puzzles = $this->puzzleResponseFactory->cards(
+            array_slice($overviews, ($page - 1) * $limit, $limit),
+        );
+
+        return new PuzzleListResponse(
+            count: count($puzzles),
+            total: $total,
+            page: $page,
+            limit: $limit,
+            has_more: $page * $limit < $total,
+            puzzles: $puzzles,
+        );
+    }
+
+    /**
+     * One budget per token owner: the player behind a PAT / authorization-code
+     * token, the client behind a client_credentials token.
+     */
+    private function consumeRateLimit(): void
+    {
+        $key = $this->security->getUser()?->getUserIdentifier() ?? 'anonymous';
+        $limit = $this->apiPuzzleSearchLimiter->create($key)->consume();
+
+        if ($limit->isAccepted()) {
+            return;
+        }
+
+        $retryAfterSeconds = max(1, $limit->getRetryAfter()->getTimestamp() - time());
+
+        throw new TooManyRequestsHttpException(
+            $retryAfterSeconds,
+            sprintf('Too many puzzle searches. Try again in %d seconds.', $retryAfterSeconds),
+        );
+    }
+
+    private static function violation(string $parameter, mixed $value, string $message): ValidationException
+    {
+        return new ValidationException(new ConstraintViolationList([
+            new ConstraintViolation($message, null, [], null, $parameter, $value),
+        ]));
+    }
+
+    private function stringValue(Operation $operation, string $key): null|string
+    {
+        $value = $operation->getParameters()?->get($key)?->getValue();
+
+        if ($value instanceof ParameterNotFound || $value === null || $value === '') {
+            return null;
+        }
+
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * @return ($default is int ? int : null|int)
+     */
+    private function intValue(Operation $operation, string $key, null|int $default): null|int
+    {
+        $value = $operation->getParameters()?->get($key)?->getValue();
+
+        return is_int($value) ? $value : $default;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listValue(Operation $operation, string $key): array
+    {
+        $value = $operation->getParameters()?->get($key)?->getValue();
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, 'is_string'));
+    }
+}

--- a/src/Api/V1/PuzzleStatisticsGroupResponse.php
+++ b/src/Api/V1/PuzzleStatisticsGroupResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use SpeedPuzzling\Web\Results\PuzzleDisciplineStatistics;
+
+/**
+ * Community statistics of a puzzle in one discipline. Seconds; null when
+ * nobody has solved the puzzle in that discipline yet.
+ */
+final class PuzzleStatisticsGroupResponse
+{
+    public function __construct(
+        public int $count,
+        public null|int $fastest_seconds,
+        public null|int $average_seconds,
+        public null|int $slowest_seconds,
+    ) {
+    }
+
+    public static function fromResult(PuzzleDisciplineStatistics $statistics): self
+    {
+        return new self(
+            count: $statistics->count,
+            fastest_seconds: $statistics->fastestSeconds,
+            average_seconds: $statistics->averageSeconds,
+            slowest_seconds: $statistics->slowestSeconds,
+        );
+    }
+}

--- a/src/Api/V1/PuzzleStatisticsResponse.php
+++ b/src/Api/V1/PuzzleStatisticsResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use SpeedPuzzling\Web\Results\PuzzleStatisticsResult;
+
+/**
+ * Community statistics of a puzzle - public, always split by discipline (solo,
+ * duo and team are different disciplines and are never merged); solved_times
+ * is the total across them.
+ */
+final class PuzzleStatisticsResponse
+{
+    public function __construct(
+        public int $solved_times,
+        public PuzzleStatisticsGroupResponse $solo,
+        public PuzzleStatisticsGroupResponse $duo,
+        public PuzzleStatisticsGroupResponse $team,
+    ) {
+    }
+
+    public static function fromResult(PuzzleStatisticsResult $statistics): self
+    {
+        return new self(
+            solved_times: $statistics->solvedTimes,
+            solo: PuzzleStatisticsGroupResponse::fromResult($statistics->solo),
+            duo: PuzzleStatisticsGroupResponse::fromResult($statistics->duo),
+            team: PuzzleStatisticsGroupResponse::fromResult($statistics->team),
+        );
+    }
+}

--- a/src/Api/V1/QueryParameterCaster.php
+++ b/src/Api/V1/QueryParameterCaster.php
@@ -15,9 +15,20 @@ final class QueryParameterCaster
      * Trims surrounding whitespace so that the length constraint judges what
      * the search will actually use.
      */
+    /**
+     * Surrounding whitespace never counts; an empty (or whitespace-only) value is
+     * the same as not sending the parameter at all - a cleared search box must not
+     * turn into a 422.
+     */
     public static function trim(mixed $value): mixed
     {
-        return is_string($value) ? trim($value) : $value;
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
     }
 
     /**

--- a/src/Api/V1/QueryParameterCaster.php
+++ b/src/Api/V1/QueryParameterCaster.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+/**
+ * castFn callbacks for API Platform QueryParameter declarations. A cast runs
+ * before validation and must never throw - whatever cannot be cast is returned
+ * untouched so that the constraints report it as a 422, not a 500.
+ */
+final class QueryParameterCaster
+{
+    /**
+     * Trims surrounding whitespace so that the length constraint judges what
+     * the search will actually use.
+     */
+    public static function trim(mixed $value): mixed
+    {
+        return is_string($value) ? trim($value) : $value;
+    }
+
+    /**
+     * "a,b" => ['a', 'b']: a comma-separated list parameter (OpenAPI style
+     * form / explode false). Empty items are dropped, so "a,,b" and "a, b"
+     * both mean ['a', 'b'].
+     *
+     * @return mixed list<string> for a string input
+     */
+    public static function commaSeparatedList(mixed $value): mixed
+    {
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        $items = [];
+
+        foreach (explode(',', $value) as $item) {
+            $item = trim($item);
+
+            if ($item !== '') {
+                $items[] = $item;
+            }
+        }
+
+        return $items;
+    }
+}

--- a/src/Api/V1/SolvesGroupResponse.php
+++ b/src/Api/V1/SolvesGroupResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use SpeedPuzzling\Web\Results\PlayerPuzzleSolvesGroup;
+
+/**
+ * The token owner's solves of one puzzle in one discipline.
+ */
+final class SolvesGroupResponse
+{
+    public function __construct(
+        public int $count,
+        public null|int $best_time_seconds,
+        public null|int $last_time_seconds,
+        public null|string $first_solved_at,
+        public null|string $last_solved_at,
+    ) {
+    }
+
+    public static function fromResult(PlayerPuzzleSolvesGroup $group): self
+    {
+        return new self(
+            count: $group->count,
+            best_time_seconds: $group->bestTimeSeconds,
+            last_time_seconds: $group->lastTimeSeconds,
+            first_solved_at: $group->firstSolvedAt?->format('c'),
+            last_solved_at: $group->lastSolvedAt?->format('c'),
+        );
+    }
+}

--- a/src/Api/V1/TimePredictionResponse.php
+++ b/src/Api/V1/TimePredictionResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use SpeedPuzzling\Web\Results\TimePredictionResult;
+
+/**
+ * The token owner's own predicted time for a puzzle (Puzzle Insights) -
+ * members-only and self-only, exactly as on the website. An endpoint returns
+ * null for this object when the owner is not entitled (not a member, opted out
+ * of time predictions, machine token, no results:read); when present, every
+ * field is null and is_personalized false if there is nothing to predict from.
+ */
+final class TimePredictionResponse
+{
+    public function __construct(
+        public null|int $predicted_seconds,
+        public null|int $range_low_seconds,
+        public null|int $range_high_seconds,
+        public bool $is_personalized,
+        public null|int $personal_solve_count,
+        public null|int $predicted_attempt_number,
+        public null|int $last_time_seconds,
+    ) {
+    }
+
+    public static function fromResult(null|TimePredictionResult $prediction): self
+    {
+        return new self(
+            predicted_seconds: $prediction?->predictedSeconds,
+            range_low_seconds: $prediction?->rangeLowSeconds,
+            range_high_seconds: $prediction?->rangeHighSeconds,
+            is_personalized: $prediction !== null && $prediction->isPersonalized,
+            personal_solve_count: $prediction?->personalSolveCount,
+            predicted_attempt_number: $prediction?->predictedAttemptNumber,
+            last_time_seconds: $prediction?->lastTimeSeconds,
+        );
+    }
+}

--- a/src/Component/GlobalSearch.php
+++ b/src/Component/GlobalSearch.php
@@ -9,6 +9,7 @@ use SpeedPuzzling\Web\Query\SearchPuzzle;
 use SpeedPuzzling\Web\Results\PiecesFilter;
 use SpeedPuzzling\Web\Results\PlayerIdentification;
 use SpeedPuzzling\Web\Results\PuzzleOverview;
+use SpeedPuzzling\Web\Value\PiecesRange;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
@@ -66,7 +67,7 @@ final class GlobalSearch
         $this->puzzle = $this->searchPuzzle->byUserInput(
             brandId: null,
             search: $query,
-            pieces: PiecesFilter::Any,
+            pieces: PiecesRange::fromFilter(PiecesFilter::Any),
             tag: null,
             limit: 15,
         );

--- a/src/Component/PuzzleSearch.php
+++ b/src/Component/PuzzleSearch.php
@@ -19,6 +19,7 @@ use SpeedPuzzling\Web\Results\UserPuzzleStatuses;
 use SpeedPuzzling\Web\Services\PuzzleFilterOptions;
 use SpeedPuzzling\Web\Services\RetrieveLoggedUserProfile;
 use SpeedPuzzling\Web\Value\DifficultyTier;
+use SpeedPuzzling\Web\Value\PiecesRange;
 use SpeedPuzzling\Web\Value\PuzzleSearchCriteria;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -188,7 +189,7 @@ final class PuzzleSearch
             return true;
         }
 
-        $piecesFilter = PiecesFilter::fromUserInput($this->criteria->pieces);
+        $piecesFilter = PiecesRange::fromFilter(PiecesFilter::fromUserInput($this->criteria->pieces));
 
         $this->totalCount = $this->searchPuzzle->countByUserInput(
             $this->criteria->brandId,
@@ -360,7 +361,7 @@ final class PuzzleSearch
     {
         return $this->cache->get('initial_puzzles_v2', function (ItemInterface $item): array {
             $item->expiresAfter(3600);
-            $pieces = PiecesFilter::fromUserInput(null);
+            $pieces = PiecesRange::fromFilter(PiecesFilter::fromUserInput(null));
 
             $puzzles = $this->searchPuzzle->byUserInput(null, null, $pieces, null, 'most-solved', 0);
             $puzzleIds = array_map(static fn (PuzzleOverview $puzzle): string => $puzzle->puzzleId, $puzzles);

--- a/src/Controller/BrandPuzzlesController.php
+++ b/src/Controller/BrandPuzzlesController.php
@@ -15,6 +15,7 @@ use SpeedPuzzling\Web\Results\BrandHubStats;
 use SpeedPuzzling\Web\Results\PiecesFilter;
 use SpeedPuzzling\Web\Results\PuzzleOverview;
 use SpeedPuzzling\Web\Services\RetrieveLoggedUserProfile;
+use SpeedPuzzling\Web\Value\PiecesRange;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -66,7 +67,7 @@ final class BrandPuzzlesController extends AbstractController
         $puzzles = $this->searchPuzzle->byUserInput(
             brandId: $stats->brandId,
             search: null,
-            pieces: PiecesFilter::Any,
+            pieces: PiecesRange::fromFilter(PiecesFilter::Any),
             tag: null,
             sortBy: 'most-solved',
             offset: 0,

--- a/src/Controller/PuzzleSearchItemsController.php
+++ b/src/Controller/PuzzleSearchItemsController.php
@@ -13,6 +13,7 @@ use SpeedPuzzling\Web\Query\SearchPuzzle;
 use SpeedPuzzling\Web\Results\PiecesFilter;
 use SpeedPuzzling\Web\Results\PuzzleOverview;
 use SpeedPuzzling\Web\Services\RetrieveLoggedUserProfile;
+use SpeedPuzzling\Web\Value\PiecesRange;
 use SpeedPuzzling\Web\Value\PuzzleSearchCriteria;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -63,7 +64,7 @@ final class PuzzleSearchItemsController extends AbstractController
         $rawOffset = $request->query->get('offset');
         $offset = is_numeric($rawOffset) ? max(0, (int) $rawOffset) : 0;
 
-        $piecesFilter = PiecesFilter::fromUserInput($criteria->pieces);
+        $piecesFilter = PiecesRange::fromFilter(PiecesFilter::fromUserInput($criteria->pieces));
 
         $totalCount = $this->searchPuzzle->countByUserInput(
             $criteria->brandId,

--- a/src/Controller/SearchPuzzleByEanController.php
+++ b/src/Controller/SearchPuzzleByEanController.php
@@ -53,19 +53,19 @@ final class SearchPuzzleByEanController extends AbstractController
 
         foreach ($puzzleResults as $result) {
             $puzzles[] = [
-                'id' => $result['puzzle_id'],
-                'name' => $result['puzzle_name'],
-                'piecesCount' => $result['pieces_count'],
-                'image' => $result['puzzle_image'],
-                'ean' => $result['puzzle_ean'],
+                'id' => $result->puzzleId,
+                'name' => $result->puzzleName,
+                'piecesCount' => $result->piecesCount,
+                'image' => $result->puzzleImage,
+                'ean' => $result->puzzleEan,
             ];
 
             // Add unique brands
-            if (!isset($seenBrandIds[$result['manufacturer_id']])) {
-                $seenBrandIds[$result['manufacturer_id']] = true;
+            if (!isset($seenBrandIds[$result->manufacturerId])) {
+                $seenBrandIds[$result->manufacturerId] = true;
                 $brands[] = [
-                    'id' => $result['manufacturer_id'],
-                    'name' => $result['manufacturer_name'],
+                    'id' => $result->manufacturerId,
+                    'name' => $result->manufacturerName,
                 ];
             }
         }

--- a/src/Query/GetPiecesHub.php
+++ b/src/Query/GetPiecesHub.php
@@ -99,8 +99,8 @@ SQL;
 
     /**
      * Most-solved puzzles with an exact piece count. Mirrors the row shape of
-     * SearchPuzzle::byUserInput (which cannot express exact piece counts
-     * outside its fixed filter buckets).
+     * SearchPuzzle::byUserInput (kept separate: a lean query for a cached hub
+     * page, no search / tag / difficulty machinery).
      *
      * @return list<PuzzleOverview>
      */

--- a/src/Query/GetPlayerPuzzleSolves.php
+++ b/src/Query/GetPlayerPuzzleSolves.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Query;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use SpeedPuzzling\Web\Results\PlayerPuzzleSolves;
+use SpeedPuzzling\Web\Results\PlayerPuzzleSolvesGroup;
+use SpeedPuzzling\Web\Value\PuzzlingType;
+
+/**
+ * One player's own solves of a list of puzzles, per discipline, in one query
+ * (the "solves" object of the public API's puzzle cards). The set of rows is
+ * the same as /me/results?type=: solo rows the player owns, duo and team rows
+ * the player took part in (team JSON containment, as GetPlayerSolvedPuzzles) -
+ * unboxed and suspicious-flagged times included, it is the player's own data.
+ * Times without seconds (relax solves) count as solves but carry no time.
+ */
+readonly final class GetPlayerPuzzleSolves
+{
+    public function __construct(
+        private Connection $database,
+    ) {
+    }
+
+    /**
+     * Puzzles the player has never solved are absent from the result; a
+     * discipline without solves is an empty group (count 0, nulls).
+     *
+     * @param list<string> $puzzleIds
+     *
+     * @return array<string, PlayerPuzzleSolves> keyed by puzzle id
+     */
+    public function forPuzzles(string $playerId, array $puzzleIds): array
+    {
+        if ($puzzleIds === []) {
+            return [];
+        }
+
+        $query = <<<SQL
+SELECT
+    pst.puzzle_id,
+    pst.puzzling_type,
+    count(*) AS solve_count,
+    min(pst.seconds_to_solve) AS best_seconds,
+    (array_agg(pst.seconds_to_solve ORDER BY COALESCE(pst.finished_at, pst.tracked_at) DESC, pst.tracked_at DESC)
+        FILTER (WHERE pst.seconds_to_solve IS NOT NULL))[1] AS last_seconds,
+    min(COALESCE(pst.finished_at, pst.tracked_at)) AS first_solved_at,
+    max(COALESCE(pst.finished_at, pst.tracked_at)) AS last_solved_at
+FROM puzzle_solving_time pst
+WHERE pst.puzzle_id IN (:puzzleIds)
+    AND (
+        (pst.puzzling_type = 'solo' AND pst.player_id = :playerId)
+        OR (
+            pst.puzzling_type IN ('duo', 'team')
+            AND pst.team IS NOT NULL
+            AND (pst.team::jsonb -> 'puzzlers') @> jsonb_build_array(jsonb_build_object('player_id', CAST(:playerId AS UUID)))
+        )
+    )
+GROUP BY pst.puzzle_id, pst.puzzling_type
+SQL;
+
+        /**
+         * @var list<array{
+         *     puzzle_id: string,
+         *     puzzling_type: string,
+         *     solve_count: int|string,
+         *     best_seconds: null|int|string,
+         *     last_seconds: null|int|string,
+         *     first_solved_at: null|string,
+         *     last_solved_at: null|string,
+         * }> $rows
+         */
+        $rows = $this->database->executeQuery(
+            $query,
+            ['playerId' => $playerId, 'puzzleIds' => $puzzleIds],
+            ['puzzleIds' => ArrayParameterType::STRING],
+        )->fetchAllAssociative();
+
+        /** @var array<string, array<string, PlayerPuzzleSolvesGroup>> $groups puzzle id → discipline → group */
+        $groups = [];
+
+        foreach ($rows as $row) {
+            $groups[$row['puzzle_id']][$row['puzzling_type']] = PlayerPuzzleSolvesGroup::fromDatabaseRow($row);
+        }
+
+        $solves = [];
+
+        foreach ($groups as $puzzleId => $byDiscipline) {
+            $solves[$puzzleId] = new PlayerPuzzleSolves(
+                puzzleId: $puzzleId,
+                solo: $byDiscipline[PuzzlingType::Solo->value] ?? PlayerPuzzleSolvesGroup::empty(),
+                duo: $byDiscipline[PuzzlingType::Duo->value] ?? PlayerPuzzleSolvesGroup::empty(),
+                team: $byDiscipline[PuzzlingType::Team->value] ?? PlayerPuzzleSolvesGroup::empty(),
+            );
+        }
+
+        return $solves;
+    }
+}

--- a/src/Query/GetPuzzleStatistics.php
+++ b/src/Query/GetPuzzleStatistics.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Query;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use SpeedPuzzling\Web\Results\PuzzleStatisticsResult;
+
+/**
+ * Community statistics of a list of puzzles in one query, from the
+ * precomputed puzzle_statistics table (the public API's puzzle cards; one
+ * batch call per list, whatever its size).
+ */
+readonly final class GetPuzzleStatistics
+{
+    public function __construct(
+        private Connection $database,
+    ) {
+    }
+
+    /**
+     * Puzzles without a statistics row (never solved) are absent from the result.
+     *
+     * @param list<string> $puzzleIds
+     *
+     * @return array<string, PuzzleStatisticsResult> keyed by puzzle id
+     */
+    public function forPuzzleList(array $puzzleIds): array
+    {
+        if ($puzzleIds === []) {
+            return [];
+        }
+
+        $query = <<<SQL
+SELECT
+    ps.puzzle_id,
+    ps.solved_times_count,
+    ps.solved_times_solo_count,
+    ps.fastest_time_solo,
+    ps.average_time_solo,
+    ps.slowest_time_solo,
+    ps.solved_times_duo_count,
+    ps.fastest_time_duo,
+    ps.average_time_duo,
+    ps.slowest_time_duo,
+    ps.solved_times_team_count,
+    ps.fastest_time_team,
+    ps.average_time_team,
+    ps.slowest_time_team
+FROM puzzle_statistics ps
+WHERE ps.puzzle_id IN (:puzzleIds)
+SQL;
+
+        /**
+         * @var list<array{
+         *     puzzle_id: string,
+         *     solved_times_count: int|string,
+         *     solved_times_solo_count: int|string,
+         *     fastest_time_solo: null|int|string,
+         *     average_time_solo: null|int|string,
+         *     slowest_time_solo: null|int|string,
+         *     solved_times_duo_count: int|string,
+         *     fastest_time_duo: null|int|string,
+         *     average_time_duo: null|int|string,
+         *     slowest_time_duo: null|int|string,
+         *     solved_times_team_count: int|string,
+         *     fastest_time_team: null|int|string,
+         *     average_time_team: null|int|string,
+         *     slowest_time_team: null|int|string,
+         * }> $rows
+         */
+        $rows = $this->database->executeQuery(
+            $query,
+            ['puzzleIds' => $puzzleIds],
+            ['puzzleIds' => ArrayParameterType::STRING],
+        )->fetchAllAssociative();
+
+        $statistics = [];
+
+        foreach ($rows as $row) {
+            $statistics[$row['puzzle_id']] = PuzzleStatisticsResult::fromDatabaseRow($row);
+        }
+
+        return $statistics;
+    }
+}

--- a/src/Query/SearchPuzzle.php
+++ b/src/Query/SearchPuzzle.php
@@ -10,8 +10,8 @@ use Psr\Clock\ClockInterface;
 use Ramsey\Uuid\Uuid;
 use SpeedPuzzling\Web\Exceptions\ManufacturerNotFound;
 use SpeedPuzzling\Web\Results\AutocompletePuzzle;
-use SpeedPuzzling\Web\Results\PiecesFilter;
 use SpeedPuzzling\Web\Results\PuzzleOverview;
+use SpeedPuzzling\Web\Value\PiecesRange;
 
 readonly final class SearchPuzzle
 {
@@ -22,15 +22,14 @@ readonly final class SearchPuzzle
     }
 
     /**
-     * @throws ManufacturerNotFound
-     */
-    /**
      * @param list<int> $difficultyTiers
+     *
+     * @throws ManufacturerNotFound
      */
     public function countByUserInput(
         null|string $brandId,
         null|string $search,
-        PiecesFilter $pieces,
+        PiecesRange $pieces,
         null|string $tag,
         array $difficultyTiers = [],
     ): int {
@@ -76,8 +75,8 @@ SQL;
             'searchFullLikeQuery' => "%$search%",
             'eanSearchFullLikeQuery' => "%$eanSearch%",
             'brandId' => $brandId,
-            'minPieces' => $pieces->minPieces(),
-            'maxPieces' => $pieces->maxPieces(),
+            'minPieces' => $pieces->minPieces,
+            'maxPieces' => $pieces->maxPieces,
             'useTags' => $tag !== null ? 1 : 0,
             'tag' => $tag ? [$tag] : [],
         ];
@@ -109,7 +108,7 @@ SQL;
     public function byUserInput(
         null|string $brandId,
         null|string $search,
-        PiecesFilter $pieces,
+        PiecesRange $pieces,
         null|string $tag,
         null|string $sortBy = null,
         int $offset = 0,
@@ -257,8 +256,8 @@ SQL;
             'eanSearchFullLikeQuery' => "%$eanSearch%",
             'brandId' => $brandId,
             'limit' => $limit,
-            'minPieces' => $pieces->minPieces(),
-            'maxPieces' => $pieces->maxPieces(),
+            'minPieces' => $pieces->minPieces,
+            'maxPieces' => $pieces->maxPieces,
             'offset' => $offset,
             'useTags' => $tag !== null ? 1 : 0,
             'tag' => $tag ? [$tag] : [],
@@ -308,10 +307,12 @@ SQL;
     }
 
     /**
-     * Search for all puzzles by EAN code.
-     * Strips leading zeros for flexible matching.
+     * Every puzzle whose barcode matches the given EAN, leading and trailing
+     * zeros tolerated on both sides (barcode scanners and typed-in codes differ
+     * in exactly that). Secret competition puzzles (hide_until in the future)
+     * are never returned; an embargoed image (hide_image_until) comes back null.
      *
-     * @return array<array{puzzle_id: string, puzzle_name: string, puzzle_image: null|string, puzzle_image_ratio: null|string, puzzle_ean: null|string, pieces_count: int, manufacturer_id: string, manufacturer_name: string}>
+     * @return list<PuzzleOverview>
      */
     public function allByEan(string $ean): array
     {
@@ -328,16 +329,31 @@ SELECT
     puzzle.name AS puzzle_name,
     CASE WHEN puzzle.hide_image_until IS NOT NULL AND puzzle.hide_image_until > :now::timestamp THEN NULL ELSE puzzle.image END AS puzzle_image,
     CASE WHEN puzzle.hide_image_until IS NOT NULL AND puzzle.hide_image_until > :now::timestamp THEN NULL ELSE puzzle.image_ratio END AS puzzle_image_ratio,
-    puzzle.ean AS puzzle_ean,
+    puzzle.alternative_name AS puzzle_alternative_name,
     puzzle.pieces_count,
+    puzzle.is_available,
+    puzzle.approved AS puzzle_approved,
+    puzzle.ean AS puzzle_ean,
+    puzzle.identification_number AS puzzle_identification_number,
+    puzzle.hide_image_until,
     manufacturer.id AS manufacturer_id,
-    manufacturer.name AS manufacturer_name
+    manufacturer.name AS manufacturer_name,
+    COALESCE(ps.solved_times_count, 0) AS solved_times,
+    ps.average_time_solo,
+    ps.fastest_time_solo,
+    ps.average_time_duo,
+    ps.fastest_time_duo,
+    ps.average_time_team,
+    ps.fastest_time_team
 FROM puzzle
 INNER JOIN manufacturer ON puzzle.manufacturer_id = manufacturer.id
-WHERE puzzle.ean LIKE :eanPattern
+LEFT JOIN puzzle_statistics ps ON ps.puzzle_id = puzzle.id
+WHERE
+    puzzle.ean LIKE :eanPattern
+    AND (puzzle.hide_until IS NULL OR puzzle.hide_until <= :now::timestamp)
+ORDER BY solved_times DESC, puzzle.name, manufacturer.name
 SQL;
 
-        /** @var array<array{puzzle_id: string, puzzle_name: string, puzzle_image: null|string, puzzle_image_ratio: null|string, puzzle_ean: null|string, pieces_count: int, manufacturer_id: string, manufacturer_name: string}> $rows */
         $rows = $this->database
             ->executeQuery($query, [
                 'now' => $this->clock->now()->format('Y-m-d H:i:s'),
@@ -345,7 +361,34 @@ SQL;
             ])
             ->fetchAllAssociative();
 
-        return $rows;
+        return array_map(static function (array $row): PuzzleOverview {
+            /**
+             * @var array{
+             *     puzzle_id: string,
+             *     puzzle_name: string,
+             *     puzzle_image: null|string,
+             *     puzzle_image_ratio: null|string,
+             *     puzzle_alternative_name: null|string,
+             *     puzzle_approved: bool,
+             *     manufacturer_name: string,
+             *     manufacturer_id: string,
+             *     pieces_count: int,
+             *     average_time_solo: null|string,
+             *     fastest_time_solo: null|int,
+             *     average_time_duo: null|string,
+             *     fastest_time_duo: null|int,
+             *     average_time_team: null|string,
+             *     fastest_time_team: null|int,
+             *     solved_times: int,
+             *     is_available: bool,
+             *     puzzle_ean: null|string,
+             *     puzzle_identification_number: null|string,
+             *     hide_image_until: null|string,
+             * } $row
+             */
+
+            return PuzzleOverview::fromDatabaseRow($row);
+        }, $rows);
     }
 
     /**

--- a/src/Results/PlayerPuzzleSolves.php
+++ b/src/Results/PlayerPuzzleSolves.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Results;
+
+/**
+ * One player's own history on one puzzle, always split by discipline - solo,
+ * duo and team are different disciplines on MySpeedPuzzling and are never
+ * merged (the same split as /me/statistics and /me/results?type=).
+ */
+readonly final class PlayerPuzzleSolves
+{
+    public function __construct(
+        public string $puzzleId,
+        public PlayerPuzzleSolvesGroup $solo,
+        public PlayerPuzzleSolvesGroup $duo,
+        public PlayerPuzzleSolvesGroup $team,
+    ) {
+    }
+
+    public static function empty(string $puzzleId): self
+    {
+        return new self(
+            puzzleId: $puzzleId,
+            solo: PlayerPuzzleSolvesGroup::empty(),
+            duo: PlayerPuzzleSolvesGroup::empty(),
+            team: PlayerPuzzleSolvesGroup::empty(),
+        );
+    }
+}

--- a/src/Results/PlayerPuzzleSolvesGroup.php
+++ b/src/Results/PlayerPuzzleSolvesGroup.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Results;
+
+use DateTimeImmutable;
+
+/**
+ * One player's solves of one puzzle in one discipline (solo, duo or team):
+ * how many, the best and the most recent time, when the first and the last
+ * one happened. "When" is COALESCE(finished_at, tracked_at), as everywhere else.
+ */
+readonly final class PlayerPuzzleSolvesGroup
+{
+    public function __construct(
+        public int $count,
+        public null|int $bestTimeSeconds,
+        public null|int $lastTimeSeconds,
+        public null|DateTimeImmutable $firstSolvedAt,
+        public null|DateTimeImmutable $lastSolvedAt,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self(
+            count: 0,
+            bestTimeSeconds: null,
+            lastTimeSeconds: null,
+            firstSolvedAt: null,
+            lastSolvedAt: null,
+        );
+    }
+
+    /**
+     * @param array{
+     *     solve_count: int|string,
+     *     best_seconds: null|int|string,
+     *     last_seconds: null|int|string,
+     *     first_solved_at: null|string,
+     *     last_solved_at: null|string,
+     *     ...
+     * } $row
+     */
+    public static function fromDatabaseRow(array $row): self
+    {
+        return new self(
+            count: (int) $row['solve_count'],
+            bestTimeSeconds: $row['best_seconds'] !== null ? (int) $row['best_seconds'] : null,
+            lastTimeSeconds: $row['last_seconds'] !== null ? (int) $row['last_seconds'] : null,
+            firstSolvedAt: $row['first_solved_at'] !== null ? new DateTimeImmutable($row['first_solved_at']) : null,
+            lastSolvedAt: $row['last_solved_at'] !== null ? new DateTimeImmutable($row['last_solved_at']) : null,
+        );
+    }
+}

--- a/src/Results/PuzzleDisciplineStatistics.php
+++ b/src/Results/PuzzleDisciplineStatistics.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Results;
+
+/**
+ * Community statistics of one puzzle in one discipline (solo, duo or team),
+ * from the precomputed puzzle_statistics row. Seconds; null when nobody has
+ * solved the puzzle in that discipline yet.
+ */
+readonly final class PuzzleDisciplineStatistics
+{
+    public function __construct(
+        public int $count,
+        public null|int $fastestSeconds,
+        public null|int $averageSeconds,
+        public null|int $slowestSeconds,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self(
+            count: 0,
+            fastestSeconds: null,
+            averageSeconds: null,
+            slowestSeconds: null,
+        );
+    }
+}

--- a/src/Results/PuzzleStatisticsResult.php
+++ b/src/Results/PuzzleStatisticsResult.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Results;
+
+/**
+ * Community statistics of one puzzle, always split by discipline - solo, duo
+ * and team are different disciplines and are never merged; solvedTimes is the
+ * total across them.
+ */
+readonly final class PuzzleStatisticsResult
+{
+    public function __construct(
+        public string $puzzleId,
+        public int $solvedTimes,
+        public PuzzleDisciplineStatistics $solo,
+        public PuzzleDisciplineStatistics $duo,
+        public PuzzleDisciplineStatistics $team,
+    ) {
+    }
+
+    /**
+     * A puzzle nobody has solved has no puzzle_statistics row at all.
+     */
+    public static function empty(string $puzzleId): self
+    {
+        return new self(
+            puzzleId: $puzzleId,
+            solvedTimes: 0,
+            solo: PuzzleDisciplineStatistics::empty(),
+            duo: PuzzleDisciplineStatistics::empty(),
+            team: PuzzleDisciplineStatistics::empty(),
+        );
+    }
+
+    /**
+     * @param array{
+     *     puzzle_id: string,
+     *     solved_times_count: int|string,
+     *     solved_times_solo_count: int|string,
+     *     fastest_time_solo: null|int|string,
+     *     average_time_solo: null|int|string,
+     *     slowest_time_solo: null|int|string,
+     *     solved_times_duo_count: int|string,
+     *     fastest_time_duo: null|int|string,
+     *     average_time_duo: null|int|string,
+     *     slowest_time_duo: null|int|string,
+     *     solved_times_team_count: int|string,
+     *     fastest_time_team: null|int|string,
+     *     average_time_team: null|int|string,
+     *     slowest_time_team: null|int|string,
+     * } $row
+     */
+    public static function fromDatabaseRow(array $row): self
+    {
+        return new self(
+            puzzleId: $row['puzzle_id'],
+            solvedTimes: (int) $row['solved_times_count'],
+            solo: new PuzzleDisciplineStatistics(
+                count: (int) $row['solved_times_solo_count'],
+                fastestSeconds: self::seconds($row['fastest_time_solo']),
+                averageSeconds: self::seconds($row['average_time_solo']),
+                slowestSeconds: self::seconds($row['slowest_time_solo']),
+            ),
+            duo: new PuzzleDisciplineStatistics(
+                count: (int) $row['solved_times_duo_count'],
+                fastestSeconds: self::seconds($row['fastest_time_duo']),
+                averageSeconds: self::seconds($row['average_time_duo']),
+                slowestSeconds: self::seconds($row['slowest_time_duo']),
+            ),
+            team: new PuzzleDisciplineStatistics(
+                count: (int) $row['solved_times_team_count'],
+                fastestSeconds: self::seconds($row['fastest_time_team']),
+                averageSeconds: self::seconds($row['average_time_team']),
+                slowestSeconds: self::seconds($row['slowest_time_team']),
+            ),
+        );
+    }
+
+    private static function seconds(null|int|string $value): null|int
+    {
+        return $value === null ? null : (int) $value;
+    }
+}

--- a/src/Services/Api/ApiTokenOwner.php
+++ b/src/Services/Api/ApiTokenOwner.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Services\Api;
+
+use SpeedPuzzling\Web\Exceptions\PlayerNotFound;
+use SpeedPuzzling\Web\Query\GetPlayerProfile;
+use SpeedPuzzling\Web\Results\PlayerProfile;
+use SpeedPuzzling\Web\Security\ApiUser;
+use SpeedPuzzling\Web\Security\PatUser;
+use SpeedPuzzling\Web\Value\OAuth2Scope;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * The single membership / scope gate of the public API: who is behind the
+ * token making this request, and what are they entitled to see.
+ *
+ * A personal access token and an authorization-code token carry a player
+ * (ApiUser); a client_credentials token authenticates as the bundle's
+ * ClientCredentialsUser and carries none - it is never a member and never
+ * sees personal data. Members-exclusive data behaves exactly as on the
+ * website (docs/features/api/README.md, Members-Exclusive Data), so every
+ * provider asks this service instead of inspecting the token itself.
+ *
+ * The profile lookup is one query, memoised for the request; FrankenPHP
+ * worker mode keeps the instance alive between requests, reset() clears it.
+ */
+final class ApiTokenOwner implements ResetInterface
+{
+    private bool $profileLoaded = false;
+
+    private null|PlayerProfile $profile = null;
+
+    public function __construct(
+        private readonly Security $security,
+        private readonly GetPlayerProfile $getPlayerProfile,
+    ) {
+    }
+
+    public function reset(): void
+    {
+        $this->profileLoaded = false;
+        $this->profile = null;
+    }
+
+    /**
+     * The player behind the token, or null for a machine token (client_credentials)
+     * and for an anonymous request. Never throws.
+     */
+    public function profile(): null|PlayerProfile
+    {
+        if ($this->profileLoaded) {
+            return $this->profile;
+        }
+
+        $this->profileLoaded = true;
+        $user = $this->security->getUser();
+
+        if (!$user instanceof ApiUser) {
+            return $this->profile = null;
+        }
+
+        try {
+            return $this->profile = $this->getPlayerProfile->byId($user->getPlayer()->id->toString());
+        } catch (PlayerNotFound) {
+            return $this->profile = null;
+        }
+    }
+
+    /**
+     * Active membership of the token owner - the gate for Puzzle Insights
+     * (difficulty, predictions, skill tiers). A machine token is never a member.
+     */
+    public function isMember(): bool
+    {
+        return $this->profile()?->activeMembership === true;
+    }
+
+    /**
+     * May the token read the owner's own results? PAT always, OAuth2 with results:read.
+     */
+    public function canReadResults(): bool
+    {
+        return $this->security->isGranted(PatUser::ROLE)
+            || $this->security->isGranted(OAuth2Scope::ResultsRead->role());
+    }
+
+    /**
+     * May the token read the owner's own statistics? PAT always, OAuth2 with statistics:read.
+     */
+    public function canReadStatistics(): bool
+    {
+        return $this->security->isGranted(PatUser::ROLE)
+            || $this->security->isGranted(OAuth2Scope::StatisticsRead->role());
+    }
+}

--- a/src/Services/Api/PuzzleResponseFactory.php
+++ b/src/Services/Api/PuzzleResponseFactory.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Services\Api;
+
+use SpeedPuzzling\Web\Api\V1\PlayerSolvesResponse;
+use SpeedPuzzling\Web\Api\V1\PuzzleDifficultyResponse;
+use SpeedPuzzling\Web\Api\V1\PuzzleManufacturerResponse;
+use SpeedPuzzling\Web\Api\V1\PuzzleResponse;
+use SpeedPuzzling\Web\Api\V1\PuzzleStatisticsResponse;
+use SpeedPuzzling\Web\Api\V1\TimePredictionResponse;
+use SpeedPuzzling\Web\Query\GetPlayerPredictions;
+use SpeedPuzzling\Web\Query\GetPlayerPuzzleSolves;
+use SpeedPuzzling\Web\Query\GetPuzzleDifficulty;
+use SpeedPuzzling\Web\Query\GetPuzzleStatistics;
+use SpeedPuzzling\Web\Results\PlayerPuzzleSolves;
+use SpeedPuzzling\Web\Results\PuzzleOverview;
+use SpeedPuzzling\Web\Results\PuzzleStatisticsResult;
+
+/**
+ * Builds the public API's puzzle cards for the calling token, at a fixed
+ * query cost: whatever the list size, one batch query for the community
+ * statistics (GetPuzzleStatistics::forPuzzleList) and at most one per insight
+ * object - difficulty (GetPuzzleDifficulty::forPuzzleList), the owner's
+ * predictions (GetPlayerPredictions::forPuzzles, itself at most 4 queries) and
+ * the owner's solves (GetPlayerPuzzleSolves::forPuzzles) - each of the latter
+ * only when the token is entitled to the object at all. What the token is not
+ * entitled to is null on every card, never an error (plan §0 N1/N3).
+ *
+ * Gates (docs/features/api/README.md, Members-Exclusive Data):
+ *   difficulty  - token owner is a member
+ *   prediction  - owner is a member, has not opted out of time predictions,
+ *                 and the token may read results (PAT or results:read)
+ *   solves      - there is an owner and the token may read results
+ */
+final readonly class PuzzleResponseFactory
+{
+    public function __construct(
+        private ApiTokenOwner $tokenOwner,
+        private GetPuzzleStatistics $getPuzzleStatistics,
+        private GetPuzzleDifficulty $getPuzzleDifficulty,
+        private GetPlayerPredictions $getPlayerPredictions,
+        private GetPlayerPuzzleSolves $getPlayerPuzzleSolves,
+    ) {
+    }
+
+    /**
+     * @param list<PuzzleOverview> $overviews
+     *
+     * @return list<PuzzleResponse> in the same order
+     */
+    public function cards(array $overviews): array
+    {
+        if ($overviews === []) {
+            return [];
+        }
+
+        $puzzleIds = array_map(static fn (PuzzleOverview $overview): string => $overview->puzzleId, $overviews);
+
+        $profile = $this->tokenOwner->profile();
+        $isMember = $this->tokenOwner->isMember();
+        $canReadResults = $this->tokenOwner->canReadResults();
+
+        // public, always; a puzzle nobody has solved has no row
+        $statistics = $this->getPuzzleStatistics->forPuzzleList($puzzleIds);
+
+        // null = not entitled (the object is null on every card); array = entitled,
+        // keyed by puzzle id, with a default synthesised for ids the query did not return
+        $difficulties = $isMember
+            ? $this->getPuzzleDifficulty->forPuzzleList($puzzleIds)
+            : null;
+
+        $predictions = $profile !== null && $isMember && $profile->timePredictionsOptedOut === false && $canReadResults
+            ? $this->getPlayerPredictions->forPuzzles($profile->playerId, $puzzleIds)
+            : null;
+
+        $solves = $profile !== null && $canReadResults
+            ? $this->getPlayerPuzzleSolves->forPuzzles($profile->playerId, $puzzleIds)
+            : null;
+
+        $cards = [];
+
+        foreach ($overviews as $overview) {
+            $puzzleId = $overview->puzzleId;
+
+            $cards[] = new PuzzleResponse(
+                id: $puzzleId,
+                name: $overview->puzzleName,
+                alternative_name: $overview->puzzleAlternativeName,
+                manufacturer: new PuzzleManufacturerResponse(
+                    id: $overview->manufacturerId,
+                    name: $overview->manufacturerName,
+                ),
+                pieces_count: $overview->piecesCount,
+                image: $overview->puzzleImage,
+                ean: $overview->puzzleEan,
+                identification_number: $overview->puzzleIdentificationNumber,
+                is_available: $overview->isAvailable,
+                is_approved: $overview->puzzleApproved,
+                statistics: PuzzleStatisticsResponse::fromResult($statistics[$puzzleId] ?? PuzzleStatisticsResult::empty($puzzleId)),
+                difficulty: $difficulties === null
+                    ? null
+                    : (isset($difficulties[$puzzleId]) ? PuzzleDifficultyResponse::fromResult($difficulties[$puzzleId]) : PuzzleDifficultyResponse::insufficient()),
+                prediction: $predictions === null
+                    ? null
+                    : TimePredictionResponse::fromResult($predictions[$puzzleId] ?? null),
+                solves: $solves === null
+                    ? null
+                    : PlayerSolvesResponse::fromResult($solves[$puzzleId] ?? PlayerPuzzleSolves::empty($puzzleId)),
+            );
+        }
+
+        return $cards;
+    }
+
+    public function card(PuzzleOverview $overview): PuzzleResponse
+    {
+        return $this->cards([$overview])[0];
+    }
+}

--- a/src/Value/DifficultyTier.php
+++ b/src/Value/DifficultyTier.php
@@ -14,19 +14,29 @@ enum DifficultyTier: int
     case VeryHard = 6;
 
     /**
-     * Stable lowercase token for the public API (the website keys its icons and
-     * translations off strtolower(name), which is not a good wire format).
+     * Stable lowercase tokens for the public API, in tier order (index + 1 =
+     * tier value). The website keys its icons and translations off
+     * strtolower(name), which is not a good wire format. A list constant so
+     * that API parameter declarations (attributes) can reference the enum.
+     *
+     * @var list<string>
      */
+    public const array API_VALUES = ['very_easy', 'easy', 'average', 'challenging', 'hard', 'very_hard'];
+
     public function toApiValue(): string
     {
-        return match ($this) {
-            self::VeryEasy => 'very_easy',
-            self::Easy => 'easy',
-            self::Average => 'average',
-            self::Challenging => 'challenging',
-            self::Hard => 'hard',
-            self::VeryHard => 'very_hard',
-        };
+        return self::API_VALUES[$this->value - 1];
+    }
+
+    /**
+     * Inverse of toApiValue(): the tier for a public API token, null for
+     * anything that is not one (the API reports that as a validation error).
+     */
+    public static function fromApiValue(string $value): null|self
+    {
+        $index = array_search($value, self::API_VALUES, true);
+
+        return $index === false ? null : self::from($index + 1);
     }
 
     public static function fromScore(float $score): self

--- a/src/Value/PiecesRange.php
+++ b/src/Value/PiecesRange.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Value;
+
+use InvalidArgumentException;
+use SpeedPuzzling\Web\Results\PiecesFilter;
+
+/**
+ * Inclusive piece-count bounds for the puzzle search. A null bound means
+ * "unbounded on that side"; an exact count is both bounds equal.
+ *
+ * The website only ever needs the handful of ranges PiecesFilter enumerates,
+ * the API lets clients pick arbitrary bounds - both end up here, so SearchPuzzle
+ * has one notion of a piece-count filter.
+ */
+final readonly class PiecesRange
+{
+    private function __construct(
+        public null|int $minPieces,
+        public null|int $maxPieces,
+    ) {
+    }
+
+    public static function any(): self
+    {
+        return new self(null, null);
+    }
+
+    /**
+     * @throws InvalidArgumentException when the bounds contradict each other
+     */
+    public static function between(null|int $minPieces, null|int $maxPieces): self
+    {
+        if ($minPieces !== null && $maxPieces !== null && $minPieces > $maxPieces) {
+            throw new InvalidArgumentException(sprintf('Minimum %d is above maximum %d.', $minPieces, $maxPieces));
+        }
+
+        return new self($minPieces, $maxPieces);
+    }
+
+    public static function fromFilter(PiecesFilter $filter): self
+    {
+        return match ($filter) {
+            PiecesFilter::Any => self::any(),
+            PiecesFilter::UpTo499 => new self(1, 499),
+            PiecesFilter::Exactly500 => new self(500, 500),
+            PiecesFilter::UpTo999 => new self(501, 999),
+            PiecesFilter::Exactly1000 => new self(1000, 1000),
+            PiecesFilter::MoreThan1000 => new self(1001, null),
+        };
+    }
+
+    public function isUnbounded(): bool
+    {
+        return $this->minPieces === null && $this->maxPieces === null;
+    }
+}

--- a/templates/for-developers.html.twig
+++ b/templates/for-developers.html.twig
@@ -345,6 +345,13 @@ HTTP/1.1 200 OK
                             <td class="text-center text-success"><i class="bi bi-check-lg"></i></td>
                             <td class="text-center text-success"><i class="bi bi-check-lg"></i></td>
                         </tr>
+                        <tr><td colspan="4" class="ps-3 fw-bold bg-light text-muted fs-sm pt-2 pb-1">{{ 'for_developers.table_section_puzzles'|trans }}</td></tr>
+                        <tr>
+                            <td class="ps-3"><code class="fs-sm">GET /api/v1/puzzles</code></td>
+                            <td class="text-center text-success"><i class="bi bi-check-lg"></i></td>
+                            <td class="text-center text-success"><i class="bi bi-check-lg"></i></td>
+                            <td class="text-center text-success"><i class="bi bi-check-lg"></i></td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/tests/Controller/Api/V1/PuzzleSearchEndpointTest.php
+++ b/tests/Controller/Api/V1/PuzzleSearchEndpointTest.php
@@ -1,0 +1,1069 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SpeedPuzzling\Web\Entity\Player;
+use SpeedPuzzling\Web\Entity\Puzzle;
+use SpeedPuzzling\Web\Entity\PuzzleDifficulty;
+use SpeedPuzzling\Web\Tests\DataFixtures\ManufacturerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
+use SpeedPuzzling\Web\Tests\OpenApiAssertions;
+use SpeedPuzzling\Web\Tests\PatTestHelper;
+use SpeedPuzzling\Web\Tests\QueryCountAssertions;
+use SpeedPuzzling\Web\Value\MetricConfidence;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+/**
+ * GET /api/v1/puzzles - catalog search and barcode lookup, with the puzzle
+ * cards' insight objects gated per token owner exactly as on the website.
+ *
+ * Fixtures (.claude/fixtures.md): PLAYER_WITH_STRIPE and PLAYER_ADMIN are
+ * members; PLAYER_REGULAR is not. PLAYER_WITH_STRIPE has one solo solve of
+ * PUZZLE_500_01 (2100 s); PLAYER_REGULAR has three solo solves of PUZZLE_500_02
+ * (2200, 1900, 1700 s) and a duo solve of PUZZLE_1000_01. PUZZLE_500_02 carries
+ * the EAN 4005556123456, PUZZLE_500_01 the identification number RB-500-001.
+ * Difficulty rows are seeded per test - the intelligence recalculation is batch.
+ *
+ * @phpstan-type StatisticsGroup array{count: int, fastest_seconds: null|int, average_seconds: null|int, slowest_seconds: null|int}
+ * @phpstan-type SolvesGroup array{count: int, best_time_seconds: null|int, last_time_seconds: null|int, first_solved_at: null|string, last_solved_at: null|string}
+ * @phpstan-type Card array{
+ *     id: string,
+ *     name: string,
+ *     alternative_name: null|string,
+ *     manufacturer: array{id: string, name: string},
+ *     pieces_count: int,
+ *     image: null|string,
+ *     ean: null|string,
+ *     identification_number: null|string,
+ *     is_available: bool,
+ *     is_approved: bool,
+ *     statistics: array{solved_times: int, solo: StatisticsGroup, duo: StatisticsGroup, team: StatisticsGroup},
+ *     difficulty: null|array{score: null|float, level: null|string, confidence: string, sample_size: int},
+ *     prediction: null|array{predicted_seconds: null|int, range_low_seconds: null|int, range_high_seconds: null|int, is_personalized: bool, personal_solve_count: null|int, predicted_attempt_number: null|int, last_time_seconds: null|int},
+ *     solves: null|array{solo: SolvesGroup, duo: SolvesGroup, team: SolvesGroup},
+ * }
+ * @phpstan-type ListResponse array{count: int, total: int, page: int, limit: int, has_more: bool, puzzles: list<Card>}
+ * @phpstan-type Problem array{detail: string, violations?: list<array{propertyPath: string, message: string}>}
+ */
+final class PuzzleSearchEndpointTest extends WebTestCase
+{
+    use OpenApiAssertions;
+    use QueryCountAssertions;
+
+    private const string ENDPOINT = '/api/v1/puzzles';
+
+    /** @var list<string> */
+    private const array PARAMETER_NAMES = ['query', 'ean', 'manufacturer', 'pieces_min', 'pieces_max', 'sort', 'difficulty', 'page', 'limit'];
+
+    /** @var list<string> every limiter key a test of this class consumes from */
+    private const array LIMITER_KEYS = [
+        PlayerFixture::PLAYER_REGULAR,
+        PlayerFixture::PLAYER_WITH_STRIPE,
+        PlayerFixture::PLAYER_ADMIN,
+        OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+    ];
+
+    public function testAnonymousRequestIsUnauthorized(): void
+    {
+        $browser = $this->createApiClient();
+
+        $browser->request('GET', self::ENDPOINT);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testPersonalAccessTokenCanSearch(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => 'Puzzle 1']);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertGreaterThan(0, $response['count']);
+        $this->assertSame(1, $response['page']);
+        $this->assertSame(20, $response['limit']);
+    }
+
+    public function testAuthorizationCodeTokenWithProfileScopeOnlyCanSearch(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => 'Puzzle 1']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertGreaterThan(0, $this->decode($browser)['count']);
+    }
+
+    /**
+     * A machine token has no player behind it: it sees the catalog, and every
+     * insight object is null - accepted, never an error, so one client code
+     * path works for every token.
+     */
+    public function testClientCredentialsTokenSearchesButGetsNoInsights(): void
+    {
+        $browser = $this->createApiClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 1.18, MetricConfidence::Medium);
+        $this->authenticateClientCredentials($browser);
+
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertSame(1, $response['count']);
+        $puzzle = $response['puzzles'][0];
+        $this->assertSame(PuzzleFixture::PUZZLE_500_02, $puzzle['id']);
+        $this->assertNull($puzzle['difficulty']);
+        $this->assertNull($puzzle['prediction']);
+        $this->assertNull($puzzle['solves']);
+    }
+
+    public function testQueryFindsPuzzlesByName(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => 'Puzzle 1', 'limit' => 100]);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $ids = $this->ids($response);
+        $this->assertContains(PuzzleFixture::PUZZLE_500_01, $ids); // "Puzzle 1"
+        $this->assertContains(PuzzleFixture::PUZZLE_1000_05, $ids); // "Puzzle 10"
+        $this->assertNotContains(PuzzleFixture::PUZZLE_500_02, $ids); // "Puzzle 2"
+
+        foreach ($response['puzzles'] as $puzzle) {
+            $this->assertStringContainsStringIgnoringCase('Puzzle 1', $puzzle['name']);
+        }
+    }
+
+    public function testQueryMatchesIdentificationNumberAndIsAccentInsensitive(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => 'RB-500-001']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([PuzzleFixture::PUZZLE_500_01], $this->ids($this->decode($browser)));
+
+        // "Püzzle 1" finds "Puzzle 1" - the same accent-insensitive matching as the website search box
+        $browser->request('GET', self::ENDPOINT, ['query' => 'Püzzle 1', 'limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $this->assertContains(PuzzleFixture::PUZZLE_500_01, $this->ids($this->decode($browser)));
+    }
+
+    public function testEanLookupIsExactWithZeroTolerance(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertSame(1, $response['count']);
+        $this->assertSame(1, $response['total']);
+        $this->assertFalse($response['has_more']);
+        $this->assertSame(PuzzleFixture::PUZZLE_500_02, $response['puzzles'][0]['id']);
+        $this->assertSame('4005556123456', $response['puzzles'][0]['ean']);
+
+        // a leading zero (UPC-A read as EAN-13) still finds it
+        $browser->request('GET', self::ENDPOINT, ['ean' => '04005556123456']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([PuzzleFixture::PUZZLE_500_02], $this->ids($this->decode($browser)));
+
+        // a barcode nobody has registered
+        $browser->request('GET', self::ENDPOINT, ['ean' => '9999999999999']);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame(0, $response['count']);
+        $this->assertSame(0, $response['total']);
+        $this->assertSame([], $response['puzzles']);
+    }
+
+    public function testEanCannotBeCombinedWithOtherFilters(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456', 'query' => 'Puzzle']);
+
+        $this->assertUnprocessableWithViolationOn($browser, 'ean');
+        $this->assertStringContainsString('query', $this->decodeProblem($browser)['violations'][0]['message'] ?? '');
+
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456', 'sort' => 'a-z']);
+        $this->assertUnprocessableWithViolationOn($browser, 'ean');
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>, string}>
+     */
+    public static function invalidParameters(): iterable
+    {
+        yield 'query too short' => [['query' => 'a'], 'query'];
+        yield 'query too long' => [['query' => str_repeat('x', 101)], 'query'];
+        yield 'query whitespace only counts as too short' => [['query' => '   a   '], 'query'];
+        yield 'ean with letters' => [['ean' => '40055561234ab'], 'ean'];
+        yield 'ean too short' => [['ean' => '1234567'], 'ean'];
+        yield 'ean too long' => [['ean' => '123456789012345'], 'ean'];
+        yield 'manufacturer not a uuid' => [['manufacturer' => 'ravensburger'], 'manufacturer'];
+        yield 'pieces_min below 1' => [['pieces_min' => '0'], 'pieces_min'];
+        yield 'pieces_min not an integer' => [['pieces_min' => 'abc'], 'pieces_min'];
+        yield 'pieces_max above 50000' => [['pieces_max' => '50001'], 'pieces_max'];
+        yield 'sort unknown' => [['sort' => 'newest'], 'sort'];
+        yield 'difficulty unknown tier' => [['difficulty' => 'impossible'], 'difficulty'];
+        yield 'difficulty one unknown tier in a list' => [['difficulty' => 'hard,impossible'], 'difficulty'];
+        yield 'page below 1' => [['page' => '0'], 'page'];
+        yield 'page above 500' => [['page' => '501'], 'page'];
+        yield 'page not an integer' => [['page' => 'two'], 'page'];
+        yield 'limit below 1' => [['limit' => '0'], 'limit'];
+        yield 'limit above 100' => [['limit' => '101'], 'limit'];
+        yield 'limit not an integer' => [['limit' => '2.5'], 'limit'];
+    }
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    #[DataProvider('invalidParameters')]
+    public function testInvalidParameterIsRejected(array $parameters, string $expectedPropertyPath): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, $parameters);
+
+        $this->assertUnprocessableWithViolationOn($browser, $expectedPropertyPath);
+    }
+
+    public function testPiecesMinAbovePiecesMaxIsRejected(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['pieces_min' => '1000', 'pieces_max' => '500']);
+
+        $this->assertUnprocessableWithViolationOn($browser, 'pieces_min');
+    }
+
+    public function testPiecesRangeFiltersByPieceCount(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        // exact count = both bounds equal
+        $browser->request('GET', self::ENDPOINT, ['pieces_min' => '500', 'pieces_max' => '500', 'limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertGreaterThanOrEqual(5, $response['count']);
+        foreach ($response['puzzles'] as $puzzle) {
+            $this->assertSame(500, $puzzle['pieces_count']);
+        }
+
+        // open-ended range
+        $browser->request('GET', self::ENDPOINT, ['pieces_min' => '2000', 'limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertGreaterThan(0, $response['count']);
+        foreach ($response['puzzles'] as $puzzle) {
+            $this->assertGreaterThanOrEqual(2000, $puzzle['pieces_count']);
+        }
+    }
+
+    public function testManufacturerFilter(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['manufacturer' => ManufacturerFixture::MANUFACTURER_TREFL, 'limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertGreaterThan(0, $response['count']);
+        foreach ($response['puzzles'] as $puzzle) {
+            $this->assertSame(ManufacturerFixture::MANUFACTURER_TREFL, $puzzle['manufacturer']['id']);
+            $this->assertSame('Trefl', $puzzle['manufacturer']['name']);
+        }
+
+        // unknown brand: empty result, not 404
+        $browser->request('GET', self::ENDPOINT, ['manufacturer' => '00000000-0000-0000-0000-000000000000']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(0, $this->decode($browser)['total']);
+    }
+
+    public function testDifficultySortRequiresMembership(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['sort' => 'easiest']);
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertStringContainsString('membership', $this->decodeProblem($browser)['detail']);
+
+        $browser->request('GET', self::ENDPOINT, ['sort' => 'hardest']);
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+
+        // a machine token is never a member either
+        $this->authenticateClientCredentials($browser);
+        $browser->request('GET', self::ENDPOINT, ['sort' => 'easiest']);
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+
+        // the non-premium sorts are for everyone
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+        $browser->request('GET', self::ENDPOINT, ['sort' => 'a-z']);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testMemberCanSortByDifficulty(): void
+    {
+        $browser = $this->createApiClient();
+        // Other fixture puzzles carry scores around 1.0 - these three sit clearly below and above them
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 0.50, MetricConfidence::High);
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_03, 0.60, MetricConfidence::High);
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_01, 5.00, MetricConfidence::High);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        $browser->request('GET', self::ENDPOINT, ['sort' => 'easiest', 'limit' => 2]);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame([PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_03], $this->ids($response));
+        $this->assertSame(0.5, $response['puzzles'][0]['difficulty']['score'] ?? null);
+
+        $browser->request('GET', self::ENDPOINT, ['sort' => 'hardest', 'limit' => 2]);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame(PuzzleFixture::PUZZLE_500_01, $this->ids($response)[0]);
+        $this->assertSame('very_hard', $response['puzzles'][0]['difficulty']['level'] ?? null);
+    }
+
+    public function testDifficultyFilterRequiresMembership(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['difficulty' => 'hard']);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $this->assertStringContainsString('membership', $this->decodeProblem($browser)['detail']);
+    }
+
+    public function testMemberCanFilterByDifficulty(): void
+    {
+        $browser = $this->createApiClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_01, 1.30, MetricConfidence::High); // hard
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 1.50, MetricConfidence::High); // very_hard
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_03, 0.70, MetricConfidence::High); // very_easy
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        $browser->request('GET', self::ENDPOINT, ['difficulty' => 'hard,very_hard', 'limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $ids = $this->ids($response);
+        $this->assertContains(PuzzleFixture::PUZZLE_500_01, $ids);
+        $this->assertContains(PuzzleFixture::PUZZLE_500_02, $ids);
+        $this->assertNotContains(PuzzleFixture::PUZZLE_500_03, $ids);
+
+        foreach ($response['puzzles'] as $puzzle) {
+            $this->assertContains($puzzle['difficulty']['level'] ?? null, ['hard', 'very_hard']);
+        }
+    }
+
+    public function testPaginationOverLimitTwo(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['manufacturer' => ManufacturerFixture::MANUFACTURER_TREFL, 'limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $all = $this->decode($browser);
+        $total = $all['total'];
+        $this->assertGreaterThan(2, $total);
+        $this->assertSame($total, $all['count']);
+
+        $seen = [];
+        $pages = (int) ceil($total / 2);
+
+        for ($page = 1; $page <= $pages; $page++) {
+            $browser->request('GET', self::ENDPOINT, ['manufacturer' => ManufacturerFixture::MANUFACTURER_TREFL, 'limit' => 2, 'page' => $page]);
+            $this->assertResponseIsSuccessful();
+            $response = $this->decode($browser);
+
+            $this->assertSame($page, $response['page']);
+            $this->assertSame(2, $response['limit']);
+            $this->assertSame($total, $response['total']);
+            $this->assertSame($page < $pages, $response['has_more'], "has_more on page {$page}");
+            $this->assertSame($page < $pages ? 2 : $total - 2 * ($pages - 1), $response['count']);
+
+            $seen = [...$seen, ...$this->ids($response)];
+        }
+
+        $this->assertSame($this->ids($all), $seen, 'Pages walk the same list as one big page');
+
+        // past the end: empty page, same total
+        $browser->request('GET', self::ENDPOINT, ['manufacturer' => ManufacturerFixture::MANUFACTURER_TREFL, 'limit' => 2, 'page' => $pages + 1]);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame(0, $response['count']);
+        $this->assertSame($total, $response['total']);
+        $this->assertFalse($response['has_more']);
+    }
+
+    public function testLimitAboveHundredIsRejected(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['limit' => '101']);
+        $this->assertUnprocessableWithViolationOn($browser, 'limit');
+
+        $browser->request('GET', self::ENDPOINT, ['limit' => '100']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(100, $this->decode($browser)['limit']);
+    }
+
+    /**
+     * A secret competition puzzle (hide_until in the future) does not exist for
+     * the API: not in the listing, not by name, not by barcode.
+     */
+    public function testHiddenPuzzleIsNeverReturned(): void
+    {
+        $browser = $this->createApiClient();
+        $this->hidePuzzleUntil($browser, PuzzleFixture::PUZZLE_500_02, new DateTimeImmutable('+30 days'));
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => 'Puzzle 2', 'limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $this->assertNotContains(PuzzleFixture::PUZZLE_500_02, $this->ids($this->decode($browser)));
+
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(0, $this->decode($browser)['total']);
+
+        $browser->request('GET', self::ENDPOINT, ['limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertNotContains(PuzzleFixture::PUZZLE_500_02, $this->ids($response));
+        $this->assertLessThanOrEqual(100, $response['count']);
+
+        // and it is back once the embargo has passed
+        $this->hidePuzzleUntil($browser, PuzzleFixture::PUZZLE_500_02, new DateTimeImmutable('-1 day'));
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame([PuzzleFixture::PUZZLE_500_02], $this->ids($this->decode($browser)));
+    }
+
+    public function testEmbargoedImageIsNull(): void
+    {
+        $browser = $this->createApiClient();
+        $this->setImage($browser, PuzzleFixture::PUZZLE_500_02, 'puzzles/test/box.jpg', hideUntil: new DateTimeImmutable('+30 days'));
+        $this->setImage($browser, PuzzleFixture::PUZZLE_1000_03, 'puzzles/test/other.jpg', hideUntil: null);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+        $this->assertNull($this->decode($browser)['puzzles'][0]['image']);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => 'Puzzle 2', 'limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $this->assertNull($this->puzzle($this->decode($browser), PuzzleFixture::PUZZLE_500_02)['image']);
+
+        // a released image is returned as stored
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556789012']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('puzzles/test/other.jpg', $this->decode($browser)['puzzles'][0]['image']);
+    }
+
+    public function testPuzzleCardShape(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => 'RB-500-001']);
+        $this->assertResponseIsSuccessful();
+
+        // field names and order, on the raw JSON
+        $raw = $this->decodeJson($browser);
+        $this->assertSame(['count', 'total', 'page', 'limit', 'has_more', 'puzzles'], array_keys($raw));
+        $card = $this->firstRawCard($browser);
+        $this->assertSame(
+            ['id', 'name', 'alternative_name', 'manufacturer', 'pieces_count', 'image', 'ean', 'identification_number', 'is_available', 'is_approved', 'statistics', 'difficulty', 'prediction', 'solves'],
+            array_keys($card),
+        );
+        $rawStatistics = $card['statistics'];
+        $this->assertIsArray($rawStatistics);
+        $this->assertSame(['solved_times', 'solo', 'duo', 'team'], array_keys($rawStatistics));
+        $this->assertSame(['count', 'fastest_seconds', 'average_seconds', 'slowest_seconds'], $this->keys($rawStatistics['solo']));
+
+        $puzzle = $this->decode($browser)['puzzles'][0];
+        $this->assertSame(PuzzleFixture::PUZZLE_500_01, $puzzle['id']);
+        $this->assertSame('Puzzle 1', $puzzle['name']);
+        $this->assertNull($puzzle['alternative_name']);
+        $this->assertSame(['id' => ManufacturerFixture::MANUFACTURER_RAVENSBURGER, 'name' => 'Ravensburger'], $puzzle['manufacturer']);
+        $this->assertSame(500, $puzzle['pieces_count']);
+        $this->assertNull($puzzle['ean']);
+        $this->assertSame('RB-500-001', $puzzle['identification_number']);
+        $this->assertTrue($puzzle['is_available']);
+        $this->assertTrue($puzzle['is_approved']);
+
+        // community statistics, always split by discipline, from the precomputed puzzle_statistics row
+        $statistics = $puzzle['statistics'];
+        // PUZZLE_500_01: eleven solo solves of several players (20-50 min), nothing in duo / team
+        $this->assertSame(11, $statistics['solved_times']);
+        $this->assertSame(11, $statistics['solo']['count']);
+        $this->assertSame(1200, $statistics['solo']['fastest_seconds']);
+        $this->assertSame(3000, $statistics['solo']['slowest_seconds']);
+        $this->assertIsInt($statistics['solo']['average_seconds']);
+        $this->assertGreaterThan(1200, $statistics['solo']['average_seconds']);
+        $this->assertLessThan(3000, $statistics['solo']['average_seconds']);
+        $this->assertSame(['count' => 0, 'fastest_seconds' => null, 'average_seconds' => null, 'slowest_seconds' => null], $statistics['duo']);
+        $this->assertSame(['count' => 0, 'fastest_seconds' => null, 'average_seconds' => null, 'slowest_seconds' => null], $statistics['team']);
+    }
+
+    public function testStatisticsAreSplitByDiscipline(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        // PUZZLE_1000_01: solo solves plus one duo solve (team-001, 3600 s) - the duo never leaks into solo
+        $browser->request('GET', self::ENDPOINT, ['query' => 'RB-1000-001']);
+        $this->assertResponseIsSuccessful();
+        $statistics = $this->decode($browser)['puzzles'][0]['statistics'];
+
+        $this->assertSame($statistics['solo']['count'] + $statistics['duo']['count'] + $statistics['team']['count'], $statistics['solved_times']);
+        $this->assertGreaterThan(0, $statistics['solo']['count']);
+        $this->assertSame(['count' => 1, 'fastest_seconds' => 3600, 'average_seconds' => 3600, 'slowest_seconds' => 3600], $statistics['duo']);
+        $this->assertSame(0, $statistics['team']['count']);
+
+        // a puzzle nobody has solved: no statistics row, zeros and nulls
+        $browser->request('GET', self::ENDPOINT, ['pieces_min' => '9000', 'pieces_max' => '9000']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            [
+                'solved_times' => 0,
+                'solo' => ['count' => 0, 'fastest_seconds' => null, 'average_seconds' => null, 'slowest_seconds' => null],
+                'duo' => ['count' => 0, 'fastest_seconds' => null, 'average_seconds' => null, 'slowest_seconds' => null],
+                'team' => ['count' => 0, 'fastest_seconds' => null, 'average_seconds' => null, 'slowest_seconds' => null],
+            ],
+            $this->decode($browser)['puzzles'][0]['statistics'],
+        );
+    }
+
+    public function testMemberSeesDifficultyAndNonMemberDoesNot(): void
+    {
+        $browser = $this->createApiClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 1.18, MetricConfidence::Medium);
+
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            ['score' => 1.18, 'level' => 'challenging', 'confidence' => 'medium', 'sample_size' => 20],
+            $this->decode($browser)['puzzles'][0]['difficulty'],
+        );
+
+        // a member looking at a puzzle without a difficulty row: "insufficient data", not "members only"
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556789012']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            ['score' => null, 'level' => null, 'confidence' => 'insufficient', 'sample_size' => 0],
+            $this->decode($browser)['puzzles'][0]['difficulty'],
+        );
+
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+        $this->assertNull($this->decode($browser)['puzzles'][0]['difficulty']);
+    }
+
+    public function testPredictionIsPersonalizedForMemberWithHistory(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => 'RB-500-001']);
+        $this->assertResponseIsSuccessful();
+
+        $this->assertSame(
+            ['predicted_seconds', 'range_low_seconds', 'range_high_seconds', 'is_personalized', 'personal_solve_count', 'predicted_attempt_number', 'last_time_seconds'],
+            $this->keys($this->firstRawCard($browser)['prediction']),
+        );
+
+        $prediction = $this->decode($browser)['puzzles'][0]['prediction'];
+        $this->assertNotNull($prediction);
+        $this->assertTrue($prediction['is_personalized']);
+        $this->assertSame(1, $prediction['personal_solve_count']);
+        $this->assertSame(2, $prediction['predicted_attempt_number']);
+        $this->assertSame(2100, $prediction['last_time_seconds']);
+        $this->assertIsInt($prediction['predicted_seconds']);
+        $this->assertGreaterThan(0, $prediction['predicted_seconds']);
+        $this->assertLessThanOrEqual($prediction['predicted_seconds'], $prediction['range_low_seconds']);
+        $this->assertGreaterThanOrEqual($prediction['predicted_seconds'], $prediction['range_high_seconds']);
+    }
+
+    public function testPredictionIsNullWhenNotEntitled(): void
+    {
+        $browser = $this->createApiClient();
+
+        // not a member (PLAYER_REGULAR has plenty of history on PUZZLE_500_02)
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+        $this->assertNull($this->decode($browser)['puzzles'][0]['prediction']);
+
+        // member, but the token may not read results (profile:read only) - prediction and solves are results data
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $browser->request('GET', self::ENDPOINT, ['query' => 'RB-500-001']);
+        $this->assertResponseIsSuccessful();
+        $puzzle = $this->decode($browser)['puzzles'][0];
+        $this->assertNull($puzzle['prediction']);
+        $this->assertNull($puzzle['solves']);
+        $this->assertIsArray($puzzle['difficulty']);
+
+        // member with results:read: both objects are present
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['results:read']);
+        $browser->request('GET', self::ENDPOINT, ['query' => 'RB-500-001']);
+        $this->assertResponseIsSuccessful();
+        $puzzle = $this->decode($browser)['puzzles'][0];
+        $this->assertTrue($puzzle['prediction']['is_personalized'] ?? null);
+        $this->assertSame(1, $puzzle['solves']['solo']['count'] ?? null);
+
+        // member who opted out of time predictions: difficulty and solves stay, prediction goes
+        $this->optOutOfTimePredictions($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $browser->request('GET', self::ENDPOINT, ['query' => 'RB-500-001']);
+        $this->assertResponseIsSuccessful();
+        $puzzle = $this->decode($browser)['puzzles'][0];
+        $this->assertNull($puzzle['prediction']);
+        $this->assertIsArray($puzzle['difficulty']);
+        $this->assertSame(1, $puzzle['solves']['solo']['count'] ?? null);
+    }
+
+    /**
+     * A member without history on a puzzle gets the statistical prediction
+     * when there is enough data, and an all-null object when there is not -
+     * the object is present either way, null means "not entitled" only.
+     */
+    public function testMemberWithoutHistoryGetsPredictionObject(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        // nothing to predict from for a 9000-piece puzzle: all null, not personalized
+        $browser->request('GET', self::ENDPOINT, ['pieces_min' => '9000', 'pieces_max' => '9000']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            ['predicted_seconds' => null, 'range_low_seconds' => null, 'range_high_seconds' => null, 'is_personalized' => false, 'personal_solve_count' => null, 'predicted_attempt_number' => null, 'last_time_seconds' => null],
+            $this->decode($browser)['puzzles'][0]['prediction'],
+        );
+    }
+
+    public function testSolvesAreSplitByDiscipline(): void
+    {
+        $browser = $this->createApiClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        // three solo solves of PUZZLE_500_02: 2200 (20 days ago), 1900 (15), 1700 (10)
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+
+        $rawSolves = $this->firstRawCard($browser)['solves'];
+        $this->assertIsArray($rawSolves);
+        $this->assertSame(['solo', 'duo', 'team'], array_keys($rawSolves));
+        $this->assertSame(['count', 'best_time_seconds', 'last_time_seconds', 'first_solved_at', 'last_solved_at'], $this->keys($rawSolves['solo']));
+
+        $solves = $this->decode($browser)['puzzles'][0]['solves'];
+        $this->assertNotNull($solves);
+        $this->assertSame(3, $solves['solo']['count']);
+        $this->assertSame(1700, $solves['solo']['best_time_seconds']);
+        $this->assertSame(1700, $solves['solo']['last_time_seconds']);
+        $this->assertIsString($solves['solo']['first_solved_at']);
+        $this->assertIsString($solves['solo']['last_solved_at']);
+        $this->assertLessThan(
+            new DateTimeImmutable($solves['solo']['last_solved_at']),
+            new DateTimeImmutable($solves['solo']['first_solved_at']),
+        );
+        $this->assertSame(['count' => 0, 'best_time_seconds' => null, 'last_time_seconds' => null, 'first_solved_at' => null, 'last_solved_at' => null], $solves['duo']);
+        $this->assertSame(['count' => 0, 'best_time_seconds' => null, 'last_time_seconds' => null, 'first_solved_at' => null, 'last_solved_at' => null], $solves['team']);
+
+        // a duo solve of PUZZLE_1000_01 (team-001 with PLAYER_PRIVATE, 3600 s) is a duo, never merged into solo
+        $browser->request('GET', self::ENDPOINT, ['query' => 'RB-1000-001']);
+        $this->assertResponseIsSuccessful();
+        $solves = $this->decode($browser)['puzzles'][0]['solves'];
+        $this->assertNotNull($solves);
+
+        $this->assertSame(0, $solves['solo']['count']);
+        $this->assertSame(1, $solves['duo']['count']);
+        $this->assertSame(3600, $solves['duo']['best_time_seconds']);
+        $this->assertSame(0, $solves['team']['count']);
+
+        // a puzzle never touched: zeros, the object is still there
+        $browser->request('GET', self::ENDPOINT, ['pieces_min' => '9000', 'pieces_max' => '9000']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(0, $this->decode($browser)['puzzles'][0]['solves']['solo']['count'] ?? null);
+    }
+
+    /**
+     * The query cost is fixed per request and does not grow with the page size
+     * (docs/features/api/v1-expansion-plan.md §4, N3). Measured (2026-08-19):
+     * authentication costs 1 query for a PAT, 3 for an OAuth2 token (access
+     * token, player, consent usage); then count + search (2), statistics (1),
+     * the owner's profile (1), solves (1), and for a member difficulty (1) +
+     * predictions (3, or 4 when the page holds a puzzle the owner has not
+     * solved yet - GetPlayerPredictions skips the statistical query otherwise).
+     */
+    public function testQueryBudgets(): void
+    {
+        $browser = $this->createApiClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_01, 1.18, MetricConfidence::Medium);
+
+        $this->authenticateClientCredentials($browser);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT, ['limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 5, 'client_credentials token, limit=100');
+
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT, ['limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 7, 'non-member PAT, limit=100');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['results:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT, ['limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 8, 'non-member authorization-code token, limit=100');
+
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT, ['limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 12, 'member PAT, limit=100');
+
+        // Same member, two page sizes of the same listing: identical cost. Sorted
+        // least-solved first, so that both pages hold puzzles the member has not
+        // solved (the complete prediction path) - the comparison is then about
+        // the page size only, not about which puzzles happen to be on the page.
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT, ['sort' => 'least-solved', 'limit' => 5]);
+        $this->assertResponseIsSuccessful();
+        $memberAtFive = $this->queryCount($browser);
+
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT, ['sort' => 'least-solved', 'limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame($memberAtFive, $this->queryCount($browser), 'A member pays the same number of queries for 100 items as for 5');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['results:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT, ['limit' => 100]);
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 13, 'member authorization-code token, limit=100');
+
+        // the barcode path: same rules, no count query
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 12, 'member authorization-code token, ean lookup');
+    }
+
+    public function testRateLimitReturnsTooManyRequestsWithRetryAfter(): void
+    {
+        $browser = $this->createApiClient();
+        // PLAYER_ADMIN is used by no other search test, so the 60-request budget is all this test's
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_ADMIN);
+
+        for ($i = 1; $i <= 60; $i++) {
+            $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+            $this->assertResponseIsSuccessful("request {$i} of 60 must still be accepted");
+        }
+
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseStatusCodeSame(Response::HTTP_TOO_MANY_REQUESTS);
+
+        $retryAfter = $browser->getResponse()->headers->get('Retry-After');
+        $this->assertNotNull($retryAfter);
+        $this->assertGreaterThanOrEqual(1, (int) $retryAfter);
+        $this->assertLessThanOrEqual(60, (int) $retryAfter);
+
+        // a 422 before the limiter is not counted, a different owner is not affected
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+        $browser->request('GET', self::ENDPOINT, ['ean' => '4005556123456']);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testOpenApiDocumentsEveryParameter(): void
+    {
+        $browser = $this->createApiClient();
+
+        $parameters = $this->assertOpenApiHasParameters($browser, self::ENDPOINT, self::PARAMETER_NAMES);
+
+        $this->assertSame(['most-solved', 'least-solved', 'a-z', 'z-a', 'easiest', 'hardest'], $parameters['sort']['schema']['enum'] ?? null);
+        $this->assertSame('most-solved', $parameters['sort']['schema']['default'] ?? null);
+        /** @var array{items?: array{enum?: list<string>}} $difficultySchema */
+        $difficultySchema = $parameters['difficulty']['schema'];
+        $this->assertSame(['very_easy', 'easy', 'average', 'challenging', 'hard', 'very_hard'], $difficultySchema['items']['enum'] ?? null);
+        $this->assertSame('form', $parameters['difficulty']['style']);
+        $this->assertFalse($parameters['difficulty']['explode']);
+        $this->assertSame('integer', $parameters['limit']['schema']['type'] ?? null);
+        $this->assertSame(100, $parameters['limit']['schema']['maximum'] ?? null);
+        $this->assertSame(20, $parameters['limit']['schema']['default'] ?? null);
+        $this->assertSame(500, $parameters['page']['schema']['maximum'] ?? null);
+        $this->assertSame('^\d{8,14}$', $parameters['ean']['schema']['pattern'] ?? null);
+        $this->assertSame('uuid', $parameters['manufacturer']['schema']['format'] ?? null);
+        $this->assertStringContainsString('members-only', $parameters['sort']['description'] ?? '');
+
+        $document = $this->openApiDocument($browser);
+        /** @var array<string, array{get: array{tags: list<string>, summary: string, responses: array<int|string, mixed>}}> $paths */
+        $paths = $document['paths'];
+        $pathItem = $paths[self::ENDPOINT];
+        $this->assertSame(['Puzzles'], $pathItem['get']['tags']);
+        $this->assertNotSame('', $pathItem['get']['summary']);
+        $this->assertArrayHasKey('429', $pathItem['get']['responses']);
+        $this->assertArrayHasKey('422', $pathItem['get']['responses']);
+    }
+
+    private function createApiClient(): KernelBrowser
+    {
+        $browser = self::createClient();
+
+        // The limiter store is not rolled back between tests or runs (filesystem
+        // cache) - start every test with a full budget for every owner it uses.
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var RateLimiterFactoryInterface $limiter */
+        $limiter = $container->get('limiter.api_puzzle_search');
+
+        foreach (self::LIMITER_KEYS as $key) {
+            $limiter->create($key)->reset();
+        }
+
+        return $browser;
+    }
+
+    private function authenticatePat(KernelBrowser $browser, string $playerId): void
+    {
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, $playerId));
+    }
+
+    /**
+     * @param array<non-empty-string> $scopes
+     */
+    private function authenticateOAuth2(KernelBrowser $browser, string $playerId, array $scopes): void
+    {
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            $playerId,
+            $scopes,
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    private function authenticateClientCredentials(KernelBrowser $browser): void
+    {
+        // sub = aud = client id is exactly what the client_credentials grant issues
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            ['profile:read', 'results:read'],
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    private function assertUnprocessableWithViolationOn(KernelBrowser $browser, string $propertyPath): void
+    {
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+
+        $response = $this->decodeProblem($browser);
+        $this->assertArrayHasKey('violations', $response, 'A 422 must carry violations');
+
+        $paths = array_column($response['violations'], 'propertyPath');
+        $this->assertContains($propertyPath, $paths, sprintf('Expected a violation on "%s", got: %s', $propertyPath, json_encode($response['violations'])));
+    }
+
+    private function seedDifficulty(KernelBrowser $browser, string $puzzleId, float $score, MetricConfidence $confidence): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        // The incremental recalculation may already have left a row behind - reuse it,
+        // the puzzle id is the primary key.
+        $difficulty = $entityManager->find(PuzzleDifficulty::class, $puzzleId) ?? new PuzzleDifficulty($puzzle);
+        $difficulty->updateDifficulty($score, $confidence, 20, new DateTimeImmutable());
+
+        $entityManager->persist($difficulty);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function hidePuzzleUntil(KernelBrowser $browser, string $puzzleId, DateTimeImmutable $until): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $puzzle->hideUntil = $until;
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function setImage(KernelBrowser $browser, string $puzzleId, string $image, null|DateTimeImmutable $hideUntil): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $puzzle->image = $image;
+        $puzzle->hideImageUntil = $hideUntil;
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function optOutOfTimePredictions(KernelBrowser $browser, string $playerId): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $player = $entityManager->find(Player::class, $playerId);
+        $this->assertNotNull($player);
+
+        $player->changeTimePredictionsOptedOut(true);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function entityManager(KernelBrowser $browser): EntityManagerInterface
+    {
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    /**
+     * The successful list response.
+     *
+     * @return ListResponse
+     */
+    private function decode(KernelBrowser $browser): array
+    {
+        /** @var ListResponse $decoded */
+        $decoded = $this->decodeJson($browser);
+
+        return $decoded;
+    }
+
+    /**
+     * An error response (application/problem+json).
+     *
+     * @return Problem
+     */
+    private function decodeProblem(KernelBrowser $browser): array
+    {
+        /** @var Problem $decoded */
+        $decoded = $this->decodeJson($browser);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(KernelBrowser $browser): array
+    {
+        $content = $browser->getResponse()->getContent();
+        $this->assertIsString($content);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+
+    /**
+     * The first card of the response as raw decoded JSON - for asserting field
+     * names and their order, which the typed decode() cannot (phpstan folds a
+     * typed shape's key list to a constant).
+     *
+     * @return array<string, mixed>
+     */
+    private function firstRawCard(KernelBrowser $browser): array
+    {
+        $puzzles = $this->decodeJson($browser)['puzzles'] ?? null;
+        $this->assertIsArray($puzzles);
+        $this->assertArrayHasKey(0, $puzzles);
+
+        /** @var array<string, mixed> $card */
+        $card = $puzzles[0];
+
+        return $card;
+    }
+
+    /**
+     * Keys of a decoded JSON object, for asserting field names and their order.
+     *
+     * @return list<int|string>
+     */
+    private function keys(mixed $value): array
+    {
+        $this->assertIsArray($value);
+
+        return array_keys($value);
+    }
+
+    /**
+     * @param ListResponse $response
+     *
+     * @return list<string>
+     */
+    private function ids(array $response): array
+    {
+        return array_map(static fn (array $puzzle): string => $puzzle['id'], $response['puzzles']);
+    }
+
+    /**
+     * @param ListResponse $response
+     *
+     * @return Card
+     */
+    private function puzzle(array $response, string $puzzleId): array
+    {
+        foreach ($response['puzzles'] as $puzzle) {
+            if ($puzzle['id'] === $puzzleId) {
+                return $puzzle;
+            }
+        }
+
+        $this->fail(sprintf('Puzzle %s is not in the response', $puzzleId));
+    }
+}

--- a/tests/Controller/Api/V1/PuzzleSearchEndpointTest.php
+++ b/tests/Controller/Api/V1/PuzzleSearchEndpointTest.php
@@ -154,6 +154,28 @@ final class PuzzleSearchEndpointTest extends WebTestCase
         }
     }
 
+    /**
+     * A cleared search box sends query= (or spaces): that is "no filter", not a 422.
+     */
+    public function testEmptyQueryMeansNoFilter(): void
+    {
+        $browser = self::createClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => '']);
+        $this->assertResponseIsSuccessful();
+        $unfiltered = $this->decode($browser);
+
+        $browser->request('GET', self::ENDPOINT, ['query' => '   ']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame($unfiltered['total'], $this->decode($browser)['total']);
+
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame($unfiltered['total'], $this->decode($browser)['total']);
+        $this->assertGreaterThan(0, $unfiltered['total']);
+    }
+
     public function testQueryMatchesIdentificationNumberAndIsAccentInsensitive(): void
     {
         $browser = $this->createApiClient();

--- a/tests/OpenApiAssertions.php
+++ b/tests/OpenApiAssertions.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * The OpenAPI document is generated from the attributes: asserting the
+ * parameter declarations are in it proves they are declared once and
+ * documented (docs/features/api/v1-expansion-plan.md, N4).
+ */
+trait OpenApiAssertions
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function openApiDocument(KernelBrowser $browser): array
+    {
+        $browser->request('GET', '/api/docs.jsonopenapi');
+        self::assertResponseIsSuccessful();
+
+        $content = $browser->getResponse()->getContent();
+        self::assertIsString($content);
+
+        /** @var array<string, mixed> $document */
+        $document = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return $document;
+    }
+
+    /**
+     * The GET operation of the path documents exactly the expected query
+     * parameters, each with a description; returns them keyed by name for
+     * further assertions (enum, schema).
+     *
+     * @param list<string> $expectedNames
+     *
+     * @return array<string, array{name: string, in: string, description?: string, schema: array<string, mixed>, style: string, explode: bool}>
+     */
+    protected function assertOpenApiHasParameters(KernelBrowser $browser, string $path, array $expectedNames): array
+    {
+        $document = $this->openApiDocument($browser);
+
+        self::assertIsArray($document['paths'] ?? null);
+        self::assertArrayHasKey($path, $document['paths'], sprintf('OpenAPI does not document %s', $path));
+
+        /** @var array{get?: array{parameters?: list<array{name: string, in: string, description?: string, schema: array<string, mixed>, style: string, explode: bool}>}} $pathItem */
+        $pathItem = $document['paths'][$path];
+        self::assertArrayHasKey('get', $pathItem);
+
+        $parameters = [];
+
+        foreach ($pathItem['get']['parameters'] ?? [] as $parameter) {
+            if ($parameter['in'] === 'query') {
+                $parameters[$parameter['name']] = $parameter;
+            }
+        }
+
+        self::assertSame($expectedNames, array_keys($parameters), sprintf('Query parameters of %s differ from the expected list.', $path));
+
+        foreach ($parameters as $name => $parameter) {
+            self::assertNotSame('', trim($parameter['description'] ?? ''), sprintf('Parameter %s has no description.', $name));
+        }
+
+        return $parameters;
+    }
+}

--- a/tests/Query/GetPlayerPuzzleSolvesTest.php
+++ b/tests/Query/GetPlayerPuzzleSolvesTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Query;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Clock\ClockInterface;
+use Ramsey\Uuid\Uuid;
+use SpeedPuzzling\Web\Entity\Player;
+use SpeedPuzzling\Web\Entity\Puzzle;
+use SpeedPuzzling\Web\Entity\PuzzleSolvingTime;
+use SpeedPuzzling\Web\Query\GetPlayerPuzzleSolves;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Value\Puzzler;
+use SpeedPuzzling\Web\Value\PuzzlersGroup;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The "solves" object of the public API's puzzle cards: one player's own
+ * history on a list of puzzles, always split by discipline, the same row set
+ * as /me/results?type= (solo rows the player owns; duo / team rows the player
+ * took part in), unboxed and untimed rows included.
+ */
+final class GetPlayerPuzzleSolvesTest extends KernelTestCase
+{
+    private GetPlayerPuzzleSolves $query;
+
+    private ClockInterface $clock;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $this->query = $container->get(GetPlayerPuzzleSolves::class);
+        $this->clock = $container->get(ClockInterface::class);
+        $this->entityManager = $container->get(EntityManagerInterface::class);
+    }
+
+    public function testSoloSolvesCountBestAndLast(): void
+    {
+        // PLAYER_REGULAR on PUZZLE_500_02: 2200 (20 days ago) -> 1900 (15) -> 1700 (10)
+        $solves = $this->query->forPuzzles(PlayerFixture::PLAYER_REGULAR, [PuzzleFixture::PUZZLE_500_02]);
+
+        self::assertArrayHasKey(PuzzleFixture::PUZZLE_500_02, $solves);
+        $solo = $solves[PuzzleFixture::PUZZLE_500_02]->solo;
+
+        self::assertSame(3, $solo->count);
+        self::assertSame(1700, $solo->bestTimeSeconds);
+        self::assertSame(1700, $solo->lastTimeSeconds);
+        self::assertNotNull($solo->firstSolvedAt);
+        self::assertNotNull($solo->lastSolvedAt);
+        self::assertSame($this->clock->now()->modify('-20 days')->format('Y-m-d'), $solo->firstSolvedAt->format('Y-m-d'));
+        self::assertSame($this->clock->now()->modify('-10 days')->format('Y-m-d'), $solo->lastSolvedAt->format('Y-m-d'));
+
+        self::assertSame(0, $solves[PuzzleFixture::PUZZLE_500_02]->duo->count);
+        self::assertSame(0, $solves[PuzzleFixture::PUZZLE_500_02]->team->count);
+    }
+
+    public function testLastTimeIsTheMostRecentTimedSolveAndUntimedRowsStillCount(): void
+    {
+        // PLAYER_REGULAR on PUZZLE_1000_02: 3950 (16 days ago), 4500 (4 days ago) and an untimed
+        // relax row (3 days ago): three solves, the last *time* is 4500, the last solve is 3 days ago
+        $solo = $this->query->forPuzzles(PlayerFixture::PLAYER_REGULAR, [PuzzleFixture::PUZZLE_1000_02])[PuzzleFixture::PUZZLE_1000_02]->solo;
+
+        self::assertSame(3, $solo->count);
+        self::assertSame(3950, $solo->bestTimeSeconds);
+        self::assertSame(4500, $solo->lastTimeSeconds);
+        self::assertNotNull($solo->lastSolvedAt);
+        self::assertSame($this->clock->now()->modify('-3 days')->format('Y-m-d'), $solo->lastSolvedAt->format('Y-m-d'));
+    }
+
+    public function testUnboxedSolvesAreIncluded(): void
+    {
+        // PLAYER_WITH_STRIPE on PUZZLE_500_02: a first-attempt solve (2000 s, 37 days ago)
+        // and an unboxed one (2000 s, 2 days ago) - the player's own data, both count
+        $solo = $this->query->forPuzzles(PlayerFixture::PLAYER_WITH_STRIPE, [PuzzleFixture::PUZZLE_500_02])[PuzzleFixture::PUZZLE_500_02]->solo;
+
+        self::assertSame(2, $solo->count);
+        self::assertSame(2000, $solo->bestTimeSeconds);
+        self::assertNotNull($solo->lastSolvedAt);
+        self::assertSame($this->clock->now()->modify('-2 days')->format('Y-m-d'), $solo->lastSolvedAt->format('Y-m-d'));
+    }
+
+    public function testDuoAndTeamAreParticipationNotOwnership(): void
+    {
+        // team-001 on PUZZLE_1000_01 (3600 s): PLAYER_REGULAR owns the row, PLAYER_PRIVATE is a
+        // participant - a duo for both of them; PLAYER_PRIVATE also has her own solo row (4200 s)
+        $regular = $this->query->forPuzzles(PlayerFixture::PLAYER_REGULAR, [PuzzleFixture::PUZZLE_1000_01])[PuzzleFixture::PUZZLE_1000_01];
+        $private = $this->query->forPuzzles(PlayerFixture::PLAYER_PRIVATE, [PuzzleFixture::PUZZLE_1000_01])[PuzzleFixture::PUZZLE_1000_01];
+
+        self::assertSame(0, $regular->solo->count);
+        self::assertSame(1, $regular->duo->count);
+        self::assertSame(3600, $regular->duo->bestTimeSeconds);
+        self::assertSame(3600, $regular->duo->lastTimeSeconds);
+        self::assertSame(0, $regular->team->count);
+
+        self::assertSame(1, $private->solo->count);
+        self::assertSame(4200, $private->solo->bestTimeSeconds);
+        self::assertSame(1, $private->duo->count);
+        self::assertSame(3600, $private->duo->bestTimeSeconds);
+
+        // a player outside the team sees nothing of it
+        $admin = $this->query->forPuzzles(PlayerFixture::PLAYER_ADMIN, [PuzzleFixture::PUZZLE_1000_01])[PuzzleFixture::PUZZLE_1000_01];
+        self::assertSame(0, $admin->duo->count);
+    }
+
+    public function testTeamOfThreeIsATeamSolveForEveryMember(): void
+    {
+        $this->seedTeamSolve(
+            PuzzleFixture::PUZZLE_9000,
+            owner: PlayerFixture::PLAYER_REGULAR,
+            participants: [PlayerFixture::PLAYER_REGULAR, PlayerFixture::PLAYER_PRIVATE, PlayerFixture::PLAYER_ADMIN],
+            seconds: 36000,
+        );
+
+        foreach ([PlayerFixture::PLAYER_REGULAR, PlayerFixture::PLAYER_PRIVATE, PlayerFixture::PLAYER_ADMIN] as $playerId) {
+            $solves = $this->query->forPuzzles($playerId, [PuzzleFixture::PUZZLE_9000])[PuzzleFixture::PUZZLE_9000];
+
+            self::assertSame(0, $solves->solo->count, $playerId);
+            self::assertSame(0, $solves->duo->count, $playerId);
+            self::assertSame(1, $solves->team->count, $playerId);
+            self::assertSame(36000, $solves->team->bestTimeSeconds, $playerId);
+            self::assertNotNull($solves->team->firstSolvedAt);
+            self::assertEquals($solves->team->firstSolvedAt, $solves->team->lastSolvedAt);
+        }
+
+        self::assertArrayNotHasKey(PuzzleFixture::PUZZLE_9000, $this->query->forPuzzles(PlayerFixture::PLAYER_WITH_STRIPE, [PuzzleFixture::PUZZLE_9000]));
+    }
+
+    public function testNeverSolvedPuzzlesAreAbsentAndOnlyAskedPuzzlesAreReturned(): void
+    {
+        $solves = $this->query->forPuzzles(PlayerFixture::PLAYER_REGULAR, [PuzzleFixture::PUZZLE_9000, PuzzleFixture::PUZZLE_500_02, PuzzleFixture::PUZZLE_500_02]);
+
+        self::assertSame([PuzzleFixture::PUZZLE_500_02], array_keys($solves));
+        self::assertSame([], $this->query->forPuzzles(PlayerFixture::PLAYER_REGULAR, []));
+        self::assertSame([], $this->query->forPuzzles('00000000-0000-0000-0000-000000000099', [PuzzleFixture::PUZZLE_500_02]));
+    }
+
+    /**
+     * @param non-empty-list<string> $participants
+     */
+    private function seedTeamSolve(string $puzzleId, string $owner, array $participants, int $seconds): void
+    {
+        $puzzle = $this->entityManager->find(Puzzle::class, $puzzleId);
+        $ownerPlayer = $this->entityManager->find(Player::class, $owner);
+        self::assertNotNull($puzzle);
+        self::assertNotNull($ownerPlayer);
+
+        $puzzlers = [];
+
+        foreach ($participants as $participantId) {
+            $participant = $this->entityManager->find(Player::class, $participantId);
+            self::assertNotNull($participant);
+
+            $puzzlers[] = new Puzzler(
+                playerId: $participant->id->toString(),
+                playerName: $participant->name,
+                playerCode: $participant->code,
+                playerCountry: null,
+                isPrivate: false,
+            );
+        }
+
+        $now = new DateTimeImmutable('-1 day');
+
+        $this->entityManager->persist(new PuzzleSolvingTime(
+            id: Uuid::uuid7(),
+            secondsToSolve: $seconds,
+            player: $ownerPlayer,
+            puzzle: $puzzle,
+            trackedAt: $now,
+            verified: true,
+            team: new PuzzlersGroup(teamId: 'team-test-trio', puzzlers: $puzzlers),
+            finishedAt: $now,
+            comment: null,
+            finishedPuzzlePhoto: null,
+            firstAttempt: true,
+            unboxed: false,
+        ));
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+    }
+}

--- a/tests/Query/GetPuzzleStatisticsTest.php
+++ b/tests/Query/GetPuzzleStatisticsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Query;
+
+use SpeedPuzzling\Web\Query\GetPuzzleStatistics;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The community statistics of the public API's puzzle cards, read in one
+ * batch from the precomputed puzzle_statistics table.
+ */
+final class GetPuzzleStatisticsTest extends KernelTestCase
+{
+    private GetPuzzleStatistics $query;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->query = self::getContainer()->get(GetPuzzleStatistics::class);
+    }
+
+    public function testStatisticsAreSplitByDiscipline(): void
+    {
+        // PUZZLE_1000_01: eight solo solves (3900-6500 s) and one duo solve (3600 s)
+        $statistics = $this->query->forPuzzleList([PuzzleFixture::PUZZLE_1000_01, PuzzleFixture::PUZZLE_500_01]);
+
+        self::assertEqualsCanonicalizing([PuzzleFixture::PUZZLE_1000_01, PuzzleFixture::PUZZLE_500_01], array_keys($statistics));
+
+        $puzzle = $statistics[PuzzleFixture::PUZZLE_1000_01];
+        self::assertSame(PuzzleFixture::PUZZLE_1000_01, $puzzle->puzzleId);
+        self::assertSame($puzzle->solo->count + $puzzle->duo->count + $puzzle->team->count, $puzzle->solvedTimes);
+        self::assertSame(8, $puzzle->solo->count);
+        self::assertSame(3900, $puzzle->solo->fastestSeconds);
+        self::assertSame(6500, $puzzle->solo->slowestSeconds);
+        self::assertNotNull($puzzle->solo->averageSeconds);
+        self::assertGreaterThan(3900, $puzzle->solo->averageSeconds);
+        self::assertLessThan(6500, $puzzle->solo->averageSeconds);
+        self::assertSame(1, $puzzle->duo->count);
+        self::assertSame(3600, $puzzle->duo->fastestSeconds);
+        self::assertSame(3600, $puzzle->duo->averageSeconds);
+        self::assertSame(3600, $puzzle->duo->slowestSeconds);
+        self::assertSame(0, $puzzle->team->count);
+        self::assertNull($puzzle->team->fastestSeconds);
+
+        // PUZZLE_500_01: solo only, 1200-3000 s
+        $puzzle = $statistics[PuzzleFixture::PUZZLE_500_01];
+        self::assertSame(11, $puzzle->solvedTimes);
+        self::assertSame(1200, $puzzle->solo->fastestSeconds);
+        self::assertSame(3000, $puzzle->solo->slowestSeconds);
+        self::assertSame(0, $puzzle->duo->count);
+    }
+
+    public function testNeverSolvedPuzzlesAreAbsent(): void
+    {
+        self::assertSame([], $this->query->forPuzzleList([PuzzleFixture::PUZZLE_9000]));
+        self::assertSame([], $this->query->forPuzzleList([]));
+    }
+}

--- a/tests/QueryCountAssertions.php
+++ b/tests/QueryCountAssertions.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests;
+
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+
+/**
+ * Query budgets for API endpoints (docs/features/api/v1-expansion-plan.md, N3):
+ * a list must cost the same number of queries at 5 items as at 100.
+ *
+ * Usage: create tokens and seed data first, call startCountingQueries() right
+ * before the request, assert after it. The first request of a test reuses the
+ * kernel the helpers booted, so the profiler's db collector would also see the
+ * helpers' own queries (token lookup, INSERT, COMMIT) - the debug data holder
+ * is reset so that only the request is counted.
+ */
+trait QueryCountAssertions
+{
+    protected function startCountingQueries(KernelBrowser $browser): void
+    {
+        $browser->enableProfiler();
+
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var DebugDataHolder $debugDataHolder */
+        $debugDataHolder = $container->get('doctrine.debug_data_holder'); // @phpstan-ignore symfonyContainer.privateService
+        $debugDataHolder->reset();
+    }
+
+    protected function queryCount(KernelBrowser $browser): int
+    {
+        $profile = $browser->getProfile();
+        self::assertInstanceOf(Profile::class, $profile, 'The profiler did not collect the request - call startCountingQueries() before the request.');
+
+        $collector = $profile->getCollector('db');
+        self::assertInstanceOf(DoctrineDataCollector::class, $collector);
+
+        return $collector->getQueryCount();
+    }
+
+    protected function assertQueryCountAtMost(KernelBrowser $browser, int $max, string $why): void
+    {
+        $count = $this->queryCount($browser);
+
+        self::assertLessThanOrEqual($max, $count, sprintf('%s: expected at most %d queries, the request ran %d.', $why, $max, $count));
+    }
+}

--- a/tests/Value/PiecesRangeTest.php
+++ b/tests/Value/PiecesRangeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Value;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SpeedPuzzling\Web\Results\PiecesFilter;
+use SpeedPuzzling\Web\Value\PiecesRange;
+
+final class PiecesRangeTest extends TestCase
+{
+    public function testBetween(): void
+    {
+        $range = PiecesRange::between(500, 1000);
+
+        self::assertSame(500, $range->minPieces);
+        self::assertSame(1000, $range->maxPieces);
+        self::assertFalse($range->isUnbounded());
+
+        $exact = PiecesRange::between(500, 500);
+        self::assertSame(500, $exact->minPieces);
+        self::assertSame(500, $exact->maxPieces);
+
+        $openEnded = PiecesRange::between(2000, null);
+        self::assertSame(2000, $openEnded->minPieces);
+        self::assertNull($openEnded->maxPieces);
+
+        self::assertTrue(PiecesRange::between(null, null)->isUnbounded());
+        self::assertTrue(PiecesRange::any()->isUnbounded());
+    }
+
+    public function testContradictingBoundsAreRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        PiecesRange::between(1000, 500);
+    }
+
+    /**
+     * @return iterable<string, array{PiecesFilter, null|int, null|int}>
+     */
+    public static function filters(): iterable
+    {
+        yield 'any' => [PiecesFilter::Any, null, null];
+        yield 'up to 499' => [PiecesFilter::UpTo499, 1, 499];
+        yield 'exactly 500' => [PiecesFilter::Exactly500, 500, 500];
+        yield '501-999' => [PiecesFilter::UpTo999, 501, 999];
+        yield 'exactly 1000' => [PiecesFilter::Exactly1000, 1000, 1000];
+        yield 'more than 1000' => [PiecesFilter::MoreThan1000, 1001, null];
+    }
+
+    /**
+     * The website's fixed ranges map onto the same bounds PiecesFilter always
+     * expressed - the search query behaves identically for every web caller.
+     */
+    #[DataProvider('filters')]
+    public function testFromFilter(PiecesFilter $filter, null|int $expectedMin, null|int $expectedMax): void
+    {
+        $range = PiecesRange::fromFilter($filter);
+
+        self::assertSame($expectedMin, $range->minPieces);
+        self::assertSame($expectedMax, $range->maxPieces);
+    }
+}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -583,6 +583,7 @@ for_developers:
     table_endpoint: "Endpoint"
     table_section_me: "Your own data (/me)"
     table_section_players: "Other players' public data"
+    table_section_puzzles: "Puzzle catalog"
     summary_pat: "<i class=\"bi bi-key me-1 text-primary\"></i><strong>PAT</strong> — your own data only. No scopes needed, full access to all <code>/me</code> endpoints."
     summary_auth_code: "<i class=\"bi bi-person-badge me-1 text-primary\"></i><strong>Auth Code</strong> — all endpoints. Access depends on granted scopes. Write scopes available."
     summary_client_cred: "<i class=\"bi bi-hdd-network me-1 text-primary\"></i><strong>Client Credentials</strong> — read-only access to any public player. No <code>/me</code> endpoints."


### PR DESCRIPTION
PR 1 of `docs/features/api/v1-expansion-plan.md` — the first puzzle catalog in V1 (an app could not obtain a `puzzle_id` before), plus the foundation every later PR reuses.

**Endpoint** `GET /api/v1/puzzles` (any valid token; PAT / auth-code / client_credentials). Parameters are declared once as API Platform `QueryParameter`s → validated (422 `application/problem+json` with `violations`) **and** documented in Swagger from the same declaration: `query` (2–100, trimmed; empty = no filter), `ean` (exact barcode, zero-tolerant, exclusive with the others), `manufacturer` (uuid), `pieces_min`/`pieces_max` (1–50000), `sort` (`easiest|hardest` members-only → 403), `difficulty` (tier list, members-only → 403), `page` (≤500), `limit` (≤100). Rate-limited 60/min per token owner (429 + `Retry-After`). Secret `hide_until` puzzles are never returned (also fixed in `allByEan` — the web scanner leaked them), embargoed images are `null`.

**Every card always carries** `statistics` (public, split solo/duo/team from the precomputed `puzzle_statistics`), `difficulty` (members), `prediction` (member + not opted out + PAT/`results:read`) and `solves` (own history solo/duo/team, PAT/`results:read`) — `null` when the token is not entitled, never an error.

**Fixed query cost** regardless of page size — one batch query per object (`GetPuzzleStatistics::forPuzzleList`, `GetPuzzleDifficulty::forPuzzleList`, `GetPlayerPredictions::forPuzzles`, new `GetPlayerPuzzleSolves::forPuzzles`), asserted in tests: cc ≤5, non-member ≤7/8, member ≤12/13 (PAT/auth-code), identical at `limit=5` and `limit=100`.

**Foundation**: `ApiTokenOwner` (the single membership/scope gate, memoised, `ResetInterface`), `PuzzleResponseFactory`, response DTOs (`PuzzleResponse`, `PuzzleStatisticsResponse`, `PuzzleDifficultyResponse`, `TimePredictionResponse`, `PlayerSolvesResponse`, …), `PiecesRange` (replaces the bucket enum in `SearchPuzzle`, web call sites unchanged in behaviour), test traits `QueryCountAssertions` / `OpenApiAssertions`.

Tests: 31 endpoint tests (+19 data-provider cases) incl. gating matrix, 422/403/429, embargo, hidden puzzles, budgets, OpenAPI parameter coverage; unit tests for the new queries and `PiecesRange`. Full suite green. Docs: README "Puzzles" section + table, `/for-developers` row, plan §12 ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uH2n4Y6gPLiYASEJwNr3H