### PR TITLE
API: profile insights (MSP rating points/rank, skill tiers, badges) on GET /me and a new GET /players/{id}

### DIFF
--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -214,6 +214,14 @@ return App::config([
                 'path' => '^/api/v1/me',
                 'roles' => [PatUser::ROLE, OAuth2User::ROLE],
             ],
+            // The public profile of a player (GET /players/{id}): profile:read, any
+            // OAuth2 token - a client_credentials token sees public profile data
+            // too. The regex ends at the id segment so it cannot shadow the
+            // per-scope rules for /players/{id}/results|statistics|collections.
+            [
+                'path' => '^/api/v1/players/[^/]+/?$',
+                'roles' => [OAuth2Scope::ProfileRead->role()],
+            ],
             [
                 'path' => '^/api/v1/players/.*/results',
                 'roles' => [OAuth2Scope::ResultsRead->role()],

--- a/docs/features/api/README.md
+++ b/docs/features/api/README.md
@@ -74,7 +74,7 @@ hand-typed `SOLVING_TIMES` variant silently matched nothing until 2026-08 (PR #1
 
 | Method | Endpoint | Required |
 |--------|----------|----------|
-| GET | `/api/v1/me` | PAT or `profile:read` (the `email` field is populated only for PAT or tokens granted `email:read`, otherwise `null`). Also carries `has_active_membership`, `membership_ends_at` (ISO-8601, `null` without an active membership) and the owner's opt-out flags `time_predictions_opted_out`, `ranking_opted_out`, `streak_opted_out` |
+| GET | `/api/v1/me` | PAT or `profile:read` (the `email` field is populated only for PAT or tokens granted `email:read`, otherwise `null`). Also carries `has_active_membership`, `membership_ends_at` (ISO-8601, `null` without an active membership), the owner's opt-out flags `time_predictions_opted_out`, `ranking_opted_out`, `streak_opted_out`, and the profile insights `rating` (MSP Rating per piece count, `null` when opted out of rankings), `skill` (skill tiers, members only), `badges` - see Profile insights below |
 | GET | `/api/v1/me/results?type=solo\|duo\|team` | PAT or `results:read`. Each result also carries the puzzle's `statistics` (public) and `difficulty` (members, else `null`) - see Insights on lists below |
 | GET | `/api/v1/me/puzzles/{puzzleId}/predicted-time` | PAT or `results:read` |
 | GET | `/api/v1/me/statistics` | PAT or `statistics:read` |
@@ -92,6 +92,7 @@ hand-typed `SOLVING_TIMES` variant silently matched nothing until 2026-08 (PR #1
 
 | Method | Endpoint | Scope |
 |--------|----------|-------|
+| GET | `/api/v1/players/{id}` | `profile:read` (client_credentials allowed) - public profile + `rating` / `skill` / `badges`; a private profile is masked, see Profile insights |
 | GET | `/api/v1/players/{id}/results?type=solo\|duo\|team` | `results:read`. Each result also carries the puzzle's `statistics` (public) and `difficulty` (**token owner** member, else `null`) |
 | GET | `/api/v1/players/{id}/statistics` | `statistics:read` |
 | GET | `/api/v1/players/{id}/collections` | `collections:read` (public only) |
@@ -213,6 +214,25 @@ The API twin of the Puzzle Insights block on the puzzle detail page (`PuzzleDeta
 - **Member who opted out of time predictions** → prediction fields `null`, difficulty still returned (same split as `templates/puzzle/_difficulty_section.html.twig`).
 - Unknown or malformed puzzle id → 404. Fixed number of queries per call (no per-item fan-out).
 
+### Profile insights (`GET /api/v1/me`, `GET /api/v1/players/{id}`)
+
+The three blocks the profile page shows, under the page's own gates (`templates/player_profile.html.twig`). Built by `ProfileInsightsResponseFactory` (`src/Services/Api/`), one query each; the providers (`CurrentUserResponseProvider`, `PlayerProfileResponseProvider`) decide who sees what.
+
+```json
+"rating": [ { "pieces_count": 500, "points": 1532, "rank": 87, "total_players": 1204 },
+            { "pieces_count": 1000, "points": 1498, "rank": 120, "total_players": 863 } ],
+"skill":  [ { "pieces_count": 500, "tier": "proficient", "percentile": 62.5, "confidence": "medium", "qualifying_puzzles_count": 14 } ],
+"badges": [ "supporter" ]
+```
+
+- `rating` - the MSP Rating per piece count from `GetPlayerRatingRanking::allForPlayer` (ascending by piece count). **`points = round(elo_rating × 1000)`** - exactly the number the website prints (`PlayerRatingEntry::displayRating()`, `PlayerRatingProfile.html.twig`), never the raw elo; `rank` / `total_players` count the ranked public players of that piece count (plus the player themself). `null` when the player **opted out of rankings** (`ranking_opted_out` on `/me` says so) or the profile is masked; an empty list when the player is not ranked yet.
+- `skill` - the skill tier per piece count from `GetPlayerSkill::byPlayerId`: `tier` is one of `enthusiast`, `apprentice`, `proficient`, `advanced`, `expert`, `master`, `legend` (`SkillTier::toApiValue()`), `confidence` one of `insufficient`, `low`, `medium`, `high`. Puzzle Insights, so **members-only for the token owner** (`ApiTokenOwner::isMember()`) - on `/players/{id}` it is the *viewer's* membership that counts, whoever the profile belongs to, exactly as the profile page checks the logged-in visitor; a `client_credentials` token is never a member. Also `null` when the player opted out of rankings or the profile is masked; an empty list when there is no tier yet.
+- `badges` - `BadgeType` values from `GetBadges::forPlayer`; always a list (empty for a masked profile).
+
+`GET /api/v1/players/{id}` is the `GET /me` shape without `email`, `membership_ends_at` and the opt-out flags: `id, name, code, avatar, country, city, bio, facebook, instagram, is_private, has_active_membership, rating, skill, badges`. Any OAuth2 token with `profile:read` (machine tokens included - it is public profile data); PAT is `/me/*` only, so 403. **Masked private profile** - the target is private and the token does not belong to that player (a machine token never does): `name, avatar, country, city, bio, facebook, instagram` are `null`, `is_private: true`, `id`, `code` and `has_active_membership` stay, `rating: null`, `skill: null`, `badges: []` - and no insight query runs. The website's "Secret puzzler #CODE" label is presentation; clients render it from `is_private` + `code`. The player behind the token asking for their own private profile gets the full response. Unknown or malformed id → 404.
+
+**Fixed query cost** (asserted in `PlayerProfileEndpointTest::testQueryBudgets`, `CurrentUserEndpointTest::testRequestQueryBudget*`): `/me` = authentication (OAuth2 3: access token, player, consent usage; PAT 1) + profile + rating + badges + skill (member) → 7 / 5; `/players/{id}` = authentication + target profile + owner profile (`ApiTokenOwner`, not for a machine token) + the same blocks → member viewer 8, non-member 7, `client_credentials` 4, masked private 5 (auth-code) / 2 (machine token).
+
 ### POST `/api/v1/me/solving-times`
 
 ```json
@@ -236,7 +256,7 @@ The API twin of the Puzzle Insights block on the puzzle detail page (`PuzzleDeta
 ### Privacy
 
 - `/api/v1/me/*` always returns full data for the token owner
-- `/api/v1/players/{id}/*` returns empty/zeroed data for private profiles (not 403)
+- `/api/v1/players/{id}/*` returns empty/zeroed data for private profiles (not 403); `/api/v1/players/{id}` itself returns the masked shape (`is_private: true`, `id` + `code` + `has_active_membership`, everything else `null` / `[]`)
 - Hidden players are never returned in service-to-service queries
 
 ### Error Handling
@@ -304,6 +324,7 @@ Access control:
   player behind it. A `client_credentials` token is authenticated too (as the bundle's `ClientCredentialsUser`, no
   roles), and under `IS_AUTHENTICATED_FULLY` it used to reach the providers, fail `assert($user instanceof ApiUser)`
   and return 500; now it gets 403
+- `^/api/v1/players/[^/]+/?$` → `ROLE_OAUTH2_PROFILE:READ` (the public profile; the regex ends at the id segment so it cannot shadow the per-scope rules below)
 - `^/api/v1/players/.*/results` → `ROLE_OAUTH2_RESULTS:READ`
 - `^/api/v1/players/.*/statistics` → `ROLE_OAUTH2_STATISTICS:READ`
 - `^/api/v1/players/.*/collections` → `ROLE_OAUTH2_COLLECTIONS:READ`
@@ -380,6 +401,9 @@ Stub endpoints for in-app purchase verification (not implemented).
 | `src/Api/V1/PuzzleResponse.php` | The puzzle card (+ `PuzzleStatisticsResponse`, `PuzzleDifficultyResponse`, `TimePredictionResponse`, `PlayerSolvesResponse`) |
 | `src/Services/Api/ApiTokenOwner.php` | The single membership / scope gate behind every provider |
 | `src/Services/Api/PuzzleResponseFactory.php` | Builds puzzle cards for the calling token at a fixed query cost (one batch call per object); `insightsFor()` + `PuzzleInsightsBatch` serve the collection-item and result lists with the same batch |
+| `src/Api/V1/PlayerProfileResponse.php` | `GET /api/v1/players/{id}` resource (+ `PlayerRatingResponse`, `PlayerSkillResponse`, shared with `CurrentUserResponse`) |
+| `src/Services/Api/ProfileInsightsResponseFactory.php` | Builds the profile insight blocks (MSP Rating, skill tiers, badges), one query each |
+| `tests/ProfileInsightsSeeding.php` | Test trait seeding `player_elo` / `player_skill` / `badge` rows (the fixtures carry none) |
 | `src/Query/GetPuzzleStatistics.php`, `GetPlayerPuzzleSolves.php` | Batch queries behind the cards' `statistics` and `solves` objects |
 | `tests/QueryCountAssertions.php`, `tests/OpenApiAssertions.php` | Test traits: query budgets via the profiler, parameter documentation via `/api/docs.jsonopenapi` |
 | `src/Controller/FairUsePolicyController.php` | Fair use policy page |

--- a/docs/features/api/v1-expansion-plan.md
+++ b/docs/features/api/v1-expansion-plan.md
@@ -234,7 +234,7 @@ Waves (dependencies): **wave 1** PR 0 ∥ PR 1 (independent) → **wave 2** PR 2
 - [ ] PR 4 `prediction` on `POST /me/solving-times`
 - [ ] PR 5 puzzle library lists (wishlist, unsolved, lend/borrow, sell/swap, library summary)
 - [x] PR 5a medians in `puzzle_statistics` — code (2026-08-19: `median_time(_solo/_duo/_team)` columns, computed with `percentile_cont(0.5)` over the same per-player-best population as the averages, `median_seconds` on every `statistics` group); **backfill on the box still to do after deploy: `php bin/console myspeedpuzzling:recalculate-puzzle-statistics` once — until then `median_seconds` is `null`**
-- [ ] PR 6 profile insights on `/me` + `GET /players/{id}`
+- [x] PR 6 profile insights on `/me` + `GET /players/{id}` (2026-08-19; measured budgets: `/me` member 7 OAuth2 / 5 PAT - the §8 "+3" on top of auth 3 + profile; `/players/{id}` member viewer 8, non-member 7, cc 4, masked 5 (auth-code) / 2 (cc). The owner's own private profile on `/players/{id}` and on `/me` returns the rating (plan §8, "the full one"), while the web's own-private-profile view replaces both blocks with an explanation - the API follows the plan)
 
 Follow-ups deliberately out of scope: write endpoints for wishlist/lend-borrow (add/remove/return), `first_attempt_average_seconds` in statistics (exists for solo/duo only), tags on puzzle card / tag filter, related puzzles, marketplace offer counts, 301 to merge-survivor on `/puzzles/{id}`, puzzle-level solvers/ranking list, exact `pieces=` shorthand, per-scope rate limits beyond search, optional pagination on collection items (default must stay = all; if added, `limit` max 100 like search), per-item `ranking`.
 

--- a/src/Api/V1/CurrentUserResponse.php
+++ b/src/Api/V1/CurrentUserResponse.php
@@ -19,7 +19,12 @@ use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
                 description: 'has_active_membership and the three opt-out flags (time_predictions_opted_out, ranking_opted_out, streak_opted_out) '
                     . 'tell an app why a members-only block elsewhere in the API is null: not a member, or the player opted out on the website. '
                     . 'membership_ends_at is the ISO-8601 end of the current membership (for a Stripe subscription: the end of the paid billing period, '
-                    . 'which renews), null when the owner has no active membership.',
+                    . 'which renews), null when the owner has no active membership. '
+                    . 'The profile insights are what the owner\'s profile page shows: "rating" is the MSP Rating per piece count '
+                    . '(points = the rating the website displays, rank and total_players among the ranked players; null when the owner '
+                    . 'opted out of rankings, an empty list when not ranked yet), "skill" the skill tier per piece count '
+                    . '(enthusiast, apprentice, proficient, advanced, expert, master, legend; members only and null when opted out '
+                    . 'of rankings, an empty list when there is no tier yet), "badges" the badge tokens the owner earned.',
             ),
             security: "is_granted('ROLE_PAT') or is_granted('ROLE_OAUTH2_PROFILE:READ')",
             provider: CurrentUserResponseProvider::class,
@@ -28,6 +33,11 @@ use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 )]
 final class CurrentUserResponse
 {
+    /**
+     * @param null|list<PlayerRatingResponse> $rating null when the owner opted out of rankings
+     * @param null|list<PlayerSkillResponse> $skill null unless the owner is a member who has not opted out of rankings
+     * @param list<string> $badges
+     */
     public function __construct(
         public string $id,
         public null|string $name,
@@ -45,6 +55,9 @@ final class CurrentUserResponse
         public bool $time_predictions_opted_out,
         public bool $ranking_opted_out,
         public bool $streak_opted_out,
+        public null|array $rating,
+        public null|array $skill,
+        public array $badges,
     ) {
     }
 }

--- a/src/Api/V1/CurrentUserResponseProvider.php
+++ b/src/Api/V1/CurrentUserResponseProvider.php
@@ -6,33 +6,43 @@ namespace SpeedPuzzling\Web\Api\V1;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
-use SpeedPuzzling\Web\Query\GetPlayerProfile;
-use SpeedPuzzling\Web\Security\ApiUser;
+use SpeedPuzzling\Web\Exceptions\PlayerNotFound;
+use SpeedPuzzling\Web\Services\Api\ApiTokenOwner;
+use SpeedPuzzling\Web\Services\Api\ProfileInsightsResponseFactory;
 use Symfony\Bundle\SecurityBundle\Security;
 
 /**
+ * GET /api/v1/me - the token owner's own profile, with the insight blocks the
+ * owner's profile page shows (MSP Rating, skill tiers, badges) under the same
+ * gates: rating and skill are hidden when the owner opted out of rankings,
+ * skill is additionally members-only.
+ *
  * @implements ProviderInterface<CurrentUserResponse>
  */
 final readonly class CurrentUserResponseProvider implements ProviderInterface
 {
     public function __construct(
         private Security $security,
-        private GetPlayerProfile $getPlayerProfile,
+        private ApiTokenOwner $tokenOwner,
+        private ProfileInsightsResponseFactory $profileInsights,
     ) {
     }
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): CurrentUserResponse
     {
-        $user = $this->security->getUser();
-        assert($user instanceof ApiUser);
-
-        $profile = $this->getPlayerProfile->byId($user->getPlayer()->id->toString());
+        // access_control admits only tokens with a player behind them (PAT, auth-code),
+        // so the owner is always there; the profile is loaded once and memoised.
+        $profile = $this->tokenOwner->profile() ?? throw new PlayerNotFound();
 
         // Email is private. Personal Access Tokens grant full access to the owner's own
         // data, while third-party OAuth2 clients must be explicitly granted the
         // "email:read" scope (role ROLE_OAUTH2_EMAIL:READ) — otherwise email stays null.
         $canReadEmail = $this->security->isGranted('ROLE_PAT')
             || $this->security->isGranted('ROLE_OAUTH2_EMAIL:READ');
+
+        // The profile page hides both blocks for a player who opted out of rankings;
+        // the skill tiers are Puzzle Insights and members-only on top of that.
+        $showsRanking = $profile->rankingOptedOut === false;
 
         return new CurrentUserResponse(
             id: $profile->playerId,
@@ -54,6 +64,9 @@ final readonly class CurrentUserResponseProvider implements ProviderInterface
             time_predictions_opted_out: $profile->timePredictionsOptedOut,
             ranking_opted_out: $profile->rankingOptedOut,
             streak_opted_out: $profile->streakOptedOut,
+            rating: $showsRanking ? $this->profileInsights->rating($profile->playerId) : null,
+            skill: $showsRanking && $this->tokenOwner->isMember() ? $this->profileInsights->skill($profile->playerId) : null,
+            badges: $this->profileInsights->badges($profile->playerId),
         );
     }
 }

--- a/src/Api/V1/PlayerProfileResponse.php
+++ b/src/Api/V1/PlayerProfileResponse.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
+use ApiPlatform\OpenApi\Model\Response as OpenApiResponse;
+use SpeedPuzzling\Web\Results\PlayerProfile;
+
+/**
+ * GET /api/v1/players/{playerId} - a player's public profile as the profile
+ * page shows it, with the same three insight blocks as GET /me. The shape is
+ * the GET /me one without email, membership_ends_at and the opt-out flags.
+ */
+#[ApiResource(
+    shortName: 'PlayerProfile',
+    operations: [
+        new Get(
+            uriTemplate: '/v1/players/{playerId}',
+            // Declared explicitly: the response carries an "id" property, which API
+            // Platform would otherwise take as the identifier and name the path
+            // variable "id" - while the route (and the provider) say "playerId".
+            uriVariables: ['playerId' => new Link(fromClass: self::class, identifiers: ['id'])],
+            openapi: new OpenApiOperation(
+                tags: ['Players'],
+                summary: 'Public profile of a player',
+                description: 'The player\'s profile page as the API: public profile fields plus the three insight blocks. '
+                    . 'A private profile is masked exactly as on the website unless the token belongs to that player: '
+                    . 'name, avatar, country, city, bio, facebook and instagram are null, is_private is true, id, code and '
+                    . 'has_active_membership stay, rating and skill are null and badges is empty - clients render the '
+                    . '"Secret puzzler #CODE" label from is_private and code. '
+                    . '"rating" is the MSP Rating per piece count (points = the rating the website displays, rank and '
+                    . 'total_players among the ranked players); null when the player opted out of rankings, an empty list '
+                    . 'when not ranked yet. "skill" is the skill tier per piece count (enthusiast, apprentice, proficient, '
+                    . 'advanced, expert, master, legend) - Puzzle Insights, members-only exactly as on the website: the '
+                    . 'token owner (PAT owner or the player behind an authorization-code token) must be a member, so a '
+                    . 'client_credentials token always gets null; also null when the player opted out of rankings, an empty '
+                    . 'list when there is no tier yet. "badges" lists the badge tokens the player earned. '
+                    . 'Unknown or malformed id: 404.',
+                responses: [
+                    '401' => new OpenApiResponse(description: 'Missing, invalid or expired token.'),
+                    '403' => new OpenApiResponse(description: 'The token was not granted the profile:read scope.'),
+                    '404' => new OpenApiResponse(description: 'Unknown or malformed player id.'),
+                ],
+            ),
+            security: "is_granted('ROLE_OAUTH2_PROFILE:READ')",
+            provider: PlayerProfileResponseProvider::class,
+        ),
+    ],
+)]
+final class PlayerProfileResponse
+{
+    /**
+     * @param null|list<PlayerRatingResponse> $rating null when the profile is masked or the player opted out of rankings
+     * @param null|list<PlayerSkillResponse> $skill null unless the token owner is a member and the profile is neither masked nor opted out of rankings
+     * @param list<string> $badges
+     */
+    public function __construct(
+        public string $id,
+        public null|string $name,
+        public string $code,
+        public null|string $avatar,
+        public null|string $country,
+        public null|string $city,
+        public null|string $bio,
+        public null|string $facebook,
+        public null|string $instagram,
+        public bool $is_private,
+        public bool $has_active_membership,
+        public null|array $rating,
+        public null|array $skill,
+        public array $badges,
+    ) {
+    }
+
+    /**
+     * A private profile seen by anyone but its owner - the website's "Secret
+     * puzzler #CODE": nothing but the id, the code and the membership badge.
+     */
+    public static function masked(PlayerProfile $profile): self
+    {
+        return new self(
+            id: $profile->playerId,
+            name: null,
+            code: $profile->code,
+            avatar: null,
+            country: null,
+            city: null,
+            bio: null,
+            facebook: null,
+            instagram: null,
+            is_private: true,
+            has_active_membership: $profile->activeMembership,
+            rating: null,
+            skill: null,
+            badges: [],
+        );
+    }
+}

--- a/src/Api/V1/PlayerProfileResponseProvider.php
+++ b/src/Api/V1/PlayerProfileResponseProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use SpeedPuzzling\Web\Query\GetPlayerProfile;
+use SpeedPuzzling\Web\Services\Api\ApiTokenOwner;
+use SpeedPuzzling\Web\Services\Api\ProfileInsightsResponseFactory;
+
+/**
+ * GET /api/v1/players/{playerId} - the profile page as the API, with its
+ * gates (templates/player_profile.html.twig):
+ *
+ *   - a private profile is masked for everyone but the player behind the token
+ *     (a machine token is never that player) - no insight query is run then;
+ *   - rating and skill are hidden when the player opted out of rankings;
+ *   - skill is Puzzle Insights and therefore members-only for the *viewer*:
+ *     the token owner must be a member (ApiTokenOwner), whoever the profile
+ *     belongs to - exactly the membership check the profile page makes on the
+ *     logged-in visitor.
+ *
+ * @implements ProviderInterface<PlayerProfileResponse>
+ */
+final readonly class PlayerProfileResponseProvider implements ProviderInterface
+{
+    public function __construct(
+        private GetPlayerProfile $getPlayerProfile,
+        private ApiTokenOwner $tokenOwner,
+        private ProfileInsightsResponseFactory $profileInsights,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): PlayerProfileResponse
+    {
+        /** @var string $playerId */
+        $playerId = $uriVariables['playerId'];
+
+        // Validates the uuid and throws PlayerNotFound (404) for an unknown one
+        $profile = $this->getPlayerProfile->byId($playerId);
+
+        $isOwnProfile = $this->tokenOwner->profile()?->playerId === $profile->playerId;
+
+        if ($profile->isPrivate && $isOwnProfile === false) {
+            return PlayerProfileResponse::masked($profile);
+        }
+
+        $showsRanking = $profile->rankingOptedOut === false;
+
+        return new PlayerProfileResponse(
+            id: $profile->playerId,
+            name: $profile->playerName,
+            code: $profile->code,
+            avatar: $profile->avatar,
+            country: $profile->country,
+            city: $profile->city,
+            bio: $profile->bio,
+            facebook: $profile->facebook,
+            instagram: $profile->instagram,
+            is_private: $profile->isPrivate,
+            has_active_membership: $profile->activeMembership,
+            rating: $showsRanking ? $this->profileInsights->rating($profile->playerId) : null,
+            skill: $showsRanking && $this->tokenOwner->isMember() ? $this->profileInsights->skill($profile->playerId) : null,
+            badges: $this->profileInsights->badges($profile->playerId),
+        );
+    }
+}

--- a/src/Api/V1/PlayerRatingResponse.php
+++ b/src/Api/V1/PlayerRatingResponse.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+/**
+ * One row of the MSP Rating block on the profile page: the player's rating
+ * for a piece count, the same number the website shows (points = the stored
+ * elo rating scaled by 1000, rounded - PlayerRatingEntry::displayRating()),
+ * and the rank among the ranked players of that piece count.
+ *
+ * An endpoint returns null for the whole list when the rating is not
+ * available to the token (the player opted out of rankings, or the profile
+ * is private and masked); an empty list means "not ranked yet".
+ */
+final class PlayerRatingResponse
+{
+    public function __construct(
+        public int $pieces_count,
+        public int $points,
+        public int $rank,
+        public int $total_players,
+    ) {
+    }
+
+    /**
+     * @param array{elo_rating: float, rank: int, total: int} $rating one entry of GetPlayerRatingRanking::allForPlayer()
+     */
+    public static function fromRating(int $piecesCount, array $rating): self
+    {
+        return new self(
+            pieces_count: $piecesCount,
+            points: (int) round($rating['elo_rating'] * 1000),
+            rank: $rating['rank'],
+            total_players: $rating['total'],
+        );
+    }
+}

--- a/src/Api/V1/PlayerSkillResponse.php
+++ b/src/Api/V1/PlayerSkillResponse.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Api\V1;
+
+use SpeedPuzzling\Web\Results\PlayerSkillResult;
+
+/**
+ * One row of the "Player insights" skill block on the profile page: the
+ * player's skill tier for a piece count (Puzzle Insights - members-only,
+ * exactly as on the website: the *token owner* must be a member to see it,
+ * whoever the profile belongs to).
+ *
+ * An endpoint returns null for the whole list when the token is not entitled
+ * to it (not a member, machine token, the player opted out of rankings, or
+ * the profile is private and masked); an empty list means "no tier yet".
+ */
+final class PlayerSkillResponse
+{
+    public function __construct(
+        public int $pieces_count,
+        public string $tier,
+        public float $percentile,
+        public string $confidence,
+        public int $qualifying_puzzles_count,
+    ) {
+    }
+
+    public static function fromResult(PlayerSkillResult $skill): self
+    {
+        return new self(
+            pieces_count: $skill->piecesCount,
+            tier: $skill->skillTier->toApiValue(),
+            percentile: $skill->skillPercentile,
+            confidence: $skill->confidence->value,
+            qualifying_puzzles_count: $skill->qualifyingPuzzlesCount,
+        );
+    }
+}

--- a/src/Services/Api/ProfileInsightsResponseFactory.php
+++ b/src/Services/Api/ProfileInsightsResponseFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Services\Api;
+
+use SpeedPuzzling\Web\Api\V1\PlayerRatingResponse;
+use SpeedPuzzling\Web\Api\V1\PlayerSkillResponse;
+use SpeedPuzzling\Web\Query\GetBadges;
+use SpeedPuzzling\Web\Query\GetPlayerRatingRanking;
+use SpeedPuzzling\Web\Query\GetPlayerSkill;
+use SpeedPuzzling\Web\Results\PlayerSkillResult;
+use SpeedPuzzling\Web\Value\BadgeType;
+
+/**
+ * Builds the three profile-insight blocks the profile page shows - MSP Rating,
+ * skill tiers, badges - for the public API (GET /me, GET /players/{id}), one
+ * query each. Who may see which block is decided by the providers (the
+ * website's gates: opt-out, private profile, token owner's membership); this
+ * factory only builds what they ask for.
+ */
+final readonly class ProfileInsightsResponseFactory
+{
+    public function __construct(
+        private GetPlayerRatingRanking $getPlayerRatingRanking,
+        private GetPlayerSkill $getPlayerSkill,
+        private GetBadges $getBadges,
+    ) {
+    }
+
+    /**
+     * @return list<PlayerRatingResponse> ascending by piece count, empty when not ranked yet
+     */
+    public function rating(string $playerId): array
+    {
+        $ratings = [];
+
+        foreach ($this->getPlayerRatingRanking->allForPlayer($playerId) as $piecesCount => $rating) {
+            $ratings[] = PlayerRatingResponse::fromRating($piecesCount, $rating);
+        }
+
+        return $ratings;
+    }
+
+    /**
+     * @return list<PlayerSkillResponse> ascending by piece count, empty when no tier yet
+     */
+    public function skill(string $playerId): array
+    {
+        return array_map(
+            static fn (PlayerSkillResult $skill): PlayerSkillResponse => PlayerSkillResponse::fromResult($skill),
+            $this->getPlayerSkill->byPlayerId($playerId),
+        );
+    }
+
+    /**
+     * @return list<string> badge tokens (BadgeType values)
+     */
+    public function badges(string $playerId): array
+    {
+        return array_map(
+            static fn (BadgeType $badge): string => $badge->value,
+            $this->getBadges->forPlayer($playerId),
+        );
+    }
+}

--- a/src/Value/SkillTier.php
+++ b/src/Value/SkillTier.php
@@ -14,6 +14,23 @@ enum SkillTier: int
     case Master = 6;
     case Legend = 7;
 
+    /**
+     * Stable lowercase token for the public API (the website keys its icons
+     * and translations off strtolower(name), which is not a wire format).
+     */
+    public function toApiValue(): string
+    {
+        return match ($this) {
+            self::Enthusiast => 'enthusiast',
+            self::Apprentice => 'apprentice',
+            self::Proficient => 'proficient',
+            self::Advanced => 'advanced',
+            self::Expert => 'expert',
+            self::Master => 'master',
+            self::Legend => 'legend',
+        };
+    }
+
     public static function fromPercentile(float $percentile): self
     {
         return match (true) {

--- a/templates/for-developers.html.twig
+++ b/templates/for-developers.html.twig
@@ -328,6 +328,12 @@ HTTP/1.1 200 OK
                         </tr>
                         <tr><td colspan="4" class="ps-3 fw-bold bg-light text-muted fs-sm pt-2 pb-1">{{ 'for_developers.table_section_players'|trans }}</td></tr>
                         <tr>
+                            <td class="ps-3"><code class="fs-sm">GET /api/v1/players/{id}</code></td>
+                            <td class="text-center text-muted">&mdash;</td>
+                            <td class="text-center text-success"><i class="bi bi-check-lg"></i></td>
+                            <td class="text-center text-success"><i class="bi bi-check-lg"></i></td>
+                        </tr>
+                        <tr>
                             <td class="ps-3"><code class="fs-sm">GET /api/v1/players/{id}/results</code></td>
                             <td class="text-center text-muted">&mdash;</td>
                             <td class="text-center text-success"><i class="bi bi-check-lg"></i></td>

--- a/tests/Controller/Api/V1/CurrentUserEndpointTest.php
+++ b/tests/Controller/Api/V1/CurrentUserEndpointTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
 
 use DateTimeImmutable;
-use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Doctrine\ORM\EntityManagerInterface;
 use SpeedPuzzling\Web\Entity\Membership;
 use SpeedPuzzling\Web\Entity\Player;
@@ -13,15 +12,21 @@ use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
 use SpeedPuzzling\Web\Tests\PatTestHelper;
-use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
+use SpeedPuzzling\Web\Tests\ProfileInsightsSeeding;
+use SpeedPuzzling\Web\Tests\QueryCountAssertions;
+use SpeedPuzzling\Web\Value\BadgeType;
+use SpeedPuzzling\Web\Value\MetricConfidence;
+use SpeedPuzzling\Web\Value\SkillTier;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Profiler\Profile;
 
 final class CurrentUserEndpointTest extends WebTestCase
 {
+    use ProfileInsightsSeeding;
+    use QueryCountAssertions;
+
     public function testWithoutTokenReturnsUnauthorized(): void
     {
         $browser = self::createClient();
@@ -364,36 +369,190 @@ final class CurrentUserEndpointTest extends WebTestCase
     }
 
     /**
-     * The four new fields come from the PlayerProfile the provider already loads -
-     * the request must not issue a single extra query. Measured before the fields
-     * were added: OAuth2 = 3 queries (player, access token, profile), PAT = 2
-     * (token, profile). Only the request is counted - the token-creation queries
-     * are flushed from the Doctrine debug log right before it.
+     * The profile page's insight blocks, for the owner: the MSP Rating rows
+     * (points = round(elo x 1000), the number the website prints), the skill
+     * tiers (members-only) and the badges. Seeded: PLAYER_REGULAR is rated
+     * higher, so PLAYER_WITH_STRIPE is #2 of 2 at 500 pieces.
      */
-    public function testRequestQueryBudgetIsUnchangedViaOAuth2(): void
+    public function testMemberGetsRatingSkillAndBadges(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_REGULAR, 500, 1.601);
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 1000, 1.4978);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Proficient, 62.5, MetricConfidence::Medium, 14);
+        $this->seedBadge($browser, PlayerFixture::PLAYER_WITH_STRIPE, BadgeType::Supporter);
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertTrue($response['has_active_membership']);
+        $this->assertSame([
+            ['pieces_count' => 500, 'points' => 1532, 'rank' => 2, 'total_players' => 2],
+            ['pieces_count' => 1000, 'points' => 1498, 'rank' => 1, 'total_players' => 1],
+        ], $response['rating']);
+        $this->assertSame([
+            ['pieces_count' => 500, 'tier' => 'proficient', 'percentile' => 62.5, 'confidence' => 'medium', 'qualifying_puzzles_count' => 14],
+        ], $response['skill']);
+        $this->assertSame(['supporter'], $response['badges']);
+    }
+
+    public function testMemberGetsRatingSkillAndBadgesViaPersonalAccessToken(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Expert, 88.0, MetricConfidence::High, 25);
+
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_WITH_STRIPE));
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertSame([['pieces_count' => 500, 'points' => 1532, 'rank' => 1, 'total_players' => 1]], $response['rating']);
+        $this->assertSame([['pieces_count' => 500, 'tier' => 'expert', 'percentile' => 88.0, 'confidence' => 'high', 'qualifying_puzzles_count' => 25]], $response['skill']);
+        $this->assertSame([], $response['badges']);
+    }
+
+    /**
+     * A member who is not ranked yet and has no tier: the lists are present and
+     * empty - null is reserved for "not available to this token".
+     */
+    public function testMemberWithoutRowsGetsEmptyLists(): void
     {
         $browser = self::createClient();
 
         $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
-        $browser->enableProfiler();
-        $this->resetQueryLog($browser);
         $browser->request('GET', '/api/v1/me');
 
         $this->assertResponseIsSuccessful();
-        $this->assertLessThanOrEqual(3, $this->queryCount($browser));
+        $response = $this->decode($browser);
+
+        $this->assertSame([], $response['rating']);
+        $this->assertSame([], $response['skill']);
+        $this->assertSame([], $response['badges']);
     }
 
-    public function testRequestQueryBudgetIsUnchangedViaPersonalAccessToken(): void
+    /**
+     * The skill tiers are Puzzle Insights - members-only on the profile page (the
+     * locked "Player insights" button) - so a non-member gets null even when a
+     * row exists; the MSP Rating is public and stays.
+     */
+    public function testNonMemberGetsRatingButNoSkill(): void
     {
         $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_REGULAR, 500, 1.601);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_REGULAR, 500, SkillTier::Advanced, 75.0, MetricConfidence::Low, 6);
+        $this->seedBadge($browser, PlayerFixture::PLAYER_REGULAR, BadgeType::Supporter);
 
-        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_WITH_STRIPE));
-        $browser->enableProfiler();
-        $this->resetQueryLog($browser);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
         $browser->request('GET', '/api/v1/me');
 
         $this->assertResponseIsSuccessful();
-        $this->assertLessThanOrEqual(2, $this->queryCount($browser));
+        $response = $this->decode($browser);
+
+        $this->assertFalse($response['has_active_membership']);
+        $this->assertSame([['pieces_count' => 500, 'points' => 1601, 'rank' => 1, 'total_players' => 1]], $response['rating']);
+        $this->assertArrayHasKey('skill', $response);
+        $this->assertNull($response['skill']);
+        $this->assertSame(['supporter'], $response['badges']);
+
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_REGULAR));
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+        $this->assertSame([['pieces_count' => 500, 'points' => 1601, 'rank' => 1, 'total_players' => 1]], $response['rating']);
+        $this->assertNull($response['skill']);
+    }
+
+    /**
+     * Opted out of rankings: the profile page replaces both blocks with an
+     * explanation, the API says null for both - ranking_opted_out tells why.
+     * Badges are not part of the opt-out.
+     */
+    public function testRankingOptOutHidesRatingAndSkill(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Proficient, 62.5, MetricConfidence::Medium, 14);
+        $this->seedBadge($browser, PlayerFixture::PLAYER_WITH_STRIPE, BadgeType::Supporter);
+        $this->optOutOfRankings($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertTrue($response['has_active_membership']);
+        $this->assertTrue($response['ranking_opted_out']);
+        $this->assertArrayHasKey('rating', $response);
+        $this->assertNull($response['rating']);
+        $this->assertArrayHasKey('skill', $response);
+        $this->assertNull($response['skill']);
+        $this->assertSame(['supporter'], $response['badges']);
+    }
+
+    /**
+     * The flags come from the PlayerProfile the provider already loads (no query
+     * of their own); the insight blocks cost one query each - rating, badges, and
+     * skill for a member - on top of the authentication and the profile. Measured:
+     * OAuth2 = 3 (access token, player, consent usage) + profile + 3 = 7 for a
+     * member, PAT = 1 (token) + profile + 3 = 5. Only the request is counted
+     * (QueryCountAssertions resets the Doctrine debug log right before it).
+     */
+    public function testRequestQueryBudgetViaOAuth2(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Proficient, 62.5, MetricConfidence::Medium, 14);
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 7, 'member, authorization-code token');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 6, 'non-member, authorization-code token (no skill query)');
+
+        $this->optOutOfRankings($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 5, 'member opted out of rankings (badges only)');
+    }
+
+    public function testRequestQueryBudgetViaPersonalAccessToken(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Proficient, 62.5, MetricConfidence::Medium, 14);
+
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_WITH_STRIPE));
+        $this->startCountingQueries($browser);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 5, 'member, personal access token');
+
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_REGULAR));
+        $this->startCountingQueries($browser);
+        $browser->request('GET', '/api/v1/me');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 4, 'non-member, personal access token (no skill query)');
     }
 
     /**
@@ -439,32 +598,6 @@ final class CurrentUserEndpointTest extends WebTestCase
         $membership->cancel(new DateTimeImmutable('-1 day'));
         $entityManager->flush();
         $entityManager->clear();
-    }
-
-    /**
-     * The first request of a test reuses the kernel that the token helpers already
-     * booted, so the Doctrine data collector would also count the queries those
-     * helpers issued. Empty the debug log so the profile covers the request only.
-     */
-    private function resetQueryLog(KernelBrowser $browser): void
-    {
-        /** @var ContainerInterface $container */
-        $container = $browser->getContainer();
-
-        /** @var DebugDataHolder $debugDataHolder */
-        $debugDataHolder = $container->get('doctrine.debug_data_holder');
-        $debugDataHolder->reset();
-    }
-
-    private function queryCount(KernelBrowser $browser): int
-    {
-        $profile = $browser->getProfile();
-        $this->assertInstanceOf(Profile::class, $profile);
-
-        $collector = $profile->getCollector('db');
-        $this->assertInstanceOf(DoctrineDataCollector::class, $collector);
-
-        return $collector->getQueryCount();
     }
 
     private function entityManager(KernelBrowser $browser): EntityManagerInterface

--- a/tests/Controller/Api/V1/PlayerProfileEndpointTest.php
+++ b/tests/Controller/Api/V1/PlayerProfileEndpointTest.php
@@ -1,0 +1,475 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
+
+use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
+use SpeedPuzzling\Web\Tests\OAuth2TestHelper;
+use SpeedPuzzling\Web\Tests\OpenApiAssertions;
+use SpeedPuzzling\Web\Tests\PatTestHelper;
+use SpeedPuzzling\Web\Tests\ProfileInsightsSeeding;
+use SpeedPuzzling\Web\Tests\QueryCountAssertions;
+use SpeedPuzzling\Web\Value\BadgeType;
+use SpeedPuzzling\Web\Value\MetricConfidence;
+use SpeedPuzzling\Web\Value\SkillTier;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * GET /api/v1/players/{playerId} - the profile page as the API: public profile
+ * plus the MSP Rating, skill tier and badge blocks, gated exactly as the page
+ * is (templates/player_profile.html.twig): a private profile is masked for
+ * everyone but its owner, rating and skill vanish when the player opted out of
+ * rankings, and skill is members-only for the *viewer* (the token owner).
+ *
+ * Fixtures (.claude/fixtures.md): PLAYER_WITH_STRIPE (Sarah Williams, London)
+ * and PLAYER_ADMIN are members, PLAYER_REGULAR is not, PLAYER_PRIVATE (Jane
+ * Smith) is private. No player_elo / player_skill / badge rows exist - the
+ * ProfileInsightsSeeding trait seeds them per test.
+ *
+ * @phpstan-type Rating array{pieces_count: int, points: int, rank: int, total_players: int}
+ * @phpstan-type Skill array{pieces_count: int, tier: string, percentile: float, confidence: string, qualifying_puzzles_count: int}
+ * @phpstan-type Profile array{
+ *     id: string,
+ *     name: null|string,
+ *     code: string,
+ *     avatar: null|string,
+ *     country: null|string,
+ *     city: null|string,
+ *     bio: null|string,
+ *     facebook: null|string,
+ *     instagram: null|string,
+ *     is_private: bool,
+ *     has_active_membership: bool,
+ *     rating: null|list<Rating>,
+ *     skill: null|list<Skill>,
+ *     badges: list<string>,
+ * }
+ */
+final class PlayerProfileEndpointTest extends WebTestCase
+{
+    use OpenApiAssertions;
+    use ProfileInsightsSeeding;
+    use QueryCountAssertions;
+
+    private const string OPENAPI_PATH = '/api/v1/players/{playerId}';
+
+    public function testAnonymousRequestIsUnauthorized(): void
+    {
+        $browser = self::createClient();
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testTokenWithoutProfileReadScopeIsForbidden(): void
+    {
+        $browser = self::createClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['results:read']);
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * Personal access tokens are for the owner's own data only (/me/*); other
+     * players' profiles are OAuth2 territory, as for every /players/{id} route.
+     */
+    public function testPersonalAccessTokenIsForbidden(): void
+    {
+        $browser = self::createClient();
+        PatTestHelper::addBearerToken($browser, PatTestHelper::createToken($browser, PlayerFixture::PLAYER_REGULAR));
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testUnknownPlayerIsNotFound(): void
+    {
+        $browser = self::createClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
+
+        $browser->request('GET', $this->endpoint('00000000-0000-0000-0000-000000000000'));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testMalformedPlayerIdIsNotFound(): void
+    {
+        $browser = self::createClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
+
+        $browser->request('GET', $this->endpoint('not-a-uuid'));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * A public profile through an authorization-code token: the GET /me shape
+     * without email, membership_ends_at and the opt-out flags, plus the three
+     * blocks. The viewer (PLAYER_REGULAR) is not a member, so skill is null
+     * even though the target has a tier - exactly the locked "Player insights"
+     * button a non-member sees on the website.
+     */
+    public function testPublicProfileShapeForNonMemberViewer(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_REGULAR, 500, 1.601);
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Proficient, 62.5, MetricConfidence::Medium, 14);
+        $this->seedBadge($browser, PlayerFixture::PLAYER_WITH_STRIPE, BadgeType::Supporter);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            ['id', 'name', 'code', 'avatar', 'country', 'city', 'bio', 'facebook', 'instagram', 'is_private', 'has_active_membership', 'rating', 'skill', 'badges'],
+            array_keys($this->decodeRaw($browser)),
+            'the GET /me shape without email, membership_ends_at and the opt-out flags, the three blocks appended',
+        );
+        $response = $this->decode($browser);
+
+        $this->assertSame(PlayerFixture::PLAYER_WITH_STRIPE, $response['id']);
+        $this->assertSame(PlayerFixture::PLAYER_WITH_STRIPE_NAME, $response['name']);
+        $this->assertSame('player4', $response['code']);
+        $this->assertSame('gb', $response['country']);
+        $this->assertSame('London', $response['city']);
+        $this->assertFalse($response['is_private']);
+        $this->assertTrue($response['has_active_membership']);
+        $this->assertSame([['pieces_count' => 500, 'points' => 1532, 'rank' => 2, 'total_players' => 2]], $response['rating']);
+        $this->assertNull($response['skill']);
+        $this->assertSame(['supporter'], $response['badges']);
+    }
+
+    /**
+     * A member viewer sees the target's skill tiers - puzzle-intelligence data
+     * about the target that the profile page shows to any member visitor.
+     */
+    public function testMemberViewerSeesSkill(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Proficient, 62.5, MetricConfidence::Medium, 14);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 1000, SkillTier::Legend, 99.2, MetricConfidence::High, 30);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_ADMIN, ['profile:read']);
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertSame([['pieces_count' => 500, 'points' => 1532, 'rank' => 1, 'total_players' => 1]], $response['rating']);
+        $this->assertSame([
+            ['pieces_count' => 500, 'tier' => 'proficient', 'percentile' => 62.5, 'confidence' => 'medium', 'qualifying_puzzles_count' => 14],
+            ['pieces_count' => 1000, 'tier' => 'legend', 'percentile' => 99.2, 'confidence' => 'high', 'qualifying_puzzles_count' => 30],
+        ], $response['skill']);
+    }
+
+    /**
+     * A member viewer looking at a public player who has no rows yet: the
+     * lists are present and empty - null means "not available to this token".
+     */
+    public function testMemberViewerGetsEmptyListsWhenTargetHasNoRows(): void
+    {
+        $browser = self::createClient();
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_ADMIN, ['profile:read']);
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_REGULAR));
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertSame(PlayerFixture::PLAYER_REGULAR_NAME, $response['name']);
+        $this->assertFalse($response['has_active_membership']);
+        $this->assertSame([], $response['rating']);
+        $this->assertSame([], $response['skill']);
+        $this->assertSame([], $response['badges']);
+    }
+
+    /**
+     * A client_credentials token has no player behind it: public profile data
+     * and the public rating, never a membership - so skill is null.
+     */
+    public function testClientCredentialsTokenSeesPublicDataWithoutSkill(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Proficient, 62.5, MetricConfidence::Medium, 14);
+        $this->seedBadge($browser, PlayerFixture::PLAYER_WITH_STRIPE, BadgeType::Supporter);
+        $this->authenticateClientCredentials($browser);
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertSame(PlayerFixture::PLAYER_WITH_STRIPE_NAME, $response['name']);
+        $this->assertTrue($response['has_active_membership']);
+        $this->assertSame([['pieces_count' => 500, 'points' => 1532, 'rank' => 1, 'total_players' => 1]], $response['rating']);
+        $this->assertNull($response['skill']);
+        $this->assertSame(['supporter'], $response['badges']);
+    }
+
+    /**
+     * Opted out of rankings: the profile page shows neither block to anyone,
+     * the API says null for both (a member viewer included); badges stay.
+     */
+    public function testRankingOptOutHidesRatingAndSkill(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Proficient, 62.5, MetricConfidence::Medium, 14);
+        $this->seedBadge($browser, PlayerFixture::PLAYER_WITH_STRIPE, BadgeType::Supporter);
+        $this->optOutOfRankings($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_ADMIN, ['profile:read']);
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+
+        $this->assertResponseIsSuccessful();
+        $raw = $this->decodeRaw($browser);
+        $this->assertArrayHasKey('rating', $raw);
+        $this->assertArrayHasKey('skill', $raw);
+        $response = $this->decode($browser);
+
+        $this->assertSame(PlayerFixture::PLAYER_WITH_STRIPE_NAME, $response['name']);
+        $this->assertNull($response['rating']);
+        $this->assertNull($response['skill']);
+        $this->assertSame(['supporter'], $response['badges']);
+    }
+
+    /**
+     * A private profile seen by anyone else - a member, a machine token - is the
+     * website's "Secret puzzler #CODE": id, code and the membership badge stay,
+     * every other field is null, the insight blocks are null / empty, and no
+     * insight query runs.
+     */
+    public function testPrivateProfileIsMaskedForAStranger(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_PRIVATE, 500, 1.9);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_PRIVATE, 500, SkillTier::Master, 96.0, MetricConfidence::High, 20);
+        $this->seedBadge($browser, PlayerFixture::PLAYER_PRIVATE, BadgeType::Supporter);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_WITH_STRIPE, ['profile:read']);
+
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_PRIVATE));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 5, 'masked private profile, authorization-code token (auth 3 + target + owner, no insight query)');
+        $response = $this->decode($browser);
+
+        $this->assertSame([
+            'id' => PlayerFixture::PLAYER_PRIVATE,
+            'name' => null,
+            'code' => 'player2',
+            'avatar' => null,
+            'country' => null,
+            'city' => null,
+            'bio' => null,
+            'facebook' => null,
+            'instagram' => null,
+            'is_private' => true,
+            'has_active_membership' => false,
+            'rating' => null,
+            'skill' => null,
+            'badges' => [],
+        ], $response);
+
+        $this->authenticateClientCredentials($browser);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_PRIVATE));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 2, 'masked private profile, client_credentials token (access token + target)');
+        $response = $this->decode($browser);
+        $this->assertNull($response['name']);
+        $this->assertTrue($response['is_private']);
+        $this->assertSame('player2', $response['code']);
+        $this->assertNull($response['rating']);
+        $this->assertNull($response['skill']);
+        $this->assertSame([], $response['badges']);
+    }
+
+    /**
+     * The player behind the token asking for their own (private) profile gets
+     * the full response - the same as GET /me minus the private fields.
+     */
+    public function testPrivateProfileIsFullForItsOwner(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_REGULAR, 500, 1.601);
+        $this->seedRating($browser, PlayerFixture::PLAYER_PRIVATE, 500, 1.9);
+        $this->seedBadge($browser, PlayerFixture::PLAYER_PRIVATE, BadgeType::Supporter);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_PRIVATE, ['profile:read']);
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_PRIVATE));
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decode($browser);
+
+        $this->assertSame(PlayerFixture::PLAYER_PRIVATE, $response['id']);
+        $this->assertSame('Jane Smith', $response['name']);
+        $this->assertSame('us', $response['country']);
+        $this->assertSame('New York', $response['city']);
+        $this->assertTrue($response['is_private']);
+        // the private player counts in their own pool: #1 of 2 (PLAYER_REGULAR is the other)
+        $this->assertSame([['pieces_count' => 500, 'points' => 1900, 'rank' => 1, 'total_players' => 2]], $response['rating']);
+        $this->assertNull($response['skill'], 'PLAYER_PRIVATE is not a member');
+        $this->assertSame(['supporter'], $response['badges']);
+    }
+
+    /**
+     * points is exactly the number the profile page prints - round(elo x 1000)
+     * (PlayerRatingEntry::displayRating()), never the raw elo.
+     */
+    public function testRatingPointsAreTheDisplayedRating(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.2346);
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 1000, 0.9994);
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 1500, 1.0004);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
+
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+
+        $this->assertResponseIsSuccessful();
+        $rating = $this->decode($browser)['rating'];
+        $this->assertNotNull($rating);
+
+        $this->assertSame([500, 1000, 1500], array_column($rating, 'pieces_count'), 'ascending by piece count');
+        $this->assertSame([1235, 999, 1000], array_column($rating, 'points'), 'round(elo x 1000), not the raw elo and not truncated');
+    }
+
+    /**
+     * Fixed cost per request (plan §8): authentication + target profile + owner
+     * profile + one query per block. Measured: OAuth2 authentication is 3
+     * queries (access token, player, consent usage), client_credentials 1.
+     */
+    public function testQueryBudgets(): void
+    {
+        $browser = self::createClient();
+        $this->seedRating($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, 1.5324);
+        $this->seedSkill($browser, PlayerFixture::PLAYER_WITH_STRIPE, 500, SkillTier::Proficient, 62.5, MetricConfidence::Medium, 14);
+        $this->seedBadge($browser, PlayerFixture::PLAYER_WITH_STRIPE, BadgeType::Supporter);
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_ADMIN, ['profile:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 8, 'member viewer: auth 3 + target + owner + rating + skill + badges');
+
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_REGULAR, ['profile:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 7, 'non-member viewer: no skill query');
+
+        $this->authenticateClientCredentials($browser);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 4, 'client_credentials: access token + target + rating + badges, no owner profile');
+
+        $this->optOutOfRankings($browser, PlayerFixture::PLAYER_WITH_STRIPE);
+        $this->authenticateOAuth2($browser, PlayerFixture::PLAYER_ADMIN, ['profile:read']);
+        $this->startCountingQueries($browser);
+        $browser->request('GET', $this->endpoint(PlayerFixture::PLAYER_WITH_STRIPE));
+        $this->assertResponseIsSuccessful();
+        $this->assertQueryCountAtMost($browser, 6, 'target opted out of rankings: badges only');
+    }
+
+    public function testOpenApiDocumentsTheEndpoint(): void
+    {
+        $browser = self::createClient();
+
+        $document = $this->openApiDocument($browser);
+
+        /** @var array<string, array{get: array{tags: list<string>, summary: string, parameters: list<array{name: string, in: string}>, responses: array<int|string, mixed>}}> $paths */
+        $paths = $document['paths'];
+        $this->assertArrayHasKey(self::OPENAPI_PATH, $paths);
+        $operation = $paths[self::OPENAPI_PATH]['get'];
+        $this->assertSame(['Players'], $operation['tags']);
+        $this->assertNotSame('', $operation['summary']);
+        $this->assertSame([['playerId', 'path']], array_map(static fn (array $p): array => [$p['name'], $p['in']], $operation['parameters']));
+        $this->assertArrayHasKey('404', $operation['responses']);
+
+        /** @var array{schemas: array<string, array{properties: array<string, mixed>}>} $components */
+        $components = $document['components'];
+        $schemas = $components['schemas'];
+        $this->assertSame(
+            ['id', 'name', 'code', 'avatar', 'country', 'city', 'bio', 'facebook', 'instagram', 'is_private', 'has_active_membership', 'rating', 'skill', 'badges'],
+            array_keys($schemas['PlayerProfile']['properties']),
+        );
+        $this->assertSame(['pieces_count', 'points', 'rank', 'total_players'], array_keys($schemas['PlayerRatingResponse']['properties']));
+        $this->assertSame(['pieces_count', 'tier', 'percentile', 'confidence', 'qualifying_puzzles_count'], array_keys($schemas['PlayerSkillResponse']['properties']));
+        // the same three blocks on GET /me, appended after the PR 0 flags
+        $this->assertSame(['rating', 'skill', 'badges'], array_slice(array_keys($schemas['CurrentUser']['properties']), -3));
+    }
+
+    private function endpoint(string $playerId): string
+    {
+        return '/api/v1/players/' . $playerId;
+    }
+
+    /**
+     * @param array<non-empty-string> $scopes
+     */
+    private function authenticateOAuth2(KernelBrowser $browser, string $playerId, array $scopes): void
+    {
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            $playerId,
+            $scopes,
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    private function authenticateClientCredentials(KernelBrowser $browser): void
+    {
+        // sub = aud = client id is exactly what the client_credentials grant issues
+        $token = OAuth2TestHelper::createAccessToken(
+            $browser,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            OAuth2ClientFixture::CONFIDENTIAL_CLIENT_ID,
+            ['profile:read'],
+        );
+
+        OAuth2TestHelper::addBearerToken($browser, $token);
+    }
+
+    /**
+     * @return Profile
+     */
+    private function decode(KernelBrowser $browser): array
+    {
+        /** @var Profile $decoded */
+        $decoded = $this->decodeRaw($browser);
+
+        return $decoded;
+    }
+
+    /**
+     * Untyped, for assertions about the wire shape itself (key order, presence).
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeRaw(KernelBrowser $browser): array
+    {
+        $content = $browser->getResponse()->getContent();
+        $this->assertIsString($content);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+}

--- a/tests/ProfileInsightsSeeding.php
+++ b/tests/ProfileInsightsSeeding.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpeedPuzzling\Web\Tests;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use SpeedPuzzling\Web\Entity\Badge;
+use SpeedPuzzling\Web\Entity\Player;
+use SpeedPuzzling\Web\Entity\PlayerElo;
+use SpeedPuzzling\Web\Entity\PlayerSkill;
+use SpeedPuzzling\Web\Value\BadgeType;
+use SpeedPuzzling\Web\Value\MetricConfidence;
+use SpeedPuzzling\Web\Value\SkillTier;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Seeds the rows behind the profile insights of the public API (GET /me,
+ * GET /players/{id}): MSP Rating (player_elo), skill tiers (player_skill) and
+ * badges. The fixtures carry none of them - the puzzle-intelligence
+ * recalculation is a batch job and the fixture solves do not reach its
+ * qualification thresholds - so every test seeds exactly what it asserts on.
+ * DAMA rolls the rows back with the test.
+ */
+trait ProfileInsightsSeeding
+{
+    protected function seedRating(KernelBrowser $browser, string $playerId, int $piecesCount, float $eloRating): void
+    {
+        $entityManager = $this->insightsEntityManager($browser);
+
+        $player = $entityManager->find(Player::class, $playerId);
+        self::assertNotNull($player);
+
+        $entityManager->persist(new PlayerElo(
+            id: Uuid::uuid7(),
+            player: $player,
+            piecesCount: $piecesCount,
+            eloRating: $eloRating,
+            computedAt: new DateTimeImmutable(),
+        ));
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    protected function seedSkill(
+        KernelBrowser $browser,
+        string $playerId,
+        int $piecesCount,
+        SkillTier $tier,
+        float $percentile,
+        MetricConfidence $confidence,
+        int $qualifyingPuzzlesCount,
+    ): void {
+        $entityManager = $this->insightsEntityManager($browser);
+
+        $player = $entityManager->find(Player::class, $playerId);
+        self::assertNotNull($player);
+
+        $entityManager->persist(new PlayerSkill(
+            id: Uuid::uuid7(),
+            player: $player,
+            piecesCount: $piecesCount,
+            skillScore: 1.0,
+            skillTier: $tier->value,
+            skillPercentile: $percentile,
+            confidence: $confidence->value,
+            qualifyingPuzzlesCount: $qualifyingPuzzlesCount,
+            computedAt: new DateTimeImmutable(),
+        ));
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    protected function seedBadge(KernelBrowser $browser, string $playerId, BadgeType $type): void
+    {
+        $entityManager = $this->insightsEntityManager($browser);
+
+        $player = $entityManager->find(Player::class, $playerId);
+        self::assertNotNull($player);
+
+        $entityManager->persist(new Badge(
+            id: Uuid::uuid7(),
+            player: $player,
+            type: $type,
+            earnedAt: new DateTimeImmutable(),
+        ));
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    protected function optOutOfRankings(KernelBrowser $browser, string $playerId): void
+    {
+        $entityManager = $this->insightsEntityManager($browser);
+
+        $player = $entityManager->find(Player::class, $playerId);
+        self::assertNotNull($player);
+
+        $player->changeRankingOptedOut(true);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    private function insightsEntityManager(KernelBrowser $browser): EntityManagerInterface
+    {
+        /** @var ContainerInterface $container */
+        $container = $browser->getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        return $entityManager;
+    }
+}


### PR DESCRIPTION
PR 6 of `docs/features/api/v1-expansion-plan.md` — what the profile page shows, as the API.

- `GET /me` gains `rating` (per piece count: `points = round(elo × 1000)`, `rank`, `total_players`; `null` when ranking-opted-out), `skill` (members only, `null` otherwise or when opted out) and `badges`. Trailing additions only; +3 queries max, asserted.
- New `GET /api/v1/players/{playerId}` (`profile:read`, client_credentials allowed): the public profile (same field names as `/me`, no email/flags) + the same three blocks. Gates as on the web: `rating` hidden when the target opted out of rankings, `skill` needs the **token owner** to be a member (viewer gate), a private profile is **masked** for everyone but the player behind the token (`id`, `code`, `is_private`, `has_active_membership` kept; everything else `null`/`[]`, no insight queries). Budgets asserted (≤8; masked ≤5).
- 15 new endpoint tests + 7 on `/me` (seeded `player_elo`/`player_skill`/`badge` rows), OpenAPI, README + for-developers rows. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uH2n4Y6gPLiYASEJwNr3H