### PR TITLE
API: statistics, difficulty, prediction and solves on collection items and result lists at a fixed query cost

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -176,6 +176,8 @@ return static function (ContainerConfigurator $configurator): void {
             __DIR__ . '/../src/Services/SocialLogin/AppleProviderWithInlineKey.php',
             // value object, not a service
             __DIR__ . '/../src/Services/Storage/SpooledOperation.php',
+            // value object built by PuzzleResponseFactory::insightsFor(), not a service
+            __DIR__ . '/../src/Services/Api/PuzzleInsightsBatch.php',
         ]);
     $services->load('SpeedPuzzling\\Web\\Query\\', __DIR__ . '/../src/Query/**/{*.php}');
     $services->load('SpeedPuzzling\\Web\\Security\\', __DIR__ . '/../src/Security/**/{*.php}')

--- a/docs/features/api/README.md
+++ b/docs/features/api/README.md
@@ -75,27 +75,27 @@ hand-typed `SOLVING_TIMES` variant silently matched nothing until 2026-08 (PR #1
 | Method | Endpoint | Required |
 |--------|----------|----------|
 | GET | `/api/v1/me` | PAT or `profile:read` (the `email` field is populated only for PAT or tokens granted `email:read`, otherwise `null`). Also carries `has_active_membership`, `membership_ends_at` (ISO-8601, `null` without an active membership) and the owner's opt-out flags `time_predictions_opted_out`, `ranking_opted_out`, `streak_opted_out` |
-| GET | `/api/v1/me/results?type=solo\|duo\|team` | PAT or `results:read` |
+| GET | `/api/v1/me/results?type=solo\|duo\|team` | PAT or `results:read`. Each result also carries the puzzle's `statistics` (public) and `difficulty` (members, else `null`) - see Insights on lists below |
 | GET | `/api/v1/me/puzzles/{puzzleId}/predicted-time` | PAT or `results:read` |
 | GET | `/api/v1/me/statistics` | PAT or `statistics:read` |
 | POST | `/api/v1/me/solving-times` | PAT or `solving-times:write` |
 | PUT | `/api/v1/me/solving-times/{timeId}` | PAT or `solving-times:write` |
 | GET | `/api/v1/me/collections` | PAT or `collections:read` |
-| GET | `/api/v1/me/collections/{id}/items` | PAT or `collections:read` |
+| GET | `/api/v1/me/collections/{id}/items` | PAT or `collections:read`. Each item also carries `statistics` (public), `difficulty` (members), `prediction` (members, not opted out, PAT or `results:read`) and `solves` (own history, PAT or `results:read`) - see Insights on lists below |
 | POST | `/api/v1/me/collections` | PAT or `collections:write` (members only) |
 | PUT | `/api/v1/me/collections/{id}` | PAT or `collections:write` (members only) |
 | DELETE | `/api/v1/me/collections/{id}` | PAT or `collections:write` (members only) |
-| POST | `/api/v1/me/collections/{id}/items` | PAT or `collections:write` |
+| POST | `/api/v1/me/collections/{id}/items` | PAT or `collections:write` (the created item is returned in the same shape as a `GET …/items` item, the four objects included) |
 | DELETE | `/api/v1/me/collections/{id}/items/{itemId}` | PAT or `collections:write` |
 
 ### Player Endpoints (OAuth2 only)
 
 | Method | Endpoint | Scope |
 |--------|----------|-------|
-| GET | `/api/v1/players/{id}/results?type=solo\|duo\|team` | `results:read` |
+| GET | `/api/v1/players/{id}/results?type=solo\|duo\|team` | `results:read`. Each result also carries the puzzle's `statistics` (public) and `difficulty` (**token owner** member, else `null`) |
 | GET | `/api/v1/players/{id}/statistics` | `statistics:read` |
 | GET | `/api/v1/players/{id}/collections` | `collections:read` (public only) |
-| GET | `/api/v1/players/{id}/collections/{cid}/items` | `collections:read` (public only) |
+| GET | `/api/v1/players/{id}/collections/{cid}/items` | `collections:read` (public only). Each item also carries `statistics` (public), `difficulty` (**token owner** member), `solves` (the **collection owner's** history, only with `results:read` on the token) and `prediction: null` always - predictions are self-only |
 
 ### Competition Endpoints (any authenticated token)
 
@@ -189,6 +189,20 @@ An app tells the reasons for a `null` members-only block apart from `GET /api/v1
 Puzzle Insights are gated **exactly as on the website** - the token owner (PAT, or the player behind an authorization-code token) must be a member; a `client_credentials` token has no player and therefore no membership. There is deliberately no `/api/v1/players/{id}/…` variant of members-only data: predictions are self-only on the website, and a single member's token must never become a proxy that serves a members-only feature to a third-party app's non-member users.
 
 One service decides this for every provider: `ApiTokenOwner` (`src/Services/Api/`) - `profile()` (the player behind the token, `null` for a machine token, memoised per request), `isMember()`, `canReadResults()` (PAT or `results:read`), `canReadStatistics()`. Providers never `assert($user instanceof ApiUser)` outside `/me/*`; they ask `ApiTokenOwner` and return `null` objects for what the token is not entitled to. Members-only blocks are **nullable objects**: `null` ⇔ "not available to this token" (not a member / machine token / missing scope / opted out); when available, the object is always present and carries `null` inside for "not enough data" (the `GET /me` flags above tell the reasons apart). Design and progress: `docs/features/api/v1-expansion-plan.md`.
+
+#### Insights on lists (collection items, result lists)
+
+The per-puzzle objects of the puzzle card (`statistics`, `difficulty`, `prediction`, `solves` - shapes above, under Puzzles) are appended to every item of the list endpoints, **always present**, `null` when the token is not entitled. The motivating case is a collection of 500 puzzles where an app wants, per item, "how hard is it, how would I do, how often have I solved it" - at a fixed query cost.
+
+| Endpoint | `statistics` | `difficulty` | `prediction` | `solves` |
+|---|---|---|---|---|
+| `GET /me/collections/{id}/items` (and the item `POST …/items` returns) | always | token owner member | member **and** not opted out **and** PAT / `results:read` | the token owner's own, PAT / `results:read` |
+| `GET /players/{id}/collections/{cid}/items` | always | token owner member (a `client_credentials` token never) | **never** - always `null` (predictions are self-only, N1) | the **collection owner's** history, only with `results:read` on the token (the same data `/players/{id}/results` exposes) |
+| `GET /me/results`, `GET /players/{id}/results` | always | token owner member | - (no field) | - (no field) |
+
+Private profiles keep today's zeroed `/players/{id}/…` response (`count: 0`, no items) and run no batch query; an empty list runs none either. Puzzle images on these lists honour the `hide_image_until` embargo (`image` / `puzzle_image` are `null` until it ends).
+
+**Fixed query cost** (asserted at two collection sizes by `MyCollectionItemsEndpointTest`, `PlayerCollectionItemsEndpointTest`, `MyResultsInsightsEndpointTest`, `PlayerResultsInsightsEndpointTest`): every provider collects the puzzle ids once and calls `PuzzleResponseFactory::insightsFor($puzzleIds, $solvesOfPlayerId, $includePrediction)` - the same batch method the puzzle cards use - which runs one query per object the token is entitled to (`GetPuzzleStatistics::forPuzzleList`, `GetPuzzleDifficulty::forPuzzleList`, `GetPlayerPredictions::forPuzzles` (≤ 4), `GetPlayerPuzzleSolves::forPuzzles`) and hands back a `PuzzleInsightsBatch` the provider maps onto its items. Measured 2026-08-19 (request only): collection items - `client_credentials` 4-5, non-member 5-6 (PAT) / 7-8 (OAuth2), member 9-11 (PAT) / 13 (OAuth2) on `/me`, 9 on `/players`; result lists - today + 2 (non-member: statistics, owner profile) or + 3 (member: + difficulty), `client_credentials` + 1.
 
 ### GET `/api/v1/me/puzzles/{puzzleId}/predicted-time`
 
@@ -365,7 +379,7 @@ Stub endpoints for in-app purchase verification (not implemented).
 | `src/Api/V1/PuzzleDetailResponse.php` | `GET /api/v1/puzzles/{puzzleId}` resource - the card of one puzzle, built only via `fromCard()` (provider `PuzzleDetailResponseProvider`) |
 | `src/Api/V1/PuzzleResponse.php` | The puzzle card (+ `PuzzleStatisticsResponse`, `PuzzleDifficultyResponse`, `TimePredictionResponse`, `PlayerSolvesResponse`) |
 | `src/Services/Api/ApiTokenOwner.php` | The single membership / scope gate behind every provider |
-| `src/Services/Api/PuzzleResponseFactory.php` | Builds puzzle cards for the calling token at a fixed query cost (one batch call per object) |
+| `src/Services/Api/PuzzleResponseFactory.php` | Builds puzzle cards for the calling token at a fixed query cost (one batch call per object); `insightsFor()` + `PuzzleInsightsBatch` serve the collection-item and result lists with the same batch |
 | `src/Query/GetPuzzleStatistics.php`, `GetPlayerPuzzleSolves.php` | Batch queries behind the cards' `statistics` and `solves` objects |
 | `tests/QueryCountAssertions.php`, `tests/OpenApiAssertions.php` | Test traits: query budgets via the profiler, parameter documentation via `/api/docs.jsonopenapi` |
 | `src/Controller/FairUsePolicyController.php` | Fair use policy page |

--- a/docs/features/api/v1-expansion-plan.md
+++ b/docs/features/api/v1-expansion-plan.md
@@ -144,7 +144,7 @@ The motivating case: a collection with 500+ puzzles where the app wants, per ite
 
 | Endpoint | per-item objects (always present; `null` when not entitled) |
 |---|---|
-| `GET /me/collections/{id}/items` | `statistics` (public, always) · `difficulty` (owner member) · `prediction` (owner member + not opted out + PAT/`results:read`) · `solves` (own, always) |
+| `GET /me/collections/{id}/items` | `statistics` (public, always) · `difficulty` (owner member) · `prediction` (owner member + not opted out + PAT/`results:read`) · `solves` (own, PAT/`results:read` - the same gate as on `/puzzles`, §0) |
 | `GET /players/{id}/collections/{cid}/items` | `statistics` · `difficulty` (**token owner** member) · `solves` (the **collection owner's** solves — only with `results:read` on the token, and only for public profiles; the zeroed private response stays zeroed with no queries) · never `prediction` |
 | `GET /me/results`, `GET /players/{id}/results` | `statistics` · `difficulty` (token owner member) |
 
@@ -230,7 +230,7 @@ Waves (dependencies): **wave 1** PR 0 ∥ PR 1 (independent) → **wave 2** PR 2
 - [x] PR 0 `GET /me` flags
 - [x] PR 1 `GET /puzzles` + foundation (§1) (2026-08-19; `statistics` shipped split by discipline - `{ solved_times, solo, duo, team }` from `puzzle_statistics` via `GetPuzzleStatistics::forPuzzleList`, as §1.2/§13 now say; measured budgets: OAuth2 auth costs 3 queries, not 2, so auth-code tokens sit one above the §4 ceilings - cc 3-4, non-member 6 PAT / 8 OAuth2, member 10-11 PAT / 12-13 OAuth2)
 - [x] PR 2 `GET /puzzles/{id}` (2026-08-19; the detail is `PuzzleResponseFactory::card()` of the overview - no separate `PuzzleInsightsAssembler`, the factory from PR 1 already is that assembler; `MyPredictedTimeResponseProvider` now gates through `ApiTokenOwner` and flattens `TimePredictionResponse`/`PuzzleDifficultyResponse` via `PredictedTimeResponse::fromInsights()`, output byte-identical; `PuzzleOverview::hideUntil` added (loaded by `GetPuzzleOverview::byId` only) for the N5 404; measured: cc 2-3, non-member 5 PAT / 7 OAuth2, member 9-10 PAT / 11-12 OAuth2 - ceilings 4 / 6 / 8 / 11 / 13)
-- [ ] PR 3 insights & solves on lists
+- [x] PR 3 insights & solves on lists (2026-08-19; `PuzzleResponseFactory::insightsFor()` + `PuzzleInsightsBatch` shared by cards, collection items and result lists; the `POST /me/collections/{id}/items` item answers in the same shape; measured: collection items cc 4-5 / non-member 5-6 PAT, 7-8 OAuth2 / member 9-11 PAT, 13 OAuth2 on `/me`, 9 on `/players`; result lists today + ≤ 3; `solves` on `/me/*` needs PAT or `results:read` like everywhere else - §6 table corrected from "always")
 - [ ] PR 4 `prediction` on `POST /me/solving-times`
 - [ ] PR 5 puzzle library lists (wishlist, unsolved, lend/borrow, sell/swap, library summary)
 - [x] PR 5a medians in `puzzle_statistics` — code (2026-08-19: `median_time(_solo/_duo/_team)` columns, computed with `percentile_cont(0.5)` over the same per-player-best population as the averages, `median_seconds` on every `statistics` group); **backfill on the box still to do after deploy: `php bin/console myspeedpuzzling:recalculate-puzzle-statistics` once — until then `median_seconds` is `null`**

--- a/src/Api/V1/AddCollectionItemProcessor.php
+++ b/src/Api/V1/AddCollectionItemProcessor.php
@@ -13,6 +13,7 @@ use SpeedPuzzling\Web\Query\GetPlayerProfile;
 use SpeedPuzzling\Web\Repository\CollectionRepository;
 use SpeedPuzzling\Web\Repository\PuzzleRepository;
 use SpeedPuzzling\Web\Security\ApiUser;
+use SpeedPuzzling\Web\Services\Api\PuzzleResponseFactory;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -29,6 +30,7 @@ final readonly class AddCollectionItemProcessor implements ProcessorInterface
         private GetCollectionItems $getCollectionItems,
         private CollectionRepository $collectionRepository,
         private PuzzleRepository $puzzleRepository,
+        private PuzzleResponseFactory $puzzleResponseFactory,
     ) {
     }
 
@@ -78,6 +80,9 @@ final readonly class AddCollectionItemProcessor implements ProcessorInterface
             throw new \RuntimeException('Collection item was not found after adding it to the collection.');
         }
 
+        // The created item has the same shape as an item of GET /me/collections/{id}/items
+        $insights = $this->puzzleResponseFactory->insightsFor([$item->puzzleId], solvesOfPlayerId: $playerId, includePrediction: true);
+
         return new CollectionItemResponse(
             collection_item_id: $item->collectionItemId,
             puzzle_id: $item->puzzleId,
@@ -87,6 +92,10 @@ final readonly class AddCollectionItemProcessor implements ProcessorInterface
             image: $item->image,
             comment: $item->comment,
             added_at: $item->addedAt->format('c'),
+            statistics: $insights->statistics($item->puzzleId),
+            difficulty: $insights->difficulty($item->puzzleId),
+            prediction: $insights->prediction($item->puzzleId),
+            solves: $insights->solves($item->puzzleId),
         );
     }
 }

--- a/src/Api/V1/CollectionItemResponse.php
+++ b/src/Api/V1/CollectionItemResponse.php
@@ -4,6 +4,18 @@ declare(strict_types=1);
 
 namespace SpeedPuzzling\Web\Api\V1;
 
+/**
+ * One item of a puzzle collection: the flat puzzle fields plus the per-puzzle
+ * insight objects. The four trailing objects are always present in the JSON
+ * and null means exactly "not available to this token" (see
+ * docs/features/api/README.md, Members-Exclusive Data): statistics is public
+ * and always an object; difficulty needs the token owner to be a member;
+ * prediction is self-only - present on /me/collections/{id}/items for a
+ * member who has not opted out and whose token may read results, always null
+ * on /players/{id}/collections/{cid}/items; solves are the collection owner's
+ * own history (the token owner on /me, the listed player on /players/{id})
+ * when the token may read results (PAT or results:read).
+ */
 final class CollectionItemResponse
 {
     public function __construct(
@@ -15,6 +27,10 @@ final class CollectionItemResponse
         public null|string $image,
         public null|string $comment,
         public string $added_at,
+        public PuzzleStatisticsResponse $statistics,
+        public null|PuzzleDifficultyResponse $difficulty = null,
+        public null|TimePredictionResponse $prediction = null,
+        public null|PlayerSolvesResponse $solves = null,
     ) {
     }
 }

--- a/src/Api/V1/MyCollectionItemsResponseProvider.php
+++ b/src/Api/V1/MyCollectionItemsResponseProvider.php
@@ -11,6 +11,7 @@ use SpeedPuzzling\Web\Query\GetCollectionItems;
 use SpeedPuzzling\Web\Repository\CollectionRepository;
 use SpeedPuzzling\Web\Results\CollectionItemOverview;
 use SpeedPuzzling\Web\Security\ApiUser;
+use SpeedPuzzling\Web\Services\Api\PuzzleResponseFactory;
 use Symfony\Bundle\SecurityBundle\Security;
 
 /**
@@ -22,6 +23,7 @@ final readonly class MyCollectionItemsResponseProvider implements ProviderInterf
         private Security $security,
         private GetCollectionItems $getCollectionItems,
         private CollectionRepository $collectionRepository,
+        private PuzzleResponseFactory $puzzleResponseFactory,
     ) {
     }
 
@@ -48,6 +50,14 @@ final readonly class MyCollectionItemsResponseProvider implements ProviderInterf
 
         $items = $this->getCollectionItems->byCollectionAndPlayer($dbCollectionId, $playerId);
 
+        // One batch per list, whatever its size: the owner's own solves and
+        // (member, not opted out, results:read) predictions - self-only data
+        $insights = $this->puzzleResponseFactory->insightsFor(
+            array_map(static fn (CollectionItemOverview $item): string => $item->puzzleId, $items),
+            solvesOfPlayerId: $playerId,
+            includePrediction: true,
+        );
+
         return new MyCollectionItemsResponse(
             collection_id: $collectionId,
             count: count($items),
@@ -61,6 +71,10 @@ final readonly class MyCollectionItemsResponseProvider implements ProviderInterf
                     image: $item->image,
                     comment: $item->comment,
                     added_at: $item->addedAt->format('c'),
+                    statistics: $insights->statistics($item->puzzleId),
+                    difficulty: $insights->difficulty($item->puzzleId),
+                    prediction: $insights->prediction($item->puzzleId),
+                    solves: $insights->solves($item->puzzleId),
                 ),
                 $items,
             ),

--- a/src/Api/V1/MyResultsResponseProvider.php
+++ b/src/Api/V1/MyResultsResponseProvider.php
@@ -9,6 +9,7 @@ use ApiPlatform\State\ProviderInterface;
 use SpeedPuzzling\Web\Query\GetPlayerSolvedPuzzles;
 use SpeedPuzzling\Web\Results\SolvedPuzzle;
 use SpeedPuzzling\Web\Security\ApiUser;
+use SpeedPuzzling\Web\Services\Api\PuzzleResponseFactory;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -21,6 +22,7 @@ final readonly class MyResultsResponseProvider implements ProviderInterface
         private Security $security,
         private GetPlayerSolvedPuzzles $getPlayerSolvedPuzzles,
         private RequestStack $requestStack,
+        private PuzzleResponseFactory $puzzleResponseFactory,
     ) {
     }
 
@@ -40,6 +42,15 @@ final readonly class MyResultsResponseProvider implements ProviderInterface
             default => $this->getPlayerSolvedPuzzles->soloByPlayerId($playerId),
         };
 
+        // One batch per list, whatever its size: community statistics (public)
+        // and difficulty (token owner member); a result list has no solves or
+        // prediction object
+        $insights = $this->puzzleResponseFactory->insightsFor(
+            array_map(static fn (SolvedPuzzle $puzzle): string => $puzzle->puzzleId, $results),
+            solvesOfPlayerId: null,
+            includePrediction: false,
+        );
+
         return new MyResultsResponse(
             player_id: $playerId,
             type: $type,
@@ -56,6 +67,8 @@ final readonly class MyResultsResponseProvider implements ProviderInterface
                     first_attempt: $puzzle->firstAttempt,
                     puzzle_image: $puzzle->puzzleImage,
                     comment: $puzzle->comment,
+                    statistics: $insights->statistics($puzzle->puzzleId),
+                    difficulty: $insights->difficulty($puzzle->puzzleId),
                 ),
                 $results,
             ),

--- a/src/Api/V1/PlayerCollectionItemsResponseProvider.php
+++ b/src/Api/V1/PlayerCollectionItemsResponseProvider.php
@@ -11,6 +11,7 @@ use SpeedPuzzling\Web\Exceptions\CollectionNotFound;
 use SpeedPuzzling\Web\Query\GetCollectionItems;
 use SpeedPuzzling\Web\Query\GetPlayerProfile;
 use SpeedPuzzling\Web\Results\CollectionItemOverview;
+use SpeedPuzzling\Web\Services\Api\PuzzleResponseFactory;
 
 /**
  * @implements ProviderInterface<PlayerCollectionItemsResponse>
@@ -20,6 +21,7 @@ final readonly class PlayerCollectionItemsResponseProvider implements ProviderIn
     public function __construct(
         private GetCollectionItems $getCollectionItems,
         private GetPlayerProfile $getPlayerProfile,
+        private PuzzleResponseFactory $puzzleResponseFactory,
     ) {
     }
 
@@ -50,6 +52,15 @@ final readonly class PlayerCollectionItemsResponseProvider implements ProviderIn
 
         $items = $this->getCollectionItems->byCollectionAndPlayer($dbCollectionId, $playerId);
 
+        // One batch per list, whatever its size. The solves are the collection
+        // owner's (results:read data, so only for a token that may read results);
+        // predictions are self-only and never appear on /players/{id} (N1)
+        $insights = $this->puzzleResponseFactory->insightsFor(
+            array_map(static fn (CollectionItemOverview $item): string => $item->puzzleId, $items),
+            solvesOfPlayerId: $playerId,
+            includePrediction: false,
+        );
+
         return new PlayerCollectionItemsResponse(
             collection_id: $collectionId,
             count: count($items),
@@ -63,6 +74,10 @@ final readonly class PlayerCollectionItemsResponseProvider implements ProviderIn
                     image: $item->image,
                     comment: $item->comment,
                     added_at: $item->addedAt->format('c'),
+                    statistics: $insights->statistics($item->puzzleId),
+                    difficulty: $insights->difficulty($item->puzzleId),
+                    prediction: null,
+                    solves: $insights->solves($item->puzzleId),
                 ),
                 $items,
             ),

--- a/src/Api/V1/PlayerResultResponse.php
+++ b/src/Api/V1/PlayerResultResponse.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace SpeedPuzzling\Web\Api\V1;
 
+/**
+ * One solving time of a result list, with the solved puzzle's community
+ * statistics (public, always an object) and difficulty (members-only: null
+ * when the token owner is not a member or the token is a machine token - see
+ * docs/features/api/README.md, Members-Exclusive Data).
+ */
 final class PlayerResultResponse
 {
     public function __construct(
@@ -17,6 +23,8 @@ final class PlayerResultResponse
         public bool $first_attempt,
         public null|string $puzzle_image,
         public null|string $comment,
+        public PuzzleStatisticsResponse $statistics,
+        public null|PuzzleDifficultyResponse $difficulty = null,
     ) {
     }
 }

--- a/src/Api/V1/PlayerResultsResponseProvider.php
+++ b/src/Api/V1/PlayerResultsResponseProvider.php
@@ -9,6 +9,7 @@ use ApiPlatform\State\ProviderInterface;
 use SpeedPuzzling\Web\Query\GetPlayerProfile;
 use SpeedPuzzling\Web\Query\GetPlayerSolvedPuzzles;
 use SpeedPuzzling\Web\Results\SolvedPuzzle;
+use SpeedPuzzling\Web\Services\Api\PuzzleResponseFactory;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -20,6 +21,7 @@ final readonly class PlayerResultsResponseProvider implements ProviderInterface
         private GetPlayerSolvedPuzzles $getPlayerSolvedPuzzles,
         private RequestStack $requestStack,
         private GetPlayerProfile $getPlayerProfile,
+        private PuzzleResponseFactory $puzzleResponseFactory,
     ) {
     }
 
@@ -48,6 +50,15 @@ final readonly class PlayerResultsResponseProvider implements ProviderInterface
             default => $this->getPlayerSolvedPuzzles->soloByPlayerId($playerId),
         };
 
+        // One batch per list, whatever its size: community statistics (public)
+        // and difficulty (token owner member); a result list has no solves or
+        // prediction object
+        $insights = $this->puzzleResponseFactory->insightsFor(
+            array_map(static fn (SolvedPuzzle $puzzle): string => $puzzle->puzzleId, $results),
+            solvesOfPlayerId: null,
+            includePrediction: false,
+        );
+
         return new PlayerResultsResponse(
             player_id: $playerId,
             type: $type,
@@ -64,6 +75,8 @@ final readonly class PlayerResultsResponseProvider implements ProviderInterface
                     first_attempt: $puzzle->firstAttempt,
                     puzzle_image: $puzzle->puzzleImage,
                     comment: $puzzle->comment,
+                    statistics: $insights->statistics($puzzle->puzzleId),
+                    difficulty: $insights->difficulty($puzzle->puzzleId),
                 ),
                 $results,
             ),

--- a/src/Services/Api/PuzzleInsightsBatch.php
+++ b/src/Services/Api/PuzzleInsightsBatch.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Services\Api;
+
+use SpeedPuzzling\Web\Api\V1\PlayerSolvesResponse;
+use SpeedPuzzling\Web\Api\V1\PuzzleDifficultyResponse;
+use SpeedPuzzling\Web\Api\V1\PuzzleStatisticsResponse;
+use SpeedPuzzling\Web\Api\V1\TimePredictionResponse;
+use SpeedPuzzling\Web\Results\PlayerPuzzleSolves;
+use SpeedPuzzling\Web\Results\PuzzleDifficultyResult;
+use SpeedPuzzling\Web\Results\PuzzleStatisticsResult;
+use SpeedPuzzling\Web\Results\TimePredictionResult;
+
+/**
+ * The per-puzzle insight objects of one API list, loaded in batch by
+ * PuzzleResponseFactory::insightsFor() and already gated for the calling
+ * token: an object type the token is not entitled to is null for every
+ * puzzle of the list; an entitled object is always present, synthesising
+ * "no data" (zeros, nulls, "insufficient") for puzzles the batch queries did
+ * not return.
+ */
+final readonly class PuzzleInsightsBatch
+{
+    /**
+     * @param array<string, PuzzleStatisticsResult> $statistics keyed by puzzle id; absent = never solved
+     * @param null|array<string, PuzzleDifficultyResult> $difficulties null = not entitled; absent id = no row yet
+     * @param null|array<string, TimePredictionResult> $predictions null = not entitled; absent id = nothing to predict from
+     * @param null|array<string, PlayerPuzzleSolves> $solves null = not entitled; absent id = never solved
+     */
+    public function __construct(
+        private array $statistics,
+        private null|array $difficulties,
+        private null|array $predictions,
+        private null|array $solves,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self(statistics: [], difficulties: null, predictions: null, solves: null);
+    }
+
+    public function statistics(string $puzzleId): PuzzleStatisticsResponse
+    {
+        return PuzzleStatisticsResponse::fromResult($this->statistics[$puzzleId] ?? PuzzleStatisticsResult::empty($puzzleId));
+    }
+
+    public function difficulty(string $puzzleId): null|PuzzleDifficultyResponse
+    {
+        if ($this->difficulties === null) {
+            return null;
+        }
+
+        return isset($this->difficulties[$puzzleId])
+            ? PuzzleDifficultyResponse::fromResult($this->difficulties[$puzzleId])
+            : PuzzleDifficultyResponse::insufficient();
+    }
+
+    public function prediction(string $puzzleId): null|TimePredictionResponse
+    {
+        if ($this->predictions === null) {
+            return null;
+        }
+
+        return TimePredictionResponse::fromResult($this->predictions[$puzzleId] ?? null);
+    }
+
+    public function solves(string $puzzleId): null|PlayerSolvesResponse
+    {
+        if ($this->solves === null) {
+            return null;
+        }
+
+        return PlayerSolvesResponse::fromResult($this->solves[$puzzleId] ?? PlayerPuzzleSolves::empty($puzzleId));
+    }
+}

--- a/src/Services/Api/PuzzleResponseFactory.php
+++ b/src/Services/Api/PuzzleResponseFactory.php
@@ -4,35 +4,34 @@ declare(strict_types=1);
 
 namespace SpeedPuzzling\Web\Services\Api;
 
-use SpeedPuzzling\Web\Api\V1\PlayerSolvesResponse;
-use SpeedPuzzling\Web\Api\V1\PuzzleDifficultyResponse;
 use SpeedPuzzling\Web\Api\V1\PuzzleManufacturerResponse;
 use SpeedPuzzling\Web\Api\V1\PuzzleResponse;
-use SpeedPuzzling\Web\Api\V1\PuzzleStatisticsResponse;
-use SpeedPuzzling\Web\Api\V1\TimePredictionResponse;
 use SpeedPuzzling\Web\Query\GetPlayerPredictions;
 use SpeedPuzzling\Web\Query\GetPlayerPuzzleSolves;
 use SpeedPuzzling\Web\Query\GetPuzzleDifficulty;
 use SpeedPuzzling\Web\Query\GetPuzzleStatistics;
-use SpeedPuzzling\Web\Results\PlayerPuzzleSolves;
 use SpeedPuzzling\Web\Results\PuzzleOverview;
-use SpeedPuzzling\Web\Results\PuzzleStatisticsResult;
 
 /**
- * Builds the public API's puzzle cards for the calling token, at a fixed
- * query cost: whatever the list size, one batch query for the community
- * statistics (GetPuzzleStatistics::forPuzzleList) and at most one per insight
- * object - difficulty (GetPuzzleDifficulty::forPuzzleList), the owner's
+ * Builds the public API's per-puzzle insight objects for the calling token,
+ * at a fixed query cost: whatever the list size, one batch query for the
+ * community statistics (GetPuzzleStatistics::forPuzzleList) and at most one
+ * per insight object - difficulty (GetPuzzleDifficulty::forPuzzleList),
  * predictions (GetPlayerPredictions::forPuzzles, itself at most 4 queries) and
- * the owner's solves (GetPlayerPuzzleSolves::forPuzzles) - each of the latter
- * only when the token is entitled to the object at all. What the token is not
- * entitled to is null on every card, never an error (plan §0 N1/N3).
+ * solves (GetPlayerPuzzleSolves::forPuzzles) - each of the latter only when
+ * the token is entitled to the object at all. What the token is not entitled
+ * to is null on every item, never an error (plan §0 N1/N3). One implementation
+ * serves the puzzle cards (/puzzles), collection items and result lists.
  *
  * Gates (docs/features/api/README.md, Members-Exclusive Data):
+ *   statistics  - public, always
  *   difficulty  - token owner is a member
- *   prediction  - owner is a member, has not opted out of time predictions,
- *                 and the token may read results (PAT or results:read)
- *   solves      - there is an owner and the token may read results
+ *   prediction  - only where the endpoint is self-only (includePrediction),
+ *                 and the owner is a member, has not opted out of time
+ *                 predictions, and the token may read results (PAT or results:read)
+ *   solves      - a player whose solves to show was given (the token owner on
+ *                 /me and /puzzles, the collection owner on /players/{id}/…)
+ *                 and the token may read results
  */
 final readonly class PuzzleResponseFactory
 {
@@ -43,6 +42,51 @@ final readonly class PuzzleResponseFactory
         private GetPlayerPredictions $getPlayerPredictions,
         private GetPlayerPuzzleSolves $getPlayerPuzzleSolves,
     ) {
+    }
+
+    /**
+     * The insight objects for a list of puzzles, gated for the calling token.
+     * Duplicate ids are fine (a result list repeats a puzzle per solve); an
+     * empty list costs no query at all.
+     *
+     * @param array<string> $puzzleIds
+     * @param null|string $solvesOfPlayerId whose solves the "solves" object shows; null = the endpoint has no solves object
+     * @param bool $includePrediction whether the endpoint carries the self-only "prediction" object at all
+     */
+    public function insightsFor(array $puzzleIds, null|string $solvesOfPlayerId, bool $includePrediction): PuzzleInsightsBatch
+    {
+        $puzzleIds = array_values(array_unique($puzzleIds));
+
+        if ($puzzleIds === []) {
+            return PuzzleInsightsBatch::empty();
+        }
+
+        $isMember = $this->tokenOwner->isMember();
+        $canReadResults = $this->tokenOwner->canReadResults();
+
+        $predictionsOf = null;
+
+        if ($includePrediction && $isMember && $canReadResults) {
+            $profile = $this->tokenOwner->profile();
+
+            if ($profile !== null && $profile->timePredictionsOptedOut === false) {
+                $predictionsOf = $profile->playerId;
+            }
+        }
+
+        return new PuzzleInsightsBatch(
+            // public, always; a puzzle nobody has solved has no row
+            statistics: $this->getPuzzleStatistics->forPuzzleList($puzzleIds),
+            difficulties: $isMember
+                ? $this->getPuzzleDifficulty->forPuzzleList($puzzleIds)
+                : null,
+            predictions: $predictionsOf !== null
+                ? $this->getPlayerPredictions->forPuzzles($predictionsOf, $puzzleIds)
+                : null,
+            solves: $solvesOfPlayerId !== null && $canReadResults
+                ? $this->getPlayerPuzzleSolves->forPuzzles($solvesOfPlayerId, $puzzleIds)
+                : null,
+        );
     }
 
     /**
@@ -58,26 +102,11 @@ final readonly class PuzzleResponseFactory
 
         $puzzleIds = array_map(static fn (PuzzleOverview $overview): string => $overview->puzzleId, $overviews);
 
-        $profile = $this->tokenOwner->profile();
-        $isMember = $this->tokenOwner->isMember();
-        $canReadResults = $this->tokenOwner->canReadResults();
-
-        // public, always; a puzzle nobody has solved has no row
-        $statistics = $this->getPuzzleStatistics->forPuzzleList($puzzleIds);
-
-        // null = not entitled (the object is null on every card); array = entitled,
-        // keyed by puzzle id, with a default synthesised for ids the query did not return
-        $difficulties = $isMember
-            ? $this->getPuzzleDifficulty->forPuzzleList($puzzleIds)
-            : null;
-
-        $predictions = $profile !== null && $isMember && $profile->timePredictionsOptedOut === false && $canReadResults
-            ? $this->getPlayerPredictions->forPuzzles($profile->playerId, $puzzleIds)
-            : null;
-
-        $solves = $profile !== null && $canReadResults
-            ? $this->getPlayerPuzzleSolves->forPuzzles($profile->playerId, $puzzleIds)
-            : null;
+        $insights = $this->insightsFor(
+            $puzzleIds,
+            solvesOfPlayerId: $this->tokenOwner->profile()?->playerId,
+            includePrediction: true,
+        );
 
         $cards = [];
 
@@ -98,16 +127,10 @@ final readonly class PuzzleResponseFactory
                 identification_number: $overview->puzzleIdentificationNumber,
                 is_available: $overview->isAvailable,
                 is_approved: $overview->puzzleApproved,
-                statistics: PuzzleStatisticsResponse::fromResult($statistics[$puzzleId] ?? PuzzleStatisticsResult::empty($puzzleId)),
-                difficulty: $difficulties === null
-                    ? null
-                    : (isset($difficulties[$puzzleId]) ? PuzzleDifficultyResponse::fromResult($difficulties[$puzzleId]) : PuzzleDifficultyResponse::insufficient()),
-                prediction: $predictions === null
-                    ? null
-                    : TimePredictionResponse::fromResult($predictions[$puzzleId] ?? null),
-                solves: $solves === null
-                    ? null
-                    : PlayerSolvesResponse::fromResult($solves[$puzzleId] ?? PlayerPuzzleSolves::empty($puzzleId)),
+                statistics: $insights->statistics($puzzleId),
+                difficulty: $insights->difficulty($puzzleId),
+                prediction: $insights->prediction($puzzleId),
+                solves: $insights->solves($puzzleId),
             );
         }
 

--- a/tests/Controller/Api/V1/MyCollectionItemsEndpointTest.php
+++ b/tests/Controller/Api/V1/MyCollectionItemsEndpointTest.php
@@ -1,0 +1,624 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use SpeedPuzzling\Web\Entity\Collection;
+use SpeedPuzzling\Web\Entity\CollectionItem;
+use SpeedPuzzling\Web\Entity\Player;
+use SpeedPuzzling\Web\Entity\Puzzle;
+use SpeedPuzzling\Web\Entity\PuzzleDifficulty;
+use SpeedPuzzling\Web\Tests\DataFixtures\CollectionFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\CollectionItemFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
+use SpeedPuzzling\Web\Tests\PatTestHelper;
+use SpeedPuzzling\Web\Tests\QueryCountAssertions;
+use SpeedPuzzling\Web\Value\CollectionVisibility;
+use SpeedPuzzling\Web\Value\MetricConfidence;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * GET /api/v1/me/collections/{collectionId}/items - every item carries
+ * statistics (public), difficulty (members), prediction (members, self-only)
+ * and solves (own history), gated per token exactly as on the website and at
+ * a fixed query cost whatever the collection size.
+ *
+ * Fixtures (.claude/fixtures.md): PLAYER_REGULAR is not a member and owns
+ * COLLECTION_FAVORITES (PUZZLE_500_01, PUZZLE_500_02) with three solo solves of
+ * PUZZLE_500_02 (2200, 1900, 1700 s); PLAYER_WITH_STRIPE is a member and owns
+ * COLLECTION_PUBLIC (8 puzzles, among them PUZZLE_500_01 solved once in 2100 s).
+ *
+ * @phpstan-type StatisticsGroup array{count: int, fastest_seconds: null|int, average_seconds: null|int, slowest_seconds: null|int, median_seconds: null|int}
+ * @phpstan-type SolvesGroup array{count: int, best_time_seconds: null|int, last_time_seconds: null|int, first_solved_at: null|string, last_solved_at: null|string}
+ * @phpstan-type Item array{
+ *     collection_item_id: string,
+ *     puzzle_id: string,
+ *     puzzle_name: string,
+ *     manufacturer_name: null|string,
+ *     pieces_count: int,
+ *     image: null|string,
+ *     comment: null|string,
+ *     added_at: string,
+ *     statistics: array{solved_times: int, solo: StatisticsGroup, duo: StatisticsGroup, team: StatisticsGroup},
+ *     difficulty: null|array{score: null|float, level: null|string, confidence: string, sample_size: int},
+ *     prediction: null|array{predicted_seconds: null|int, range_low_seconds: null|int, range_high_seconds: null|int, is_personalized: bool, personal_solve_count: null|int, predicted_attempt_number: null|int, last_time_seconds: null|int},
+ *     solves: null|array{solo: SolvesGroup, duo: SolvesGroup, team: SolvesGroup},
+ * }
+ * @phpstan-type ListResponse array{collection_id: string, count: int, items: list<Item>}
+ */
+final class MyCollectionItemsEndpointTest extends WebTestCase
+{
+    use QueryCountAssertions;
+
+    /** @var list<string> the item fields before the insight objects were added - must stay byte-identical */
+    private const array ORIGINAL_ITEM_KEYS = ['collection_item_id', 'puzzle_id', 'puzzle_name', 'manufacturer_name', 'pieces_count', 'image', 'comment', 'added_at'];
+
+    private const array EMPTY_SOLVES_GROUP = ['count' => 0, 'best_time_seconds' => null, 'last_time_seconds' => null, 'first_solved_at' => null, 'last_solved_at' => null];
+
+    /**
+     * The pre-change fields keep their names, order and values; the four
+     * objects are appended in a fixed order.
+     */
+    public function testExistingFieldsAreUnchangedAndTheInsightObjectsAreAppended(): void
+    {
+        $browser = self::createClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_FAVORITES));
+        $this->assertResponseIsSuccessful();
+
+        $raw = $this->decodeJson($browser);
+        $this->assertSame(CollectionFixture::COLLECTION_FAVORITES, $raw['collection_id'] ?? null);
+        $this->assertSame(2, $raw['count'] ?? null);
+        $rawItems = $raw['items'] ?? null;
+        $this->assertIsArray($rawItems);
+        $this->assertCount(2, $rawItems);
+
+        foreach ($rawItems as $rawItem) {
+            $this->assertSame(
+                [...self::ORIGINAL_ITEM_KEYS, 'statistics', 'difficulty', 'prediction', 'solves'],
+                $this->keys($rawItem),
+            );
+            $this->assertIsArray($rawItem);
+            $rawStatistics = $rawItem['statistics'];
+            $this->assertIsArray($rawStatistics);
+            $this->assertSame(['solved_times', 'solo', 'duo', 'team'], array_keys($rawStatistics));
+            $this->assertSame(['count', 'fastest_seconds', 'average_seconds', 'slowest_seconds', 'median_seconds'], $this->keys($rawStatistics['solo']));
+            $rawSolves = $rawItem['solves'];
+            $this->assertIsArray($rawSolves);
+            $this->assertSame(['solo', 'duo', 'team'], array_keys($rawSolves));
+            $this->assertSame(['count', 'best_time_seconds', 'last_time_seconds', 'first_solved_at', 'last_solved_at'], $this->keys($rawSolves['solo']));
+        }
+
+        // the values the endpoint returned before this change (fixture data, newest first)
+        $items = $this->decode($browser)['items'];
+        $this->assertSame(CollectionItemFixture::ITEM_08, $items[0]['collection_item_id']);
+        $this->assertSame(PuzzleFixture::PUZZLE_500_02, $items[0]['puzzle_id']);
+        $this->assertSame('Puzzle 2', $items[0]['puzzle_name']);
+        $this->assertSame('Ravensburger', $items[0]['manufacturer_name']);
+        $this->assertSame(500, $items[0]['pieces_count']);
+        $this->assertNull($items[0]['image']);
+        $this->assertSame('Solved this 3 times, love it!', $items[0]['comment']);
+        $this->assertNotFalse(DateTimeImmutable::createFromFormat(DATE_ATOM, $items[0]['added_at']));
+
+        $this->assertSame(CollectionItemFixture::ITEM_07, $items[1]['collection_item_id']);
+        $this->assertSame(PuzzleFixture::PUZZLE_500_01, $items[1]['puzzle_id']);
+        $this->assertSame('Puzzle 1', $items[1]['puzzle_name']);
+        $this->assertSame('Ravensburger', $items[1]['manufacturer_name']);
+        $this->assertSame(500, $items[1]['pieces_count']);
+        $this->assertNull($items[1]['image']);
+        $this->assertNull($items[1]['comment']);
+        $this->assertGreaterThan(
+            new DateTimeImmutable($items[1]['added_at']),
+            new DateTimeImmutable($items[0]['added_at']),
+        );
+    }
+
+    public function testNonMemberGetsStatisticsAndOwnSolvesButNoDifficultyOrPrediction(): void
+    {
+        $browser = self::createClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_FAVORITES));
+        $this->assertResponseIsSuccessful();
+
+        $item = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_02);
+
+        // community statistics, public, split by discipline: ten solo solves of PUZZLE_500_02 in the fixtures
+        $this->assertSame(10, $item['statistics']['solved_times']);
+        $this->assertSame(10, $item['statistics']['solo']['count']);
+        $this->assertSame(1350, $item['statistics']['solo']['fastest_seconds']);
+        $this->assertSame(2500, $item['statistics']['solo']['slowest_seconds']);
+        $this->assertSame(0, $item['statistics']['duo']['count']);
+        $this->assertSame(0, $item['statistics']['team']['count']);
+
+        $this->assertNull($item['difficulty']);
+        $this->assertNull($item['prediction']);
+
+        // own solves: three solo solves, 2200 → 1900 → 1700, the duo and team disciplines untouched
+        $solves = $item['solves'];
+        $this->assertNotNull($solves);
+        $this->assertSame(3, $solves['solo']['count']);
+        $this->assertSame(1700, $solves['solo']['best_time_seconds']);
+        $this->assertSame(1700, $solves['solo']['last_time_seconds']);
+        $this->assertIsString($solves['solo']['first_solved_at']);
+        $this->assertIsString($solves['solo']['last_solved_at']);
+        $this->assertLessThan(new DateTimeImmutable($solves['solo']['last_solved_at']), new DateTimeImmutable($solves['solo']['first_solved_at']));
+        $this->assertSame(self::EMPTY_SOLVES_GROUP, $solves['duo']);
+        $this->assertSame(self::EMPTY_SOLVES_GROUP, $solves['team']);
+
+        // PUZZLE_500_01: three solo solves (1800, a 1850 competition time, 1750) - competition times are the player's own results too
+        $solves = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_01)['solves'];
+        $this->assertNotNull($solves);
+        $this->assertSame(3, $solves['solo']['count']);
+        $this->assertSame(1750, $solves['solo']['best_time_seconds']);
+        $this->assertSame(1750, $solves['solo']['last_time_seconds']);
+    }
+
+    public function testMemberGetsDifficultyAndPrediction(): void
+    {
+        $browser = self::createClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 1.18, MetricConfidence::Medium);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame(8, $response['count']);
+
+        $this->assertSame(
+            ['score' => 1.18, 'level' => 'challenging', 'confidence' => 'medium', 'sample_size' => 20],
+            $this->item($response, PuzzleFixture::PUZZLE_500_02)['difficulty'],
+        );
+        // a puzzle without a difficulty row: "insufficient data", not "members only"
+        $this->assertSame(
+            ['score' => null, 'level' => null, 'confidence' => 'insufficient', 'sample_size' => 0],
+            $this->item($response, PuzzleFixture::PUZZLE_500_04)['difficulty'],
+        );
+
+        // PUZZLE_500_01: solved once (2100 s) - personal prediction and own solves
+        $rawSolved = $this->rawItem($browser, PuzzleFixture::PUZZLE_500_01);
+        $this->assertSame(['score', 'level', 'confidence', 'sample_size'], $this->keys($rawSolved['difficulty']));
+        $this->assertSame(
+            ['predicted_seconds', 'range_low_seconds', 'range_high_seconds', 'is_personalized', 'personal_solve_count', 'predicted_attempt_number', 'last_time_seconds'],
+            $this->keys($rawSolved['prediction']),
+        );
+        $solved = $this->item($response, PuzzleFixture::PUZZLE_500_01);
+        $prediction = $solved['prediction'];
+        $this->assertNotNull($prediction);
+        $this->assertTrue($prediction['is_personalized']);
+        $this->assertSame(1, $prediction['personal_solve_count']);
+        $this->assertSame(2, $prediction['predicted_attempt_number']);
+        $this->assertSame(2100, $prediction['last_time_seconds']);
+        $this->assertIsInt($prediction['predicted_seconds']);
+        $solves = $solved['solves'];
+        $this->assertNotNull($solves);
+        $this->assertSame(1, $solves['solo']['count']);
+        $this->assertSame(2100, $solves['solo']['best_time_seconds']);
+
+        // PUZZLE_500_04: never solved, nothing to predict from - the object is present, all null
+        $this->assertSame(
+            ['predicted_seconds' => null, 'range_low_seconds' => null, 'range_high_seconds' => null, 'is_personalized' => false, 'personal_solve_count' => null, 'predicted_attempt_number' => null, 'last_time_seconds' => null],
+            $this->item($response, PuzzleFixture::PUZZLE_500_04)['prediction'],
+        );
+    }
+
+    /**
+     * prediction and solves are results data: a collections:read token without
+     * results:read gets difficulty only; with results:read it gets all three.
+     */
+    public function testAuthorizationCodeTokenNeedsResultsReadForPredictionAndSolves(): void
+    {
+        $browser = self::createClient();
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['collections:read']);
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $item = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_01);
+        $this->assertIsArray($item['difficulty']);
+        $this->assertNull($item['prediction']);
+        $this->assertNull($item['solves']);
+        $this->assertGreaterThan(0, $item['statistics']['solved_times']);
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['collections:read', 'results:read']);
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $item = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_01);
+        $this->assertIsArray($item['difficulty']);
+        $this->assertTrue($item['prediction']['is_personalized'] ?? null);
+        $this->assertSame(1, $item['solves']['solo']['count'] ?? null);
+
+        // a non-member with results:read: solves yes, the members-only objects no
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['collections:read', 'results:read']);
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_FAVORITES));
+        $this->assertResponseIsSuccessful();
+        $item = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_02);
+        $this->assertNull($item['difficulty']);
+        $this->assertNull($item['prediction']);
+        $this->assertSame(3, $item['solves']['solo']['count'] ?? null);
+    }
+
+    public function testOptedOutMemberKeepsDifficultyAndSolvesButGetsNoPrediction(): void
+    {
+        $browser = self::createClient();
+        $this->optOutOfTimePredictions($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+
+        foreach ($this->decode($browser)['items'] as $item) {
+            $this->assertNull($item['prediction']);
+            $this->assertIsArray($item['difficulty']);
+            $this->assertIsArray($item['solves']);
+        }
+    }
+
+    public function testEmbargoedImageIsNull(): void
+    {
+        $browser = self::createClient();
+        $this->setImage($browser, PuzzleFixture::PUZZLE_500_02, 'puzzles/test/box.jpg', hideUntil: new DateTimeImmutable('+30 days'));
+        $this->setImage($browser, PuzzleFixture::PUZZLE_500_01, 'puzzles/test/other.jpg', hideUntil: null);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_FAVORITES));
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertNull($this->item($response, PuzzleFixture::PUZZLE_500_02)['image']);
+        $this->assertSame('puzzles/test/other.jpg', $this->item($response, PuzzleFixture::PUZZLE_500_01)['image']);
+    }
+
+    /**
+     * The query cost is fixed per request and does not grow with the number
+     * of items (docs/features/api/v1-expansion-plan.md §6, N3). Measured
+     * (2026-08-19): authentication 1 query (PAT) / 3 (OAuth2), the collection
+     * lookup 1 (named collections), the items 1; then statistics 1, the
+     * owner's profile 1, and per entitlement solves 1, difficulty 1 and
+     * predictions 3-4 (GetPlayerPredictions runs its statistical query only
+     * when the list holds a puzzle the owner has not solved).
+     */
+    public function testQueryBudgets(): void
+    {
+        $browser = self::createClient();
+
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_FAVORITES));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 6, 'non-member PAT (statistics, profile, solves)');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['collections:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_FAVORITES));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 7, 'non-member authorization-code token without results:read (statistics, profile)');
+
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 11, 'member PAT (statistics, profile, difficulty, predictions, solves)');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['collections:read', 'results:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 13, 'member authorization-code token');
+    }
+
+    /**
+     * A member pays the same number of queries for a collection of one puzzle
+     * as for one of twenty - both collections hold a puzzle the member has not
+     * solved, so both take the complete prediction path and the comparison is
+     * about the size only.
+     */
+    public function testQueryCountDoesNotGrowWithTheCollectionSize(): void
+    {
+        $browser = self::createClient();
+        $single = $this->seedCollection($browser, PlayerFixture::PLAYER_WITH_STRIPE, [PuzzleFixture::PUZZLE_9000]);
+        $this->seedCollectionItems($browser, CollectionFixture::COLLECTION_PUBLIC, PlayerFixture::PLAYER_WITH_STRIPE, [
+            PuzzleFixture::PUZZLE_500_03,
+            PuzzleFixture::PUZZLE_1000_02,
+            PuzzleFixture::PUZZLE_1000_04,
+            PuzzleFixture::PUZZLE_1500_01,
+            PuzzleFixture::PUZZLE_1500_02,
+            PuzzleFixture::PUZZLE_2000,
+            PuzzleFixture::PUZZLE_3000,
+            PuzzleFixture::PUZZLE_4000,
+            PuzzleFixture::PUZZLE_5000,
+            PuzzleFixture::PUZZLE_6000,
+            PuzzleFixture::PUZZLE_9000,
+            PuzzleFixture::PUZZLE_UNAPPROVED,
+        ]);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        // warm-up: a token's first request may find entities the helper saved
+        // in the entity manager (one lookup fewer) - a test artefact that would
+        // skew the comparison
+        $browser->request('GET', $this->path($single));
+        $this->assertResponseIsSuccessful();
+
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path($single));
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(1, $this->decode($browser)['count']);
+        $atOne = $this->queryCount($browser);
+
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(20, $this->decode($browser)['count']);
+        $this->assertSame($atOne, $this->queryCount($browser), 'A member pays the same number of queries for 20 items as for 1');
+    }
+
+    /**
+     * POST /me/collections/{id}/items answers with the same item shape, the
+     * four objects included (gated the same way; a non-member PAT here).
+     */
+    public function testAddedItemCarriesTheSameObjects(): void
+    {
+        $browser = self::createClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request(
+            'POST',
+            $this->path('default'),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode(['puzzle_id' => PuzzleFixture::PUZZLE_500_02]),
+        );
+        $this->assertResponseIsSuccessful();
+
+        $raw = $this->decodeJson($browser);
+        $this->assertSame([...self::ORIGINAL_ITEM_KEYS, 'statistics', 'difficulty', 'prediction', 'solves'], array_keys($raw));
+        $this->assertSame(PuzzleFixture::PUZZLE_500_02, $raw['puzzle_id']);
+        /** @var Item $item */
+        $item = $raw;
+        $this->assertSame(10, $item['statistics']['solved_times']);
+        $this->assertNull($item['difficulty']);
+        $this->assertNull($item['prediction']);
+        $solves = $item['solves'];
+        $this->assertNotNull($solves);
+        $this->assertSame(3, $solves['solo']['count']);
+        $this->assertSame(1700, $solves['solo']['best_time_seconds']);
+    }
+
+    public function testEmptyCollectionRunsNoBatchQuery(): void
+    {
+        $browser = self::createClient();
+        $empty = $this->seedCollection($browser, PlayerFixture::PLAYER_WITH_STRIPE, []);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path($empty));
+        $this->assertResponseIsSuccessful();
+
+        $response = $this->decode($browser);
+        $this->assertSame($empty, $response['collection_id']);
+        $this->assertSame(0, $response['count']);
+        $this->assertSame([], $response['items']);
+        // authentication, the collection lookup, the (empty) items - nothing else
+        $this->assertQueryCountAtMost($browser, 3, 'member PAT, empty collection');
+    }
+
+    private function path(string $collectionId): string
+    {
+        return '/api/v1/me/collections/' . $collectionId . '/items';
+    }
+
+    private function authenticatePat(KernelBrowser $browser, string $playerId): void
+    {
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, $playerId));
+    }
+
+    /**
+     * @param array<non-empty-string> $scopes
+     */
+    private function authenticateOAuth2(KernelBrowser $browser, string $playerId, array $scopes): void
+    {
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            $playerId,
+            $scopes,
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    private function seedDifficulty(KernelBrowser $browser, string $puzzleId, float $score, MetricConfidence $confidence): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $difficulty = $entityManager->find(PuzzleDifficulty::class, $puzzleId) ?? new PuzzleDifficulty($puzzle);
+        $difficulty->updateDifficulty($score, $confidence, 20, new DateTimeImmutable());
+
+        $entityManager->persist($difficulty);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function setImage(KernelBrowser $browser, string $puzzleId, string $image, null|DateTimeImmutable $hideUntil): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $puzzle->image = $image;
+        $puzzle->hideImageUntil = $hideUntil;
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function optOutOfTimePredictions(KernelBrowser $browser, string $playerId): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $player = $entityManager->find(Player::class, $playerId);
+        $this->assertNotNull($player);
+
+        $player->changeTimePredictionsOptedOut(true);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    /**
+     * A new collection of the player holding exactly the given puzzles; returns its id.
+     *
+     * @param list<string> $puzzleIds
+     */
+    private function seedCollection(KernelBrowser $browser, string $playerId, array $puzzleIds): string
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $player = $entityManager->find(Player::class, $playerId);
+        $this->assertNotNull($player);
+
+        $collection = new Collection(
+            id: Uuid::uuid7(),
+            player: $player,
+            name: 'Budget test',
+            description: null,
+            visibility: CollectionVisibility::Private,
+            createdAt: new DateTimeImmutable(),
+        );
+        $entityManager->persist($collection);
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $this->seedCollectionItems($browser, $collection->id->toString(), $playerId, $puzzleIds);
+
+        return $collection->id->toString();
+    }
+
+    /**
+     * @param list<string> $puzzleIds
+     */
+    private function seedCollectionItems(KernelBrowser $browser, string $collectionId, string $playerId, array $puzzleIds): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $collection = $entityManager->find(Collection::class, $collectionId);
+        $this->assertNotNull($collection);
+        $player = $entityManager->find(Player::class, $playerId);
+        $this->assertNotNull($player);
+
+        foreach ($puzzleIds as $puzzleId) {
+            $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+            $this->assertNotNull($puzzle);
+
+            $entityManager->persist(new CollectionItem(
+                id: Uuid::uuid7(),
+                collection: $collection,
+                player: $player,
+                puzzle: $puzzle,
+                comment: null,
+                addedAt: new DateTimeImmutable(),
+            ));
+        }
+
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function entityManager(KernelBrowser $browser): EntityManagerInterface
+    {
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    /**
+     * @return ListResponse
+     */
+    private function decode(KernelBrowser $browser): array
+    {
+        /** @var ListResponse $decoded */
+        $decoded = $this->decodeJson($browser);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(KernelBrowser $browser): array
+    {
+        $content = $browser->getResponse()->getContent();
+        $this->assertIsString($content);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+
+    /**
+     * One item of the response as raw decoded JSON - for asserting field names
+     * and their order, which the typed decode() cannot (phpstan folds a typed
+     * shape's key list to a constant).
+     *
+     * @return array<string, mixed>
+     */
+    private function rawItem(KernelBrowser $browser, string $puzzleId): array
+    {
+        $items = $this->decodeJson($browser)['items'] ?? null;
+        $this->assertIsArray($items);
+
+        foreach ($items as $item) {
+            $this->assertIsArray($item);
+
+            if (($item['puzzle_id'] ?? null) === $puzzleId) {
+                /** @var array<string, mixed> $item */
+                return $item;
+            }
+        }
+
+        $this->fail(sprintf('Puzzle %s is not in the response', $puzzleId));
+    }
+
+    /**
+     * Keys of a decoded JSON object, for asserting field names and their order.
+     *
+     * @return list<int|string>
+     */
+    private function keys(mixed $value): array
+    {
+        $this->assertIsArray($value);
+
+        return array_keys($value);
+    }
+
+    /**
+     * @param ListResponse $response
+     *
+     * @return Item
+     */
+    private function item(array $response, string $puzzleId): array
+    {
+        foreach ($response['items'] as $item) {
+            if ($item['puzzle_id'] === $puzzleId) {
+                return $item;
+            }
+        }
+
+        $this->fail(sprintf('Puzzle %s is not in the response', $puzzleId));
+    }
+}

--- a/tests/Controller/Api/V1/MyResultsInsightsEndpointTest.php
+++ b/tests/Controller/Api/V1/MyResultsInsightsEndpointTest.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use SpeedPuzzling\Web\Entity\Puzzle;
+use SpeedPuzzling\Web\Entity\PuzzleDifficulty;
+use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleSolvingTimeFixture;
+use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
+use SpeedPuzzling\Web\Tests\PatTestHelper;
+use SpeedPuzzling\Web\Tests\QueryCountAssertions;
+use SpeedPuzzling\Web\Value\MetricConfidence;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * GET /api/v1/me/results - every result carries the solved puzzle's statistics
+ * (public) and difficulty (token owner member), at a fixed query cost whatever
+ * the list size. The existing fields are untouched (MyResultsEndpointTest).
+ *
+ * Fixtures (.claude/fixtures.md): PLAYER_REGULAR (not a member) has 17 solo
+ * results, among them TIME_08 - PUZZLE_500_02 in 1700 s - and two duo results;
+ * PLAYER_WITH_STRIPE and PLAYER_ADMIN are members.
+ *
+ * @phpstan-type StatisticsGroup array{count: int, fastest_seconds: null|int, average_seconds: null|int, slowest_seconds: null|int, median_seconds: null|int}
+ * @phpstan-type Result array{
+ *     time_id: string,
+ *     puzzle_id: string,
+ *     puzzle_name: string,
+ *     manufacturer_name: string,
+ *     pieces_count: int,
+ *     time_seconds: null|int,
+ *     finished_at: null|string,
+ *     first_attempt: bool,
+ *     puzzle_image: null|string,
+ *     comment: null|string,
+ *     statistics: array{solved_times: int, solo: StatisticsGroup, duo: StatisticsGroup, team: StatisticsGroup},
+ *     difficulty: null|array{score: null|float, level: null|string, confidence: string, sample_size: int},
+ * }
+ * @phpstan-type ListResponse array{player_id: string, type: string, count: int, results: list<Result>}
+ */
+final class MyResultsInsightsEndpointTest extends WebTestCase
+{
+    use QueryCountAssertions;
+
+    private const string ENDPOINT = '/api/v1/me/results';
+
+    /** @var list<string> the result fields before the insight objects were added - must stay byte-identical */
+    private const array ORIGINAL_RESULT_KEYS = ['time_id', 'puzzle_id', 'puzzle_name', 'manufacturer_name', 'pieces_count', 'time_seconds', 'finished_at', 'first_attempt', 'puzzle_image', 'comment'];
+
+    public function testExistingFieldsAreUnchangedAndTheInsightObjectsAreAppended(): void
+    {
+        $browser = self::createClient();
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+
+        $raw = $this->decodeJson($browser);
+        $this->assertSame(PlayerFixture::PLAYER_REGULAR, $raw['player_id'] ?? null);
+        $this->assertSame('solo', $raw['type'] ?? null);
+        $this->assertSame(17, $raw['count'] ?? null);
+        $rawResults = $raw['results'] ?? null;
+        $this->assertIsArray($rawResults);
+        $this->assertCount(17, $rawResults);
+
+        foreach ($rawResults as $rawResult) {
+            $this->assertSame([...self::ORIGINAL_RESULT_KEYS, 'statistics', 'difficulty'], $this->keys($rawResult));
+            $this->assertIsArray($rawResult);
+            $rawStatistics = $rawResult['statistics'];
+            $this->assertIsArray($rawStatistics);
+            $this->assertSame(['solved_times', 'solo', 'duo', 'team'], array_keys($rawStatistics));
+            $this->assertSame(['count', 'fastest_seconds', 'average_seconds', 'slowest_seconds', 'median_seconds'], $this->keys($rawStatistics['solo']));
+        }
+
+        // the values the endpoint returned before this change (TIME_08: the 1700 s solve of PUZZLE_500_02)
+        $result = $this->resultByTimeId($this->decode($browser), PuzzleSolvingTimeFixture::TIME_08);
+        $this->assertSame(PuzzleFixture::PUZZLE_500_02, $result['puzzle_id']);
+        $this->assertSame('Puzzle 2', $result['puzzle_name']);
+        $this->assertSame('Ravensburger', $result['manufacturer_name']);
+        $this->assertSame(500, $result['pieces_count']);
+        $this->assertSame(1700, $result['time_seconds']);
+        $this->assertIsString($result['finished_at']);
+        $this->assertNotFalse(DateTimeImmutable::createFromFormat(DATE_ATOM, $result['finished_at']));
+        $this->assertFalse($result['first_attempt']);
+        $this->assertNull($result['puzzle_image']);
+        $this->assertNull($result['comment']);
+    }
+
+    public function testNonMemberGetsStatisticsButNoDifficulty(): void
+    {
+        $browser = self::createClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 1.18, MetricConfidence::Medium);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $result = $this->resultByTimeId($this->decode($browser), PuzzleSolvingTimeFixture::TIME_08);
+
+        // community statistics of PUZZLE_500_02, public, split by discipline: ten solo solves
+        $this->assertSame(10, $result['statistics']['solved_times']);
+        $this->assertSame(10, $result['statistics']['solo']['count']);
+        $this->assertSame(1350, $result['statistics']['solo']['fastest_seconds']);
+        $this->assertSame(2500, $result['statistics']['solo']['slowest_seconds']);
+        $this->assertSame(0, $result['statistics']['duo']['count']);
+        $this->assertNull($result['difficulty']);
+
+        // the duo list: the duo solve of PUZZLE_1000_01 (3600 s) - its statistics split the same way
+        $browser->request('GET', self::ENDPOINT, ['type' => 'duo']);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame('duo', $response['type']);
+        $duo = $this->resultByTimeId($response, PuzzleSolvingTimeFixture::TIME_12);
+        $this->assertSame(PuzzleFixture::PUZZLE_1000_01, $duo['puzzle_id']);
+        $this->assertSame(['count' => 1, 'fastest_seconds' => 3600, 'average_seconds' => 3600, 'slowest_seconds' => 3600, 'median_seconds' => 3600], $duo['statistics']['duo']);
+        $this->assertGreaterThan(0, $duo['statistics']['solo']['count']);
+        $this->assertNull($duo['difficulty']);
+    }
+
+    public function testMemberGetsDifficulty(): void
+    {
+        $browser = self::createClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_01, 1.18, MetricConfidence::Medium);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame(11, $response['count']);
+
+        foreach ($response['results'] as $result) {
+            $this->assertIsArray($result['difficulty']);
+        }
+
+        $this->assertSame(['score', 'level', 'confidence', 'sample_size'], $this->keys($this->rawResult($browser, PuzzleSolvingTimeFixture::TIME_05)['difficulty']));
+        $this->assertSame(
+            ['score' => 1.18, 'level' => 'challenging', 'confidence' => 'medium', 'sample_size' => 20],
+            $this->resultByTimeId($response, PuzzleSolvingTimeFixture::TIME_05)['difficulty'],
+        );
+
+        // an authorization-code token of the same member: the same
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['results:read']);
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(1.18, $this->resultByTimeId($this->decode($browser), PuzzleSolvingTimeFixture::TIME_05)['difficulty']['score'] ?? null);
+
+        // a non-member's authorization-code token: null
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['results:read']);
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $this->assertNull($this->resultByTimeId($this->decode($browser), PuzzleSolvingTimeFixture::TIME_01)['difficulty']);
+    }
+
+    public function testEmbargoedImageIsNull(): void
+    {
+        $browser = self::createClient();
+        $this->setImage($browser, PuzzleFixture::PUZZLE_500_02, 'puzzles/test/box.jpg', hideUntil: new DateTimeImmutable('+30 days'));
+        $this->setImage($browser, PuzzleFixture::PUZZLE_500_01, 'puzzles/test/other.jpg', hideUntil: null);
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertNull($this->resultByTimeId($response, PuzzleSolvingTimeFixture::TIME_08)['puzzle_image']);
+        $this->assertSame('puzzles/test/other.jpg', $this->resultByTimeId($response, PuzzleSolvingTimeFixture::TIME_01)['puzzle_image']);
+    }
+
+    /**
+     * Measured (2026-08-19): authentication 1 query (PAT) / 3 (OAuth2), the
+     * player existence check 1, the results 1 (+1 team-players lookup for duo
+     * and team lists); then statistics 1, the owner's profile 1 and, for a
+     * member, difficulty 1. An empty list adds nothing.
+     */
+    public function testQueryBudgets(): void
+    {
+        $browser = self::createClient();
+
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_REGULAR);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 5, 'non-member PAT (statistics, profile)');
+
+        // the team list of PLAYER_REGULAR is empty: no batch query at all
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT, ['type' => 'team']);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(0, $this->decode($browser)['count']);
+        $this->assertQueryCountAtMost($browser, 4, 'empty list');
+
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 6, 'member PAT (statistics, profile, difficulty)');
+        $memberAtEleven = $this->queryCount($browser);
+
+        // another member with a different number of results: the same cost
+        $this->authenticatePat($browser, PlayerFixture::PLAYER_ADMIN);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $adminCount = $this->decode($browser)['count'];
+        $this->assertGreaterThan(0, $adminCount);
+        $this->assertNotSame(11, $adminCount);
+        $this->assertSame($memberAtEleven, $this->queryCount($browser), 'A member pays the same number of queries whatever the length of the list');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['results:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', self::ENDPOINT);
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 8, 'member authorization-code token');
+    }
+
+    private function authenticatePat(KernelBrowser $browser, string $playerId): void
+    {
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, $playerId));
+    }
+
+    /**
+     * @param array<non-empty-string> $scopes
+     */
+    private function authenticateOAuth2(KernelBrowser $browser, string $playerId, array $scopes): void
+    {
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            $playerId,
+            $scopes,
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    private function seedDifficulty(KernelBrowser $browser, string $puzzleId, float $score, MetricConfidence $confidence): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $difficulty = $entityManager->find(PuzzleDifficulty::class, $puzzleId) ?? new PuzzleDifficulty($puzzle);
+        $difficulty->updateDifficulty($score, $confidence, 20, new DateTimeImmutable());
+
+        $entityManager->persist($difficulty);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function setImage(KernelBrowser $browser, string $puzzleId, string $image, null|DateTimeImmutable $hideUntil): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $puzzle->image = $image;
+        $puzzle->hideImageUntil = $hideUntil;
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function entityManager(KernelBrowser $browser): EntityManagerInterface
+    {
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    /**
+     * @return ListResponse
+     */
+    private function decode(KernelBrowser $browser): array
+    {
+        /** @var ListResponse $decoded */
+        $decoded = $this->decodeJson($browser);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(KernelBrowser $browser): array
+    {
+        $content = $browser->getResponse()->getContent();
+        $this->assertIsString($content);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+
+    /**
+     * One result of the response as raw decoded JSON - for asserting field
+     * names and their order, which the typed decode() cannot.
+     *
+     * @return array<string, mixed>
+     */
+    private function rawResult(KernelBrowser $browser, string $timeId): array
+    {
+        $results = $this->decodeJson($browser)['results'] ?? null;
+        $this->assertIsArray($results);
+
+        foreach ($results as $result) {
+            $this->assertIsArray($result);
+
+            if (($result['time_id'] ?? null) === $timeId) {
+                /** @var array<string, mixed> $result */
+                return $result;
+            }
+        }
+
+        $this->fail(sprintf('Time %s is not in the response', $timeId));
+    }
+
+    /**
+     * @return list<int|string>
+     */
+    private function keys(mixed $value): array
+    {
+        $this->assertIsArray($value);
+
+        return array_keys($value);
+    }
+
+    /**
+     * @param ListResponse $response
+     *
+     * @return Result
+     */
+    private function resultByTimeId(array $response, string $timeId): array
+    {
+        foreach ($response['results'] as $result) {
+            if ($result['time_id'] === $timeId) {
+                return $result;
+            }
+        }
+
+        $this->fail(sprintf('Time %s is not in the response', $timeId));
+    }
+}

--- a/tests/Controller/Api/V1/PlayerCollectionItemsEndpointTest.php
+++ b/tests/Controller/Api/V1/PlayerCollectionItemsEndpointTest.php
@@ -1,0 +1,526 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use SpeedPuzzling\Web\Entity\Collection;
+use SpeedPuzzling\Web\Entity\CollectionItem;
+use SpeedPuzzling\Web\Entity\Player;
+use SpeedPuzzling\Web\Entity\Puzzle;
+use SpeedPuzzling\Web\Entity\PuzzleDifficulty;
+use SpeedPuzzling\Web\Tests\DataFixtures\CollectionFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\CollectionItemFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
+use SpeedPuzzling\Web\Tests\QueryCountAssertions;
+use SpeedPuzzling\Web\Value\CollectionVisibility;
+use SpeedPuzzling\Web\Value\MetricConfidence;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * GET /api/v1/players/{playerId}/collections/{collectionId}/items - every item
+ * carries statistics (public), difficulty (the *token owner* is a member) and
+ * solves (the *collection owner's* history, only for a token with results:read);
+ * never a prediction - predictions are self-only (plan §0 N1). The private
+ * profile short-circuit is untouched.
+ *
+ * Fixtures (.claude/fixtures.md): PLAYER_WITH_STRIPE (member) owns
+ * COLLECTION_PUBLIC with PUZZLE_500_01 (solved once, 2100 s) and PUZZLE_500_02
+ * among its 8 puzzles; PLAYER_REGULAR is not a member.
+ *
+ * @phpstan-type StatisticsGroup array{count: int, fastest_seconds: null|int, average_seconds: null|int, slowest_seconds: null|int, median_seconds: null|int}
+ * @phpstan-type SolvesGroup array{count: int, best_time_seconds: null|int, last_time_seconds: null|int, first_solved_at: null|string, last_solved_at: null|string}
+ * @phpstan-type Item array{
+ *     collection_item_id: string,
+ *     puzzle_id: string,
+ *     puzzle_name: string,
+ *     manufacturer_name: null|string,
+ *     pieces_count: int,
+ *     image: null|string,
+ *     comment: null|string,
+ *     added_at: string,
+ *     statistics: array{solved_times: int, solo: StatisticsGroup, duo: StatisticsGroup, team: StatisticsGroup},
+ *     difficulty: null|array{score: null|float, level: null|string, confidence: string, sample_size: int},
+ *     prediction: null|array<string, mixed>,
+ *     solves: null|array{solo: SolvesGroup, duo: SolvesGroup, team: SolvesGroup},
+ * }
+ * @phpstan-type ListResponse array{collection_id: string, count: int, items: list<Item>}
+ */
+final class PlayerCollectionItemsEndpointTest extends WebTestCase
+{
+    use QueryCountAssertions;
+
+    /** @var list<string> the item fields before the insight objects were added - must stay byte-identical */
+    private const array ORIGINAL_ITEM_KEYS = ['collection_item_id', 'puzzle_id', 'puzzle_name', 'manufacturer_name', 'pieces_count', 'image', 'comment', 'added_at'];
+
+    public function testExistingFieldsAreUnchangedAndTheInsightObjectsAreAppended(): void
+    {
+        $browser = self::createClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['collections:read']);
+
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+
+        $raw = $this->decodeJson($browser);
+        $this->assertSame(CollectionFixture::COLLECTION_PUBLIC, $raw['collection_id'] ?? null);
+        $this->assertSame(8, $raw['count'] ?? null);
+        $rawItems = $raw['items'] ?? null;
+        $this->assertIsArray($rawItems);
+        $this->assertCount(8, $rawItems);
+
+        foreach ($rawItems as $rawItem) {
+            $this->assertSame(
+                [...self::ORIGINAL_ITEM_KEYS, 'statistics', 'difficulty', 'prediction', 'solves'],
+                $this->keys($rawItem),
+            );
+            $this->assertIsArray($rawItem);
+            $this->assertSame(['solved_times', 'solo', 'duo', 'team'], $this->keys($rawItem['statistics']));
+        }
+
+        // the values the endpoint returned before this change (ITEM_01 of COLLECTION_PUBLIC)
+        $item = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_01);
+        $this->assertSame(CollectionItemFixture::ITEM_01, $item['collection_item_id']);
+        $this->assertSame('Puzzle 1', $item['puzzle_name']);
+        $this->assertSame('Ravensburger', $item['manufacturer_name']);
+        $this->assertSame(500, $item['pieces_count']);
+        $this->assertNull($item['image']);
+        $this->assertSame('Beautiful landscape puzzle, one of my favorites!', $item['comment']);
+        $this->assertNotFalse(DateTimeImmutable::createFromFormat(DATE_ATOM, $item['added_at']));
+    }
+
+    /**
+     * Statistics are public; solves are the collection owner's results, so
+     * they need results:read on the token (collections:read alone ⇒ null);
+     * a prediction never appears on a /players endpoint.
+     */
+    public function testSolvesAreTheCollectionOwnersAndNeedResultsRead(): void
+    {
+        $browser = self::createClient();
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['collections:read']);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $item = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_01);
+        // PUZZLE_500_01: eleven solo solves of several players
+        $this->assertSame(11, $item['statistics']['solved_times']);
+        $this->assertSame(11, $item['statistics']['solo']['count']);
+        $this->assertSame(1200, $item['statistics']['solo']['fastest_seconds']);
+        $this->assertNull($item['difficulty']);
+        $this->assertNull($item['prediction']);
+        $this->assertNull($item['solves']);
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['collections:read', 'results:read']);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        // PLAYER_WITH_STRIPE solved PUZZLE_500_01 once (2100 s) - not the token owner's (PLAYER_REGULAR: 1800, 1850, 1750)
+        $this->assertSame(['solo', 'duo', 'team'], $this->keys($this->rawItem($browser, PuzzleFixture::PUZZLE_500_01)['solves']));
+        $solves = $this->item($response, PuzzleFixture::PUZZLE_500_01)['solves'];
+        $this->assertNotNull($solves);
+        $this->assertSame(1, $solves['solo']['count']);
+        $this->assertSame(2100, $solves['solo']['best_time_seconds']);
+        $this->assertSame(2100, $solves['solo']['last_time_seconds']);
+        $this->assertSame(0, $solves['duo']['count']);
+        $this->assertSame(0, $solves['team']['count']);
+
+        // a puzzle the owner never solved: the object is there, with zeros
+        $this->assertSame(0, $this->item($response, PuzzleFixture::PUZZLE_500_04)['solves']['solo']['count'] ?? null);
+
+        foreach ($response['items'] as $item) {
+            $this->assertNull($item['prediction']);
+        }
+    }
+
+    /**
+     * Difficulty follows the token owner's membership, whoever owns the collection.
+     */
+    public function testDifficultyFollowsTheTokenOwnersMembership(): void
+    {
+        $browser = self::createClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 1.18, MetricConfidence::Medium);
+
+        // member token owner looking at a non-member's collection
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['collections:read']);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_REGULAR, 'default'));
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame(3, $response['count']);
+
+        foreach ($response['items'] as $item) {
+            // present for every item - a seeded row or the synthesised "insufficient" one
+            $this->assertIsArray($item['difficulty']);
+            $this->assertNull($item['prediction']);
+        }
+
+        $this->assertSame(['score', 'level', 'confidence', 'sample_size'], $this->keys($this->rawItem($browser, PuzzleFixture::PUZZLE_1000_01)['difficulty']));
+
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            ['score' => 1.18, 'level' => 'challenging', 'confidence' => 'medium', 'sample_size' => 20],
+            $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_02)['difficulty'],
+        );
+
+        // a member looking at their own collection through /players: still no prediction (self-only lives on /me)
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['collections:read', 'results:read']);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $item = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_01);
+        $this->assertIsArray($item['difficulty']);
+        $this->assertNull($item['prediction']);
+        $this->assertSame(1, $item['solves']['solo']['count'] ?? null);
+
+        // non-member token owner looking at a member's collection
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['collections:read']);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $this->assertNull($this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_02)['difficulty']);
+    }
+
+    /**
+     * A machine token has no player: statistics yes, difficulty never; the
+     * owner's solves only with results:read (public results data, as
+     * /players/{id}/results).
+     */
+    public function testClientCredentialsTokenGetsStatisticsButNoDifficulty(): void
+    {
+        $browser = self::createClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 1.18, MetricConfidence::Medium);
+
+        $this->authenticateClientCredentials($browser, ['collections:read']);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $item = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_02);
+        $this->assertGreaterThan(0, $item['statistics']['solved_times']);
+        $this->assertNull($item['difficulty']);
+        $this->assertNull($item['prediction']);
+        $this->assertNull($item['solves']);
+
+        $this->authenticateClientCredentials($browser, ['collections:read', 'results:read']);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $item = $this->item($this->decode($browser), PuzzleFixture::PUZZLE_500_01);
+        $this->assertNull($item['difficulty']);
+        $this->assertNull($item['prediction']);
+        $this->assertSame(1, $item['solves']['solo']['count'] ?? null);
+    }
+
+    public function testPrivateProfileStaysZeroedWithoutBatchQueries(): void
+    {
+        $browser = self::createClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['collections:read', 'results:read']);
+
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_PRIVATE, 'default'));
+        $this->assertResponseIsSuccessful();
+
+        $response = $this->decode($browser);
+        $this->assertSame('default', $response['collection_id']);
+        $this->assertSame(0, $response['count']);
+        $this->assertSame([], $response['items']);
+        // authentication (3) + the profile lookup - nothing else
+        $this->assertQueryCountAtMost($browser, 4, 'private profile short-circuit');
+    }
+
+    public function testEmbargoedImageIsNull(): void
+    {
+        $browser = self::createClient();
+        $this->setImage($browser, PuzzleFixture::PUZZLE_500_02, 'puzzles/test/box.jpg', hideUntil: new DateTimeImmutable('+30 days'));
+        $this->setImage($browser, PuzzleFixture::PUZZLE_500_01, 'puzzles/test/other.jpg', hideUntil: null);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['collections:read']);
+
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertNull($this->item($response, PuzzleFixture::PUZZLE_500_02)['image']);
+        $this->assertSame('puzzles/test/other.jpg', $this->item($response, PuzzleFixture::PUZZLE_500_01)['image']);
+    }
+
+    /**
+     * Measured (2026-08-19): authentication 3 queries (OAuth2: access token,
+     * player, consent usage; a client_credentials token 1-2), the listed
+     * player's profile 1, the items 1; then statistics 1, and per entitlement
+     * the token owner's profile 1, difficulty 1 (member), solves 1
+     * (results:read).
+     */
+    public function testQueryBudgets(): void
+    {
+        $browser = self::createClient();
+
+        $this->authenticateClientCredentials($browser, ['collections:read', 'results:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 5, 'client_credentials token (statistics, owner solves)');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['collections:read', 'results:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 8, 'non-member authorization-code token (statistics, profile, owner solves)');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['collections:read', 'results:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_REGULAR, 'default'));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 9, 'member authorization-code token (statistics, profile, difficulty, owner solves)');
+    }
+
+    public function testQueryCountDoesNotGrowWithTheCollectionSize(): void
+    {
+        $browser = self::createClient();
+        $single = $this->seedCollection($browser, PlayerFixture::PLAYER_WITH_STRIPE, [PuzzleFixture::PUZZLE_9000]);
+        $this->seedCollectionItems($browser, CollectionFixture::COLLECTION_PUBLIC, PlayerFixture::PLAYER_WITH_STRIPE, [
+            PuzzleFixture::PUZZLE_500_03,
+            PuzzleFixture::PUZZLE_1000_02,
+            PuzzleFixture::PUZZLE_1000_04,
+            PuzzleFixture::PUZZLE_1500_01,
+            PuzzleFixture::PUZZLE_1500_02,
+            PuzzleFixture::PUZZLE_2000,
+            PuzzleFixture::PUZZLE_3000,
+            PuzzleFixture::PUZZLE_4000,
+            PuzzleFixture::PUZZLE_5000,
+            PuzzleFixture::PUZZLE_6000,
+            PuzzleFixture::PUZZLE_9000,
+            PuzzleFixture::PUZZLE_UNAPPROVED,
+        ]);
+        // a member with results:read: every object the endpoint can carry
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_ADMIN, ['collections:read', 'results:read']);
+
+        // warm-up: the token's first request finds the access token in the
+        // entity manager the helper saved it through (one lookup fewer) - a
+        // test artefact that would skew the comparison
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, $single));
+        $this->assertResponseIsSuccessful();
+
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, $single));
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(1, $this->decode($browser)['count']);
+        $atOne = $this->queryCount($browser);
+
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE, CollectionFixture::COLLECTION_PUBLIC));
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(20, $this->decode($browser)['count']);
+        $this->assertSame($atOne, $this->queryCount($browser), 'The same number of queries for 20 items as for 1');
+    }
+
+    private function path(string $playerId, string $collectionId): string
+    {
+        return '/api/v1/players/' . $playerId . '/collections/' . $collectionId . '/items';
+    }
+
+    /**
+     * @param array<non-empty-string> $scopes
+     */
+    private function authenticateOAuth2(KernelBrowser $browser, string $playerId, array $scopes): void
+    {
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            $playerId,
+            $scopes,
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    /**
+     * @param array<non-empty-string> $scopes
+     */
+    private function authenticateClientCredentials(KernelBrowser $browser, array $scopes): void
+    {
+        // sub = aud = client id is exactly what the client_credentials grant issues
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            $scopes,
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    private function seedDifficulty(KernelBrowser $browser, string $puzzleId, float $score, MetricConfidence $confidence): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $difficulty = $entityManager->find(PuzzleDifficulty::class, $puzzleId) ?? new PuzzleDifficulty($puzzle);
+        $difficulty->updateDifficulty($score, $confidence, 20, new DateTimeImmutable());
+
+        $entityManager->persist($difficulty);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function setImage(KernelBrowser $browser, string $puzzleId, string $image, null|DateTimeImmutable $hideUntil): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $puzzle->image = $image;
+        $puzzle->hideImageUntil = $hideUntil;
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    /**
+     * A new public collection of the player holding exactly the given puzzles; returns its id.
+     *
+     * @param list<string> $puzzleIds
+     */
+    private function seedCollection(KernelBrowser $browser, string $playerId, array $puzzleIds): string
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $player = $entityManager->find(Player::class, $playerId);
+        $this->assertNotNull($player);
+
+        $collection = new Collection(
+            id: Uuid::uuid7(),
+            player: $player,
+            name: 'Budget test',
+            description: null,
+            visibility: CollectionVisibility::Public,
+            createdAt: new DateTimeImmutable(),
+        );
+        $entityManager->persist($collection);
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $this->seedCollectionItems($browser, $collection->id->toString(), $playerId, $puzzleIds);
+
+        return $collection->id->toString();
+    }
+
+    /**
+     * @param list<string> $puzzleIds
+     */
+    private function seedCollectionItems(KernelBrowser $browser, string $collectionId, string $playerId, array $puzzleIds): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $collection = $entityManager->find(Collection::class, $collectionId);
+        $this->assertNotNull($collection);
+        $player = $entityManager->find(Player::class, $playerId);
+        $this->assertNotNull($player);
+
+        foreach ($puzzleIds as $puzzleId) {
+            $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+            $this->assertNotNull($puzzle);
+
+            $entityManager->persist(new CollectionItem(
+                id: Uuid::uuid7(),
+                collection: $collection,
+                player: $player,
+                puzzle: $puzzle,
+                comment: null,
+                addedAt: new DateTimeImmutable(),
+            ));
+        }
+
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function entityManager(KernelBrowser $browser): EntityManagerInterface
+    {
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    /**
+     * @return ListResponse
+     */
+    private function decode(KernelBrowser $browser): array
+    {
+        /** @var ListResponse $decoded */
+        $decoded = $this->decodeJson($browser);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(KernelBrowser $browser): array
+    {
+        $content = $browser->getResponse()->getContent();
+        $this->assertIsString($content);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+
+    /**
+     * One item of the response as raw decoded JSON - for asserting field names
+     * and their order, which the typed decode() cannot.
+     *
+     * @return array<string, mixed>
+     */
+    private function rawItem(KernelBrowser $browser, string $puzzleId): array
+    {
+        $items = $this->decodeJson($browser)['items'] ?? null;
+        $this->assertIsArray($items);
+
+        foreach ($items as $item) {
+            $this->assertIsArray($item);
+
+            if (($item['puzzle_id'] ?? null) === $puzzleId) {
+                /** @var array<string, mixed> $item */
+                return $item;
+            }
+        }
+
+        $this->fail(sprintf('Puzzle %s is not in the response', $puzzleId));
+    }
+
+    /**
+     * @return list<int|string>
+     */
+    private function keys(mixed $value): array
+    {
+        $this->assertIsArray($value);
+
+        return array_keys($value);
+    }
+
+    /**
+     * @param ListResponse $response
+     *
+     * @return Item
+     */
+    private function item(array $response, string $puzzleId): array
+    {
+        foreach ($response['items'] as $item) {
+            if ($item['puzzle_id'] === $puzzleId) {
+                return $item;
+            }
+        }
+
+        $this->fail(sprintf('Puzzle %s is not in the response', $puzzleId));
+    }
+}

--- a/tests/Controller/Api/V1/PlayerResultsInsightsEndpointTest.php
+++ b/tests/Controller/Api/V1/PlayerResultsInsightsEndpointTest.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use SpeedPuzzling\Web\Entity\Puzzle;
+use SpeedPuzzling\Web\Entity\PuzzleDifficulty;
+use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleSolvingTimeFixture;
+use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
+use SpeedPuzzling\Web\Tests\QueryCountAssertions;
+use SpeedPuzzling\Web\Value\MetricConfidence;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * GET /api/v1/players/{playerId}/results - every result carries the solved
+ * puzzle's statistics (public) and difficulty (the *token owner* is a member,
+ * never a machine token), at a fixed query cost whatever the list size. The
+ * existing fields and the private-profile short-circuit are untouched
+ * (PlayerResultsEndpointTest).
+ *
+ * Fixtures (.claude/fixtures.md): PLAYER_REGULAR (not a member) has 17 solo
+ * results, among them TIME_08 - PUZZLE_500_02 in 1700 s; PLAYER_WITH_STRIPE is
+ * a member with 11 solo results; PLAYER_PRIVATE has a private profile.
+ *
+ * @phpstan-type StatisticsGroup array{count: int, fastest_seconds: null|int, average_seconds: null|int, slowest_seconds: null|int, median_seconds: null|int}
+ * @phpstan-type Result array{
+ *     time_id: string,
+ *     puzzle_id: string,
+ *     puzzle_name: string,
+ *     manufacturer_name: string,
+ *     pieces_count: int,
+ *     time_seconds: null|int,
+ *     finished_at: null|string,
+ *     first_attempt: bool,
+ *     puzzle_image: null|string,
+ *     comment: null|string,
+ *     statistics: array{solved_times: int, solo: StatisticsGroup, duo: StatisticsGroup, team: StatisticsGroup},
+ *     difficulty: null|array{score: null|float, level: null|string, confidence: string, sample_size: int},
+ * }
+ * @phpstan-type ListResponse array{player_id: string, type: string, count: int, results: list<Result>}
+ */
+final class PlayerResultsInsightsEndpointTest extends WebTestCase
+{
+    use QueryCountAssertions;
+
+    /** @var list<string> the result fields before the insight objects were added - must stay byte-identical */
+    private const array ORIGINAL_RESULT_KEYS = ['time_id', 'puzzle_id', 'puzzle_name', 'manufacturer_name', 'pieces_count', 'time_seconds', 'finished_at', 'first_attempt', 'puzzle_image', 'comment'];
+
+    public function testExistingFieldsAreUnchangedAndTheInsightObjectsAreAppended(): void
+    {
+        $browser = self::createClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['results:read']);
+
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_REGULAR));
+        $this->assertResponseIsSuccessful();
+
+        $raw = $this->decodeJson($browser);
+        $this->assertSame(PlayerFixture::PLAYER_REGULAR, $raw['player_id'] ?? null);
+        $this->assertSame('solo', $raw['type'] ?? null);
+        $this->assertSame(17, $raw['count'] ?? null);
+        $rawResults = $raw['results'] ?? null;
+        $this->assertIsArray($rawResults);
+        $this->assertCount(17, $rawResults);
+
+        foreach ($rawResults as $rawResult) {
+            $this->assertSame([...self::ORIGINAL_RESULT_KEYS, 'statistics', 'difficulty'], $this->keys($rawResult));
+            $this->assertIsArray($rawResult);
+            $this->assertSame(['solved_times', 'solo', 'duo', 'team'], $this->keys($rawResult['statistics']));
+        }
+
+        // the values the endpoint returned before this change (TIME_08: the 1700 s solve of PUZZLE_500_02)
+        $result = $this->resultByTimeId($this->decode($browser), PuzzleSolvingTimeFixture::TIME_08);
+        $this->assertSame(PuzzleFixture::PUZZLE_500_02, $result['puzzle_id']);
+        $this->assertSame('Puzzle 2', $result['puzzle_name']);
+        $this->assertSame('Ravensburger', $result['manufacturer_name']);
+        $this->assertSame(500, $result['pieces_count']);
+        $this->assertSame(1700, $result['time_seconds']);
+        $this->assertIsString($result['finished_at']);
+        $this->assertNotFalse(DateTimeImmutable::createFromFormat(DATE_ATOM, $result['finished_at']));
+        $this->assertFalse($result['first_attempt']);
+        $this->assertNull($result['puzzle_image']);
+        $this->assertNull($result['comment']);
+    }
+
+    /**
+     * Difficulty follows the token owner's membership, whoever the listed player is.
+     */
+    public function testDifficultyFollowsTheTokenOwnersMembership(): void
+    {
+        $browser = self::createClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 1.18, MetricConfidence::Medium);
+
+        // a member looking at a non-member's results
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['results:read']);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_REGULAR));
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        foreach ($response['results'] as $result) {
+            $this->assertIsArray($result['difficulty']);
+        }
+
+        $this->assertSame(['score', 'level', 'confidence', 'sample_size'], $this->keys($this->rawResult($browser, PuzzleSolvingTimeFixture::TIME_08)['difficulty']));
+        $result = $this->resultByTimeId($response, PuzzleSolvingTimeFixture::TIME_08);
+        $this->assertSame(['score' => 1.18, 'level' => 'challenging', 'confidence' => 'medium', 'sample_size' => 20], $result['difficulty']);
+        // statistics of PUZZLE_500_02: ten solo solves, split by discipline
+        $this->assertSame(10, $result['statistics']['solved_times']);
+        $this->assertSame(10, $result['statistics']['solo']['count']);
+        $this->assertSame(1350, $result['statistics']['solo']['fastest_seconds']);
+        $this->assertSame(0, $result['statistics']['duo']['count']);
+
+        // a non-member looking at a member's results
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['results:read']);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE));
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame(11, $response['count']);
+
+        foreach ($response['results'] as $result) {
+            $this->assertNull($result['difficulty']);
+            $this->assertGreaterThanOrEqual(0, $result['statistics']['solved_times']);
+        }
+
+        // the duo list of PLAYER_REGULAR: the duo solve of PUZZLE_1000_01 (3600 s)
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_REGULAR), ['type' => 'duo']);
+        $this->assertResponseIsSuccessful();
+        $duo = $this->resultByTimeId($this->decode($browser), PuzzleSolvingTimeFixture::TIME_12);
+        $this->assertSame(['count' => 1, 'fastest_seconds' => 3600, 'average_seconds' => 3600, 'slowest_seconds' => 3600, 'median_seconds' => 3600], $duo['statistics']['duo']);
+        $this->assertNull($duo['difficulty']);
+    }
+
+    public function testClientCredentialsTokenGetsStatisticsButNoDifficulty(): void
+    {
+        $browser = self::createClient();
+        $this->seedDifficulty($browser, PuzzleFixture::PUZZLE_500_02, 1.18, MetricConfidence::Medium);
+        $this->authenticateClientCredentials($browser);
+
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_REGULAR));
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame(17, $response['count']);
+
+        foreach ($response['results'] as $result) {
+            $this->assertNull($result['difficulty']);
+        }
+
+        $this->assertSame(10, $this->resultByTimeId($response, PuzzleSolvingTimeFixture::TIME_08)['statistics']['solved_times']);
+    }
+
+    public function testPrivateProfileStaysZeroedWithoutBatchQueries(): void
+    {
+        $browser = self::createClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['results:read']);
+
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_PRIVATE));
+        $this->assertResponseIsSuccessful();
+
+        $response = $this->decode($browser);
+        $this->assertSame(PlayerFixture::PLAYER_PRIVATE, $response['player_id']);
+        $this->assertSame(0, $response['count']);
+        $this->assertSame([], $response['results']);
+        // authentication (3) + the profile lookup - nothing else
+        $this->assertQueryCountAtMost($browser, 4, 'private profile short-circuit');
+    }
+
+    public function testEmbargoedImageIsNull(): void
+    {
+        $browser = self::createClient();
+        $this->setImage($browser, PuzzleFixture::PUZZLE_500_02, 'puzzles/test/box.jpg', hideUntil: new DateTimeImmutable('+30 days'));
+        $this->setImage($browser, PuzzleFixture::PUZZLE_500_01, 'puzzles/test/other.jpg', hideUntil: null);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['results:read']);
+
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_REGULAR));
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertNull($this->resultByTimeId($response, PuzzleSolvingTimeFixture::TIME_08)['puzzle_image']);
+        $this->assertSame('puzzles/test/other.jpg', $this->resultByTimeId($response, PuzzleSolvingTimeFixture::TIME_01)['puzzle_image']);
+    }
+
+    /**
+     * Measured (2026-08-19): authentication 3 queries (OAuth2; a
+     * client_credentials token 1-2), the listed player's profile 1, the
+     * existence check 1, the results 1; then statistics 1 and, for a player
+     * token, the owner's profile 1 and for a member difficulty 1.
+     */
+    public function testQueryBudgets(): void
+    {
+        $browser = self::createClient();
+
+        $this->authenticateClientCredentials($browser);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_REGULAR));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 5, 'client_credentials token (statistics)');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['results:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 8, 'non-member authorization-code token (statistics, profile)');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['results:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_REGULAR));
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(17, $this->decode($browser)['count']);
+        $this->assertQueryCountAtMost($browser, 9, 'member authorization-code token (statistics, profile, difficulty)');
+        $atSeventeen = $this->queryCount($browser);
+
+        // the same member token on a shorter list: the same cost
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->path(PlayerFixture::PLAYER_WITH_STRIPE));
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(11, $this->decode($browser)['count']);
+        $this->assertSame($atSeventeen, $this->queryCount($browser), 'The same number of queries for 11 results as for 17');
+    }
+
+    private function path(string $playerId): string
+    {
+        return '/api/v1/players/' . $playerId . '/results';
+    }
+
+    /**
+     * @param array<non-empty-string> $scopes
+     */
+    private function authenticateOAuth2(KernelBrowser $browser, string $playerId, array $scopes): void
+    {
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            $playerId,
+            $scopes,
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    private function authenticateClientCredentials(KernelBrowser $browser): void
+    {
+        // sub = aud = client id is exactly what the client_credentials grant issues
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            ['results:read'],
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    private function seedDifficulty(KernelBrowser $browser, string $puzzleId, float $score, MetricConfidence $confidence): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $difficulty = $entityManager->find(PuzzleDifficulty::class, $puzzleId) ?? new PuzzleDifficulty($puzzle);
+        $difficulty->updateDifficulty($score, $confidence, 20, new DateTimeImmutable());
+
+        $entityManager->persist($difficulty);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function setImage(KernelBrowser $browser, string $puzzleId, string $image, null|DateTimeImmutable $hideUntil): void
+    {
+        $entityManager = $this->entityManager($browser);
+
+        $puzzle = $entityManager->find(Puzzle::class, $puzzleId);
+        $this->assertNotNull($puzzle);
+
+        $puzzle->image = $image;
+        $puzzle->hideImageUntil = $hideUntil;
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function entityManager(KernelBrowser $browser): EntityManagerInterface
+    {
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+
+    /**
+     * @return ListResponse
+     */
+    private function decode(KernelBrowser $browser): array
+    {
+        /** @var ListResponse $decoded */
+        $decoded = $this->decodeJson($browser);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(KernelBrowser $browser): array
+    {
+        $content = $browser->getResponse()->getContent();
+        $this->assertIsString($content);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+
+    /**
+     * One result of the response as raw decoded JSON - for asserting field
+     * names and their order, which the typed decode() cannot.
+     *
+     * @return array<string, mixed>
+     */
+    private function rawResult(KernelBrowser $browser, string $timeId): array
+    {
+        $results = $this->decodeJson($browser)['results'] ?? null;
+        $this->assertIsArray($results);
+
+        foreach ($results as $result) {
+            $this->assertIsArray($result);
+
+            if (($result['time_id'] ?? null) === $timeId) {
+                /** @var array<string, mixed> $result */
+                return $result;
+            }
+        }
+
+        $this->fail(sprintf('Time %s is not in the response', $timeId));
+    }
+
+    /**
+     * @return list<int|string>
+     */
+    private function keys(mixed $value): array
+    {
+        $this->assertIsArray($value);
+
+        return array_keys($value);
+    }
+
+    /**
+     * @param ListResponse $response
+     *
+     * @return Result
+     */
+    private function resultByTimeId(array $response, string $timeId): array
+    {
+        foreach ($response['results'] as $result) {
+            if ($result['time_id'] === $timeId) {
+                return $result;
+            }
+        }
+
+        $this->fail(sprintf('Time %s is not in the response', $timeId));
+    }
+}


### PR DESCRIPTION
PR 3 of `docs/features/api/v1-expansion-plan.md`.

Per-item objects on the existing list endpoints, always present, `null` when the token is not entitled (gates as on the web, via `ApiTokenOwner`):

| Endpoint | objects |
|---|---|
| `GET /me/collections/{id}/items` (+ the `POST …/items` response, same DTO) | `statistics`, `difficulty` (member), `prediction` (member, not opted out, PAT/`results:read`), `solves` (own, PAT/`results:read`) |
| `GET /players/{id}/collections/{cid}/items` | `statistics`, `difficulty` (token owner member), `solves` (the collection owner's, `results:read`), never `prediction` |
| `GET /me/results`, `GET /players/{id}/results` | `statistics`, `difficulty` |

- One shared batch (`PuzzleResponseFactory::insightsFor()` + `PuzzleInsightsBatch`) serves cards, collection items and result items — one query per object per list, size-independent (asserted identical for 1 vs 20 items); private profiles stay zeroed with no extra queries; empty lists cost nothing extra.
- BC: existing fields byte-identical (asserted against pre-change values and key order); new keys appended only.
- Embargoed images were already `null` on these queries — asserted. 29 new tests, full suite green.
- Found, not changed (follow-up): `PlayerCollectionItemsResponseProvider` checks the player's privacy but not the collection's own `visibility` (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uH2n4Y6gPLiYASEJwNr3H