### PR TITLE
API: PUT /me/solving-times/{id} keeps the time's competition link

### DIFF
--- a/docs/features/api/README.md
+++ b/docs/features/api/README.md
@@ -303,6 +303,7 @@ The three blocks the profile page shows, under the page's own gates (`templates/
 - `time` format: `HH:MM:SS` or `MM:SS`
 - `group_players`: player codes prefixed with `#`, or plain names for unregistered players
 - `round_id`: optional, nullable. When set, the time is linked to that competition round and automatically to its competition. An invalid or unknown `round_id` returns 404.
+- `PUT` never changes the event link: the payload has no `round_id`/competition field, and the processor carries the time's current competition through to the handler (`PuzzleSolvingTime::modify()` assigns whatever it is given, and the round link is never touched by it). Before 2026-08-19 a `PUT` silently detached the time from its competition.
 - Photo uploads not supported via API (use the website)
 
 Response (`SolvingTimeResponse`, shared with `PUT …/solving-times/{timeId}`):

--- a/src/Api/V1/UpdateSolvingTimeProcessor.php
+++ b/src/Api/V1/UpdateSolvingTimeProcessor.php
@@ -57,11 +57,17 @@ final readonly class UpdateSolvingTimeProcessor implements ProcessorInterface
 
         $finishedAt = $data->finishedAt !== null ? new DateTimeImmutable($data->finishedAt) : null;
 
+        // The API payload has no notion of the event link, but the handler passes the message's
+        // competition straight to PuzzleSolvingTime::modify(), which assigns it unconditionally —
+        // so `null` here would silently detach the time from its competition on every PUT.
+        // Carry the current link through; the round link is never touched by modify().
+        $competitionId = $solvingTime->competition?->id->toString();
+
         $this->messageBus->dispatch(
             new EditPuzzleSolvingTime(
                 currentUserId: $userId,
                 puzzleSolvingTimeId: $timeId,
-                competitionId: null,
+                competitionId: $competitionId,
                 time: $data->time,
                 comment: $data->comment,
                 groupPlayers: $data->groupPlayers,

--- a/tests/Controller/Api/V1/UpdateSolvingTimeEndpointTest.php
+++ b/tests/Controller/Api/V1/UpdateSolvingTimeEndpointTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SpeedPuzzling\Web\Tests\Controller\Api\V1;
 
 use Doctrine\DBAL\Connection;
+use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionFixture;
+use SpeedPuzzling\Web\Tests\DataFixtures\CompetitionRoundFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\OAuth2ClientFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PlayerFixture;
 use SpeedPuzzling\Web\Tests\DataFixtures\PuzzleSolvingTimeFixture;
@@ -46,6 +48,39 @@ final class UpdateSolvingTimeEndpointTest extends WebTestCase
         self::assertNotFalse($row);
         self::assertSame(PlayerFixture::PLAYER_REGULAR, $row['player_id']);
         self::assertSame('Updated via API', $row['comment']);
+    }
+
+    public function testUpdateKeepsCompetitionAndRoundLink(): void
+    {
+        // The PUT payload carries no event information; the processor must carry the time's current
+        // competition through to the handler, otherwise modify() detaches it (regression: it used to pass null).
+        $browser = self::createClient();
+
+        $token = PatTestHelper::createToken($browser, PlayerFixture::PLAYER_REGULAR);
+        PatTestHelper::addBearerToken($browser, $token);
+
+        $browser->request(
+            'PUT',
+            '/api/v1/me/solving-times/' . PuzzleSolvingTimeFixture::TIME_09,
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode(['comment' => 'Still a WJPC result']),
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        /** @var Connection $database */
+        $database = self::getContainer()->get(Connection::class);
+
+        /** @var array{competition_id: null|string, competition_round_id: null|string, comment: null|string}|false $row */
+        $row = $database->fetchAssociative(
+            'SELECT competition_id, competition_round_id, comment FROM puzzle_solving_time WHERE id = :id',
+            ['id' => PuzzleSolvingTimeFixture::TIME_09],
+        );
+
+        self::assertNotFalse($row);
+        self::assertSame('Still a WJPC result', $row['comment']);
+        self::assertSame(CompetitionFixture::COMPETITION_WJPC_2024, $row['competition_id']);
+        self::assertSame(CompetitionRoundFixture::ROUND_WJPC_QUALIFICATION, $row['competition_round_id']);
     }
 
     public function testUpdateForeignTimeReturnsForbidden(): void


### PR DESCRIPTION
## What

`PUT /api/v1/me/solving-times/{timeId}` dispatched `EditPuzzleSolvingTime` with `competitionId: null`; `EditPuzzleSolvingTimeHandler` → `PuzzleSolvingTime::modify()` assigns the competition unconditionally, so **every API edit silently detached the time from its event**. The processor now carries the time's current competition through (it already loads the entity for the ownership check). The round link is never touched by `modify()`, so it was — and stays — intact.

## Why a separate tiny PR

Live data-loss bug, 1-line fix; it ships ahead of the larger picker work tracked in #204 (PR 1 of 4).

## Tests

- New `UpdateSolvingTimeEndpointTest::testUpdateKeepsCompetitionAndRoundLink` (PUT on a WJPC-linked fixture time keeps `competition_id` + `competition_round_id`) — verified it fails on `main` (`null` vs the WJPC id) and passes here.
- Full gates green locally: cs, phpstan (max), "Project Test Suite" (2184 tests), schema:validate, prod warmup.

## Docs

`docs/features/api/README.md`: PUT never changes the event link.

Refs #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUegPi2i9SjwkcrNWyENnL
